### PR TITLE
Permit empty package list

### DIFF
--- a/rpm_lockfile/schema.py
+++ b/rpm_lockfile/schema.py
@@ -25,7 +25,6 @@ def get_schema():
             "packages": {
                 "type": "array",
                 "items": {"type": "string"},
-                "minItems": 1,
             },
             "contentOrigin": {
                 "type": "object",


### PR DESCRIPTION
Use this for things like ostree where the treefile provides the whole package list.