### PR TITLE
Add compatibility with Python 3.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@
 - Missing sources are reported as a warning only.
 - List of `packages` in input file can be empty.
 
+### Fixed
+
+- Compatibility with Python 3.9
+
 ## [0.1.0-alpha.1] - 2024-04-11
 
 Initial release

--- a/rpm_lockfile/content_origin/__init__.py
+++ b/rpm_lockfile/content_origin/__init__.py
@@ -2,7 +2,11 @@ from importlib.metadata import entry_points
 
 
 def load():
-    return {
-        c.name: c.load()
-        for c in entry_points(group="rpm_lockfile.content_origins")
-    }
+    group = "rpm_lockfile.content_origins"
+    try:
+        # Python 3.10+
+        eps = entry_points(group=group)
+    except TypeError:
+        # Python 3.9
+        eps = entry_points()[group]
+    return {c.name: c.load() for c in eps}


### PR DESCRIPTION
The importlib.metadata.entry_points function only accepts the groups argument since 3.10.