### PR TITLE
Download images with skopeo instead of podman

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@
 - All options from repofiles are now honored and passed over to DNF. This means
   that DNF will now see even disabled repos, but will not include any packages
   from there.
+- Extracting rpmdb from an image is now done with skopeo. This makes it
+  possible to run inside non-privileged containers. The `--pull` option is now
+  deprecated and doesn't do anything, the image is always pulled fresh.
 
 ## [0.1.0-alpha.2] - 2024-04-25
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ $ pip install --user https://github.com/konflux-ci/rpm-lockfile-prototype/archiv
 The tool requires on dnf libraries, which are painful to get into virtual
 environment. Enabling system packages makes it easier.
 
-Additionally, the tool requires podman and rpm to be available on the system.
+Additionally, the tool requires skopeo and rpm to be available on the system.
 
 ```
 $ python -m venv venv --system-site-packages
@@ -61,16 +61,10 @@ options:
   --debug
   --arch ARCH           Run the resolution for this architecture. Can be specified
                         multiple times.
-  --pull {always,missing,never,newer}
-                        Pull policy for the base image. See `podman-run --pull` for more
-                        details. Only makes sense if Containerfile is used.
   --outfile OUTFILE
   --print-schema        Print schema for the input file to stdout.
 (venv) $
 ```
-
-It is possible to run the tool in a container, but you need to use the
-`--privileged` option to be able to run podman inside podman. Good luck!
 
 # What's the `INPUT_FILE`
 


### PR DESCRIPTION
This should make it possible to run the tool inside non-privileged containers at the cost of slightly higher complexity.

The image is downloaded into a temporary directory, and then files in known rpmdb locations extracted from each layer sequantially.

Since skopeo always downloads the image, the `--pull` option is no longer useful. It is still accepted, but doesn't do anything.

This also unblocks a possible caching to avoid downloading the same image multiple times. We could find out the digest of the image with `skopeo inspect` first, use it as a cache key, and only download and extract if that cache entry doesn't exist. However, this is not implemented in this patch.