### PR TITLE
Stop depending on DNF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+### Changed
+
+- There is no explicit dependency on DNF anymore. It was causing problems in
+  certain installation scenarios. Instead, if you run the tool with no
+  python3-dnf package available, an error message is printed with instructions
+  on what to do.
+
 ## [0.1.0-alpha.4] - 2024-06-10
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,6 @@ authors = [
 ]
 readme = "README.md"
 dependencies = [
-    "dnf",
     "jsonschema",
     "productmd",
     "pyyaml",

--- a/rpm_lockfile/__init__.py
+++ b/rpm_lockfile/__init__.py
@@ -14,8 +14,17 @@ import tempfile
 from pathlib import Path
 from dataclasses import asdict, dataclass
 
-import dnf
-import hawkey
+try:
+    import dnf
+    import hawkey
+except ImportError:
+    print(
+        "Python bindings for DNF are missing.",
+        "Please install python3-dnf (or equivalent) with system package manager.",
+        sep="\n",
+        file=sys.stderr
+    )
+    sys.exit(127)
 import yaml
 
 from . import content_origin, schema


### PR DESCRIPTION
It is still needed, we just let the user install it manually. That was actually always needed, since the dnf package on DNF is just a stub that prints instructions on what to do.

Except in certain conditions, it causes pip to break down and start spewing a lot of warnings about aborting installation, which is massively confusing.