### PR TITLE
Add a way to list packages to reinstall

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+### Added
+
+- The input file can specify `reinstallPackages` as a list of strings. These
+  are packages already installed in the base image that will be reinstalled.
+
+  Listing something that is not in the base image will lead to an error.
+
+  There will also be an error if the configured repos do not contain identical
+  version to the package in the base image.
+
 ## [0.1.0-alpha.7] - 2024-06-20
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -101,6 +101,10 @@ contentOrigin:
 packages:
   # list of rpm names to resolve
   - vim-enhanced
+
+reinstallPackages: []
+  # list of rpms already provided in the base image, but which should be
+  # reinstalled
 ```
 
 # What does this do

--- a/rpm_lockfile/schema.py
+++ b/rpm_lockfile/schema.py
@@ -30,6 +30,10 @@ def get_schema():
                 "type": "array",
                 "items": {"type": "string"},
             },
+            "reinstallPackages": {
+                "type": "array",
+                "items": {"type": "string"},
+            },
             "contentOrigin": {
                 "type": "object",
                 "properties": {


### PR DESCRIPTION
Base containers typically do not contain documentation. If a container image wants that, it needs to reinstall the package in question.

This tool however did not support that. If a required package was already installed, nothing would happen and it would not be listed in the final lockfile.

This patch adds a new key to the input file. The expected value is a list of strings with package specs, which will be reinstalled.

This can fail in two new ways
 * reinstalling something that is not in the base image
 * reinstalling when the repos no longer contain the same version

The feature only really makes sense for the container image use case, but it can be used for the local and bare modes too.

Fixes: #12