### PR TITLE
Allow specifying arches in the input file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+### Added
+
+- List of architectures to resolve on can now be specified in the input file.
+  The list can be overridden by command line options. The precedence is 1.
+  architectures specified on command line, 2. list from config file, 3. current
+  host architecture. The first one provided wins.
+
 ## [0.1.0-alpha.6] - 2024-06-19
 
 ### Added

--- a/rpm_lockfile/__init__.py
+++ b/rpm_lockfile/__init__.py
@@ -319,7 +319,7 @@ def main():
     schema.validate(config)
 
     data = {"lockfileVersion": 1, "lockfileVendor": "redhat", "arches": []}
-    arches = args.arch or [platform.machine()]
+    arches = args.arch or config.get("arches") or [platform.machine()]
 
     if args.local_system and arches != [platform.machine()]:
         parser.error(

--- a/rpm_lockfile/schema.py
+++ b/rpm_lockfile/schema.py
@@ -26,6 +26,10 @@ def get_schema():
                 "type": "array",
                 "items": {"type": "string"},
             },
+            "arches": {
+                "type": "array",
+                "items": {"type": "string"},
+            },
             "contentOrigin": {
                 "type": "object",
                 "properties": {


### PR DESCRIPTION
If this should be called by any automation, the list of arches has to come from somewhere.