### PR TITLE
Remove URL from lockfiles

### DIFF
--- a/rpm_lockfile/__init__.py
+++ b/rpm_lockfile/__init__.py
@@ -132,7 +132,6 @@ def strip_suffix(s, suf):
 
 @dataclass(frozen=True, order=True)
 class PackageItem:
-    url: str
     repoid: str
     size: int
     checksum: str = None
@@ -143,7 +142,6 @@ class PackageItem:
     @classmethod
     def from_dnf(cls, pkg):
         return cls(
-            pkg.remote_location(),
             pkg.repoid,
             pkg.downloadsize,
             f"{hawkey.chksum_name(pkg.chksum[0])}:{pkg.chksum[1].hex()}",


### PR DESCRIPTION
Fedora derivatives use the concept of a "compose" which is just a bunch of JSON wrapping RPMs stored in a datestamped directory.

Including the URL of the package in the lockfile causes total churn of the entire file anytime we bump a compose.

For the systems targeted by this tool, NEVRA uniqueness is enforced by koji. We do not need to encode the URL.