### PR TITLE
Add --flatpak option to read packages from container.yaml

### DIFF
--- a/rpm_lockfile/schema.py
+++ b/rpm_lockfile/schema.py
@@ -42,7 +42,7 @@ def get_schema():
                 },
             },
         },
-        "required": ["packages", "contentOrigin"],
+        "required": ["contentOrigin"],
         "additionalProperties": False,
     }
 


### PR DESCRIPTION
For Flatpak containers, the set of packages to include in the Flatpak is defined in the container.yaml, and for runtimes, can be very big, so we don't want to duplicate it in rpms.in.yaml. Instead read the package list from container.yaml.