### PR TITLE
Allow setting options via config file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+### Added
+
+- Most command line options can now also be set in the input configuration file
+  in the new `context` section.
+
+
 ## [0.3.0] - 2024-07-12
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -107,6 +107,23 @@ packages:
 reinstallPackages: []
   # list of rpms already provided in the base image, but which should be
   # reinstalled
+
+arches:
+  # The list of architectures can be set in the config file. Any `--arch` option set
+  # on the command line will override this list.
+  - aarch64
+  - x86_64
+
+context:
+    # Alternative to setting command line options. Usually you will only want
+    # to include one of these options, with the exception of `flatpak` that
+    # can be combined with `image` and `containerfile`
+    image: registry.fedoraproject.org/fedora:latest
+    containerfile: Containerfile.fedora
+    flatpak: true
+    bare: true
+    localSystem: true
+    rpmOstreeTreefile: centos-bootc/centos-bootc.yaml
 ```
 
 # What does this do

--- a/rpm_lockfile/__init__.py
+++ b/rpm_lockfile/__init__.py
@@ -10,6 +10,7 @@ import re
 import shlex
 import shutil
 import subprocess
+import sys
 import tarfile
 import tempfile
 from pathlib import Path
@@ -28,7 +29,7 @@ except ImportError:
     sys.exit(127)
 import yaml
 
-from . import content_origin, schema
+from . import content_origin, schema, utils
 
 CONTAINERFILE_HELP = """
 Load installed packages from base image specified in Containerfile and make
@@ -354,9 +355,7 @@ def read_packages_from_container_yaml(arch):
 def main():
     parser = argparse.ArgumentParser()
     group = parser.add_mutually_exclusive_group()
-    group.add_argument(
-        "-f", "--containerfile", default="Containerfile", help=CONTAINERFILE_HELP
-    )
+    group.add_argument("-f", "--containerfile", help=CONTAINERFILE_HELP)
     group.add_argument("--image", help=IMAGE_HELP)
     group.add_argument("--local-system", action="store_true", help=LOCAL_SYSTEM_HELP)
     group.add_argument("--bare", action="store_true", help=BARE_HELP)
@@ -391,26 +390,41 @@ def main():
     data = {"lockfileVersion": 1, "lockfileVendor": "redhat", "arches": []}
     arches = args.arch or config.get("arches") or [platform.machine()]
 
-    if args.local_system and arches != [platform.machine()]:
+    context = config.get("context", {})
+
+    local = args.local_system or context.get("localSystem")
+    if local and arches != [platform.machine()]:
         parser.error(
             f"Only current architecture ({platform.machine()}) can be resolved against local system.",
         )
 
     repos = collect_content_origins(config_dir, config["contentOrigin"])
 
-    if args.local_system:
+    if args.local_system or context.get("localSystem"):
         rpmdb = local_rpmdb()
-    elif args.bare or args.rpm_ostree_treefile:
+    elif args.bare or context.get("bare") or args.rpm_ostree_treefile:
+        rpmdb = empty_rpmdb()
+    elif args.rpm_ostree_treefile or context.get("rpmOstreeTreefile"):
         rpmdb = empty_rpmdb()
     else:
-        rpmdb = image_rpmdb(args.image or extract_image(args.containerfile))
+        image = args.image or context.get("image")
+        containerfile = (
+            args.containerfile
+            or utils.relative_to(config_dir, context.get("containerfile"))
+            or "Containerfile"
+        )
+        rpmdb = image_rpmdb(image or extract_image(containerfile))
 
     # TODO maybe try extracting packages from Containerfile?
     for arch in sorted(arches):
         packages = set()
         if args.rpm_ostree_treefile:
-            packages = read_packages_from_treefile(arch, args.rpm_ostree_treefile)
-        elif args.flatpak:
+            packages = read_packages_from_treefile(
+                arch,
+                args.rpm_ostree_treefile
+                or utils.relative_to(config_dir, context.get("rpmOstreeTreefile")),
+            )
+        elif args.flatpak or context.get("flatpak"):
             packages = read_packages_from_container_yaml(arch)
         data["arches"].append(
             process_arch(

--- a/rpm_lockfile/__init__.py
+++ b/rpm_lockfile/__init__.py
@@ -418,7 +418,7 @@ def main():
     # TODO maybe try extracting packages from Containerfile?
     for arch in sorted(arches):
         packages = set()
-        if args.rpm_ostree_treefile:
+        if args.rpm_ostree_treefile or context.get("rpmOstreeTreefile"):
             packages = read_packages_from_treefile(
                 arch,
                 args.rpm_ostree_treefile

--- a/rpm_lockfile/schema.py
+++ b/rpm_lockfile/schema.py
@@ -41,6 +41,37 @@ def get_schema():
                     for source_type, collector in content_origin.load().items()
                 },
             },
+            "context": {
+                "type": "object",
+                "anyOf": [
+                    {
+                        "additionalProperties": False,
+                        "properties": {
+                            "image": {"type": "string"},
+                            "flatpak": {"type": "boolean"},
+                        },
+                    },
+                    {
+                        "additionalProperties": False,
+                        "properties": {
+                            "containerfile": {"type": "string"},
+                            "flatpak": {"type": "boolean"},
+                        },
+                    },
+                    {
+                        "additionalProperties": False,
+                        "properties": {"rpmOstreeTreefile": {"type": "string"}}
+                    },
+                    {
+                        "additionalProperties": False,
+                        "properties": {"localSystem": {"type": "boolean"}}
+                    },
+                    {
+                        "additionalProperties": False,
+                        "properties": {"bare": {"type": "boolean"}}
+                    },
+                ],
+            },
         },
         "required": ["contentOrigin"],
         "additionalProperties": False,

--- a/rpm_lockfile/utils.py
+++ b/rpm_lockfile/utils.py
@@ -1,0 +1,8 @@
+import os
+
+
+def relative_to(directory, path):
+    """os.path.join() that gracefully handles None"""
+    if path:
+        return os.path.join(directory, path)
+    return None

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,15 @@
+import pytest
+
+from rpm_lockfile import utils
+
+
+@pytest.mark.parametrize(
+    "dir,path,expected",
+    [
+        ("/topdir", "subdir", "/topdir/subdir"),
+        ("/topdir", "/root", "/root"),
+        ("/topdir", None, None),
+    ]
+)
+def test_relative_to(dir, path, expected):
+    assert utils.relative_to(dir, path) == expected


### PR DESCRIPTION
Using command line options is not always practical. This patch makes it possible to set the options in the input config file too.

When both the config and CLI option is provided, the CLI will will (though this only makes sense for non-boolean options).

Fixes: #17