### PR TITLE
Bump pyproject.toml version to 0.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rpm-lockfile-prototype"
-version = "0.1.0"
+version = "0.4.0"
 description = ""
 authors = [
     {name = "Lubomír Sedlář", email = "lsedlar@redhat.com"},


### PR DESCRIPTION
When installing `v0.4` to pick up the latest and greatest changes, I was confused when installing that I ended up with the exact package I had just removed:

```
pip uninstall rpm-lockfile-prototype
Found existing installation: rpm-lockfile-prototype 0.1.0
Uninstalling rpm-lockfile-prototype-0.1.0:
  Would remove:
    /home/ckelley/.local/bin/rpm-lockfile-prototype
    /home/ckelley/.local/lib/python3.12/site-packages/rpm_lockfile/*
    /home/ckelley/.local/lib/python3.12/site-packages/rpm_lockfile_prototype-0.1.0.dist-info/*
Proceed (Y/n)? y
  Successfully uninstalled rpm-lockfile-prototype-0.1.0
```
...then...
```
pip install --user https://github.com/konflux-ci/rpm-lockfile-prototype/archive/refs/tags/v0.4.0.tar.gz
Collecting https://github.com/konflux-ci/rpm-lockfile-prototype/archive/refs/tags/v0.4.0.tar.gz
  Using cached https://github.com/konflux-ci/rpm-lockfile-prototype/archive/refs/tags/v0.4.0.tar.gz
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Preparing metadata (pyproject.toml) ... done
Requirement already satisfied: jsonschema in /usr/lib/python3.12/site-packages (from rpm-lockfile-prototype==0.1.0) (4.19.1)
Requirement already satisfied: productmd in /usr/lib/python3.12/site-packages (from rpm-lockfile-prototype==0.1.0) (1.38)
Requirement already satisfied: pyyaml in /usr/lib64/python3.12/site-packages (from rpm-lockfile-prototype==0.1.0) (6.0.1)
Requirement already satisfied: requests in /usr/lib/python3.12/site-packages (from rpm-lockfile-prototype==0.1.0) (2.31.0)
Requirement already satisfied: attrs>=22.2.0 in /usr/lib/python3.12/site-packages (from jsonschema->rpm-lockfile-prototype==0.1.0) (23.2.0)
Requirement already satisfied: jsonschema-specifications>=2023.03.6 in /usr/lib/python3.12/site-packages (from jsonschema->rpm-lockfile-prototype==0.1.0) (2023.11.2)
Requirement already satisfied: referencing>=0.28.4 in /usr/lib/python3.12/site-packages (from jsonschema->rpm-lockfile-prototype==0.1.0) (0.31.1)
Requirement already satisfied: rpds-py>=0.7.1 in /usr/lib64/python3.12/site-packages (from jsonschema->rpm-lockfile-prototype==0.1.0) (0.18.1)
Requirement already satisfied: six in /usr/lib/python3.12/site-packages (from productmd->rpm-lockfile-prototype==0.1.0) (1.16.0)
Requirement already satisfied: charset-normalizer<4,>=2 in /usr/lib/python3.12/site-packages (from requests->rpm-lockfile-prototype==0.1.0) (3.3.2)
Requirement already satisfied: idna<4,>=2.5 in /usr/lib/python3.12/site-packages (from requests->rpm-lockfile-prototype==0.1.0) (3.7)
Requirement already satisfied: urllib3<3,>=1.21.1 in /usr/lib/python3.12/site-packages (from requests->rpm-lockfile-prototype==0.1.0) (1.26.19)
Building wheels for collected packages: rpm-lockfile-prototype
  Building wheel for rpm-lockfile-prototype (pyproject.toml) ... done
  Created wheel for rpm-lockfile-prototype: filename=rpm_lockfile_prototype-0.1.0-py3-none-any.whl size=14103 sha256=10c26782c828e1cf9d2d0c3aae0b96339f60762e5d3e82b8fead39047ee610b3
  Stored in directory: /tmp/pip-ephem-wheel-cache-cqwh3p3z/wheels/16/e0/47/ef46aabcdeca8665021cc9fdf79de79d6f9fe20f90f7243efe
Successfully built rpm-lockfile-prototype
Installing collected packages: rpm-lockfile-prototype
Successfully installed rpm-lockfile-prototype-0.1.0
```
I don't know how/if you want to designate pre-release versions/snapshots or whatever, I thought about `0.5.0.pre`? Anyway, I put it to the current version so you can decide for yourself and this is more of an FYI :smile: 