### PR TITLE
Support multi stage container builds

### DIFF
--- a/rpm_lockfile/__init__.py
+++ b/rpm_lockfile/__init__.py
@@ -255,11 +255,14 @@ def image_rpmdb(baseimage):
 
 def extract_image(containerfile):
     """Find image mentioned in the first FROM statement in the containerfile."""
+    baseimg = ""
     with open(containerfile) as f:
         for line in f:
             if line.startswith("FROM "):
-                return line.split()[1]
-    raise RuntimeError("Base image could not be identified.")
+                baseimg = line.split()[1]
+    if baseimg == "":
+        raise RuntimeError("Base image could not be identified.")
+    return baseimg
 
 
 def process_arch(

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,5 +1,7 @@
 import pytest
 
+from unittest.mock import patch, mock_open
+
 import rpm_lockfile
 
 @pytest.mark.parametrize(
@@ -12,3 +14,21 @@ import rpm_lockfile
 )
 def test_strip_tag(image_spec, expected):
     assert rpm_lockfile._strip_tag(image_spec) == expected
+
+
+@pytest.mark.parametrize(
+    "file,expected",
+    [
+        ("""FROM registry.io/repository/base
+RUN something
+""", "registry.io/repository/base"),
+        ("""FROM registry.io/repository/build as build
+RUN build
+FROM registry.io/repository/base
+COPY --from=build /artifact /
+""", "registry.io/repository/base"),
+    ]
+)
+def test_extract_image(file, expected):
+    with patch("builtins.open", mock_open(read_data=file)) as mock_file:
+        assert rpm_lockfile.extract_image(file) == expected


### PR DESCRIPTION
The last `FROM` is the base image for the resulting image; in general, assuming the build didn't specify a different named build stage. So we need to search and return for the last `FROM` in `extract_image`.