### PR TITLE
schema.py: allow flatpak to be combined with bare

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ arches:
 context:
     # Alternative to setting command line options. Usually you will only want
     # to include one of these options, with the exception of `flatpak` that
-    # can be combined with `image` and `containerfile`
+    # can be combined with `image`, `containerfile`, or `bare`
     image: registry.fedoraproject.org/fedora:latest
     containerfile: Containerfile.fedora
     flatpak: true

--- a/rpm_lockfile/schema.py
+++ b/rpm_lockfile/schema.py
@@ -68,7 +68,10 @@ def get_schema():
                     },
                     {
                         "additionalProperties": False,
-                        "properties": {"bare": {"type": "boolean"}}
+                        "properties": {
+                            "bare": {"type": "boolean"},
+                            "flatpak": {"type": "boolean"},
+                        }
                     },
                 ],
             },


### PR DESCRIPTION
When we are building a Flatpak runtime, we need to run with --bare (ignore the Containerfile) *and* --flatpak (get the package list from container.yaml).