### PR TITLE
Add variable interpolation to repofile URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,22 @@
 
 ## Unreleased
 
+### Added
+
+- The repofiles can now be specified by an object with `location` key (with the
+  same meaning as the original single string specification). If the object
+  additionally specifies `varsFromImage` or `varsFromContainerfile`, the
+  resolver will query the image labels and interpolate them into the URL.
+
+  This way it is possible to get to the exact same repos that were used to
+  build the base image, but user must know where the raw repofile is.
+
 ### Changed
 
 - When no Containerfile is specified, stop assuming `Containerfile` and instead
   inspect current working directory to find either `Containerfile` or
   `Dockerfile`. If both exist, `Containerfile` will be preferred.
+
 
 ## [0.6.1] - 2024-07-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,15 @@
   This way it is possible to get to the exact same repos that were used to
   build the base image, but user must know where the raw repofile is.
 
+- Alternatively, the repofiles can also be specified as a reference to a git
+  repository, from which the actual repofile will be obtained. The keys in this
+  case are `giturl`, `gitref` and `file`. Their meanings are in order: clone
+  URL for the repository, commit sha and path inside the repo. All of the
+  values can reference image labels if `varsFromImage` or
+  `varsFromContainerfile` is specified using `{label-name}` syntax. The repo
+  url can also reference environment variables using shell syntax (`$VAR` or
+  `${VAR}`).
+
 ### Changed
 
 - When no Containerfile is specified, stop assuming `Containerfile` and instead

--- a/README.md
+++ b/README.md
@@ -92,6 +92,13 @@ contentOrigin:
       # can be interpolated into the repofile URL.
       varsFromImage: registry.fedoraproject.org/fedora:latest
       varsFromContainerfile: Containerfile
+    - giturl: https://$USER:$TOKEN@example.com/my-repo.git
+      gitref: '{vcs-ref}'
+      file: custom.repo
+      # The labels from image specified either directly or via Containerfile
+      # can be interpolated into the repofile URL.
+      varsFromImage: registry.fedoraproject.org/fedora:latest
+      varsFromContainerfile: Containerfile
   composes:
     # If your environment uses Compose Tracking Service (https://pagure.io/cts/)
     # and you define environment variable CTS_URL, you can look up repos from

--- a/README.md
+++ b/README.md
@@ -84,9 +84,14 @@ contentOrigin:
       # You can list any option that would be in .repo file here too.
       # For example sslverify, proxy or excludepkgs might be of interest
   repofiles:
-    # Either local path or url pointing to .repo file
+    # Either local path, url pointing to .repo file or an object
     - ./c9s.repo
     - https://example.com/updates.repo
+    - location: https://scm.example.com/cgit/base/plain/devel.repo?commit={vcs-ref}
+      # The labels from image specified either directly or via Containerfile
+      # can be interpolated into the repofile URL.
+      varsFromImage: registry.fedoraproject.org/fedora:latest
+      varsFromContainerfile: Containerfile
   composes:
     # If your environment uses Compose Tracking Service (https://pagure.io/cts/)
     # and you define environment variable CTS_URL, you can look up repos from

--- a/rpm_lockfile/__init__.py
+++ b/rpm_lockfile/__init__.py
@@ -7,7 +7,6 @@ import logging
 import os
 import platform
 import re
-import shlex
 import shutil
 import subprocess
 import sys
@@ -60,11 +59,6 @@ RPMDB_PATH = subprocess.run(
 ).stdout.strip()[1:]
 
 
-def logged_run(cmd, *args, **kwargs):
-    logging.info("$ %s", shlex.join(cmd))
-    return subprocess.run(cmd, *args, **kwargs)
-
-
 def _translate_arch(arch):
     # This is a horrible hack. Skopeo will reject x86_64, but is happy with
     # amd64. The same goes for aarch64 -> arm64.
@@ -104,7 +98,7 @@ def setup_rpmdb(cache_dir, baseimage, arch):
             f"docker://{_strip_tag(baseimage)}",
             f"dir:{tmpdir}",
         ]
-        logged_run(cmd, check=True)
+        utils.logged_run(cmd, check=True)
 
         # The manifest is always in the same location, and contains information
         # about individual layers.

--- a/rpm_lockfile/__init__.py
+++ b/rpm_lockfile/__init__.py
@@ -277,19 +277,6 @@ def image_rpmdb(baseimage):
     )
 
 
-def extract_image(containerfile):
-    """Find image mentioned in the first FROM statement in the containerfile."""
-    logging.debug("Looking for base image in %s", containerfile)
-    baseimg = ""
-    with open(containerfile) as f:
-        for line in f:
-            if line.startswith("FROM "):
-                baseimg = line.split()[1]
-    if baseimg == "":
-        raise RuntimeError("Base image could not be identified.")
-    return baseimg
-
-
 def process_arch(
     arch, rpmdb, repos, packages, allow_erasing, reinstall_packages: set[str]
 ):
@@ -441,7 +428,7 @@ def main():
             or utils.relative_to(config_dir, context.get("containerfile"))
             or utils.find_containerfile(Path.cwd())
         )
-        rpmdb = image_rpmdb(image or extract_image(containerfile))
+        rpmdb = image_rpmdb(image or utils.extract_image(containerfile))
 
     # TODO maybe try extracting packages from Containerfile?
     for arch in sorted(arches):

--- a/rpm_lockfile/utils.py
+++ b/rpm_lockfile/utils.py
@@ -1,3 +1,4 @@
+import logging
 import os
 
 
@@ -17,3 +18,16 @@ def find_containerfile(dir):
         if candidate.exists():
             return candidate
     return None
+
+
+def extract_image(containerfile):
+    """Find image mentioned in the first FROM statement in the containerfile."""
+    logging.debug("Looking for base image in %s", containerfile)
+    baseimg = ""
+    with open(containerfile) as f:
+        for line in f:
+            if line.startswith("FROM "):
+                baseimg = line.split()[1]
+    if baseimg == "":
+        raise RuntimeError("Base image could not be identified.")
+    return baseimg

--- a/rpm_lockfile/utils.py
+++ b/rpm_lockfile/utils.py
@@ -1,5 +1,7 @@
 import logging
 import os
+import shlex
+import subprocess
 
 
 def relative_to(directory, path):
@@ -18,6 +20,11 @@ def find_containerfile(dir):
         if candidate.exists():
             return candidate
     return None
+
+
+def logged_run(cmd, *args, **kwargs):
+    logging.info("$ %s", shlex.join(cmd))
+    return subprocess.run(cmd, *args, **kwargs)
 
 
 def extract_image(containerfile):

--- a/tests/content_origin/test_repofiles.py
+++ b/tests/content_origin/test_repofiles.py
@@ -1,0 +1,135 @@
+import json
+import subprocess
+from unittest.mock import patch, mock_open, Mock, ANY
+
+import pytest
+
+from rpm_lockfile.content_origin import Repo, repofiles
+
+
+@pytest.mark.parametrize(
+    "template,vars,expected",
+    [
+        ("foo{x}bar", {"x": "X"}, "fooXbar"),
+        ("{x}{y}", {"x": "X", "y": "Y"}, "XY"),
+        ("foo{x}bar}", {}, "foo{x}bar}"),
+        ("foobar", {}, "foobar"),
+        ("foobar", {"x": "X"}, "foobar"),
+    ]
+)
+def test_subst_vars(template, vars, expected):
+    assert repofiles.subst_vars(template, vars) == expected
+
+
+REPOFILE = """
+[repo-0]
+baseurl = https://example.com/repo
+"""
+REPO = Repo(repoid="repo-0", baseurl="https://example.com/repo")
+
+
+def test_collect_local():
+    origin = repofiles.RepofileOrigin("/test")
+    with patch("builtins.open", mock_open(read_data=REPOFILE)) as m:
+        repos = list(origin.collect(["test.repo"]))
+
+    assert repos == [REPO]
+    m.assert_called_once_with("/test/test.repo")
+
+
+def test_collect_http():
+    origin = repofiles.RepofileOrigin("/test")
+    origin.session = Mock()
+    origin.session.get.return_value = Mock(text=REPOFILE)
+    repourl = "http://example.com/test.repo"
+
+    repos = origin.collect([repourl])
+
+    assert list(repos) == [REPO]
+    origin.session.get.assert_called_once_with(repourl, timeout=ANY)
+
+
+def test_collect_local_complex():
+    origin = repofiles.RepofileOrigin("/test")
+    with patch("builtins.open", mock_open(read_data=REPOFILE)) as m:
+        repos = list(origin.collect([{"location": "test.repo"}]))
+
+    assert repos == [REPO]
+    m.assert_called_once_with("/test/test.repo")
+
+
+def test_collect_http_complex():
+    origin = repofiles.RepofileOrigin("/test")
+    origin.session = Mock()
+    origin.session.get.return_value = Mock(text=REPOFILE)
+    repourl = "http://example.com/test.repo"
+
+    repos = origin.collect([{"location": repourl}])
+
+    assert list(repos) == [REPO]
+    origin.session.get.assert_called_once_with(repourl, timeout=ANY)
+
+
+INSPECT_OUTPUT = {
+    "Labels": {
+        "vcs-ref": "abcdef",
+        "architecture": "x86_64",
+    },
+    "Os": "linux",
+}
+
+
+def test_collect_http_with_vars_from_image():
+    origin = repofiles.RepofileOrigin("/test")
+    origin.session = Mock()
+    origin.session.get.return_value = Mock(text=REPOFILE)
+    repourl = "http://example.com/test.repo"
+    image = "registry.example.com/image:latest"
+
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = Mock(
+            stdout=json.dumps(INSPECT_OUTPUT)
+        )
+        repos = list(
+            origin.collect(
+                [{"location": f"{repourl}?x={{vcs-ref}}", "varsFromImage": image}]
+            )
+        )
+
+    assert repos == [REPO]
+    origin.session.get.assert_called_once_with(f"{repourl}?x=abcdef", timeout=ANY)
+    mock_run.assert_called_once_with(
+        ["skopeo", "inspect", f"docker://{image}"], check=True, stdout=subprocess.PIPE
+    )
+
+
+def test_collect_http_with_vars_from_containerfile():
+    origin = repofiles.RepofileOrigin("/test")
+    origin.session = Mock()
+    origin.session.get.return_value = Mock(text=REPOFILE)
+    repourl = "http://example.com/test.repo"
+    image = "registry.example.com/image:latest"
+    CONTAINERFILE = f"FROM {image}\nRUN date\n"
+
+    with patch("builtins.open", mock_open(read_data=CONTAINERFILE)) as m_open, \
+            patch("subprocess.run") as mock_run:
+        mock_run.return_value = Mock(
+            stdout=json.dumps(INSPECT_OUTPUT)
+        )
+        repos = list(
+            origin.collect(
+                [
+                    {
+                        "location": f"{repourl}?x={{vcs-ref}}",
+                        "varsFromContainerfile": "Containerfile",
+                    }
+                ],
+            )
+        )
+
+    assert repos == [REPO]
+    origin.session.get.assert_called_once_with(f"{repourl}?x=abcdef", timeout=ANY)
+    m_open.assert_called_once_with("/test/Containerfile")
+    mock_run.assert_called_once_with(
+        ["skopeo", "inspect", f"docker://{image}"], check=True, stdout=subprocess.PIPE
+    )

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,8 +1,8 @@
 import pytest
 
-from unittest.mock import patch, mock_open
 
 import rpm_lockfile
+
 
 @pytest.mark.parametrize(
     "image_spec,expected",
@@ -14,21 +14,3 @@ import rpm_lockfile
 )
 def test_strip_tag(image_spec, expected):
     assert rpm_lockfile._strip_tag(image_spec) == expected
-
-
-@pytest.mark.parametrize(
-    "file,expected",
-    [
-        ("""FROM registry.io/repository/base
-RUN something
-""", "registry.io/repository/base"),
-        ("""FROM registry.io/repository/build as build
-RUN build
-FROM registry.io/repository/base
-COPY --from=build /artifact /
-""", "registry.io/repository/base"),
-    ]
-)
-def test_extract_image(file, expected):
-    with patch("builtins.open", mock_open(read_data=file)) as mock_file:
-        assert rpm_lockfile.extract_image(file) == expected

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch, mock_open
+
 import pytest
 
 from rpm_lockfile import utils
@@ -33,3 +35,21 @@ def test_find_containerfile(tmpdir, files, expected):
         assert actual == tmpdir / expected
     else:
         assert actual is None
+
+
+@pytest.mark.parametrize(
+    "file,expected",
+    [
+        ("""FROM registry.io/repository/base
+RUN something
+""", "registry.io/repository/base"),
+        ("""FROM registry.io/repository/build as build
+RUN build
+FROM registry.io/repository/base
+COPY --from=build /artifact /
+""", "registry.io/repository/base"),
+    ]
+)
+def test_extract_image(file, expected):
+    with patch("builtins.open", mock_open(read_data=file)):
+        assert utils.extract_image(file) == expected


### PR DESCRIPTION
Make it possible to interpolate image labels into the repofile URLs. This can be used to consume the exact same repos that were used to build the base image.