### PR TITLE
Fix extracting RPMDB from container images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- Detection of installed packages in container images did not work correctly if
+  the rpmdb in the image differed from local system. This is now fixed.
+
 ## [0.5.1] - 2024-07-25
 
 ### Changed


### PR DESCRIPTION
The original code did extract the database, but did not ensure that it is consumable by local DNF.

If the _dbpath configuration differed between local system and the container image, the dependency resolution would run as if the database was empty with nothing installed.

This patch fixes that by creating a symlink in such case.