### PR TITLE
Detect Containerfile or Dockerfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+### Changed
+
+- When no Containerfile is specified, stop assuming `Containerfile` and instead
+  inspect current working directory to find either `Containerfile` or
+  `Dockerfile`. If both exist, `Containerfile` will be preferred.
+
 ## [0.6.1] - 2024-07-31
 
 - Follow up patch to prevous fix to correctly handle images that provide rpmdb

--- a/rpm_lockfile/__init__.py
+++ b/rpm_lockfile/__init__.py
@@ -279,6 +279,7 @@ def image_rpmdb(baseimage):
 
 def extract_image(containerfile):
     """Find image mentioned in the first FROM statement in the containerfile."""
+    logging.debug("Looking for base image in %s", containerfile)
     baseimg = ""
     with open(containerfile) as f:
         for line in f:
@@ -438,7 +439,7 @@ def main():
         containerfile = (
             args.containerfile
             or utils.relative_to(config_dir, context.get("containerfile"))
-            or "Containerfile"
+            or utils.find_containerfile(Path.cwd())
         )
         rpmdb = image_rpmdb(image or extract_image(containerfile))
 

--- a/rpm_lockfile/utils.py
+++ b/rpm_lockfile/utils.py
@@ -6,3 +6,14 @@ def relative_to(directory, path):
     if path:
         return os.path.join(directory, path)
     return None
+
+
+def find_containerfile(dir):
+    """Look for a containerfile in the given directory.
+
+    Returns a path to the found file or None.
+    """
+    for candidate in (dir / "Containerfile", dir / "Dockerfile"):
+        if candidate.exists():
+            return candidate
+    return None

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -13,3 +13,23 @@ from rpm_lockfile import utils
 )
 def test_relative_to(dir, path, expected):
     assert utils.relative_to(dir, path) == expected
+
+
+@pytest.mark.parametrize(
+    "files,expected",
+    [
+        (["Containerfile"], "Containerfile"),
+        (["Dockerfile"], "Dockerfile"),
+        (["Containerfile", "Dockerfile"], "Containerfile"),
+        (["foobar"], None),
+        ([], None),
+    ]
+)
+def test_find_containerfile(tmpdir, files, expected):
+    for fn in files:
+        (tmpdir / fn).write_text("", encoding="utf-8")
+    actual = utils.find_containerfile(tmpdir)
+    if expected:
+        assert actual == tmpdir / expected
+    else:
+        assert actual is None


### PR DESCRIPTION
This allows users to follow whatever naming convention they prefer.