### PR TITLE
Include modular metadata in the output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,22 @@
 # Changelog
 
+## Unreleased
+
+### Changed
+
+- When a modular package is included in the resolved set, the lockfile will now
+  contain references to modulemd metadata files from respective repos. These
+  can then be prefetched together with the RPMs and included in the build
+  repository to make dnf happy.
+
+
 ## [0.7.2] - 2024-09-03
 
 ### Fixed
 
 - Obtaining labels from base image now works even if the image is specified
   using both tag and digest. The tag is ignored in such case.
+
 
 ## [0.7.1] - 2024-09-02
 

--- a/rpm_lockfile/utils.py
+++ b/rpm_lockfile/utils.py
@@ -1,3 +1,4 @@
+import hashlib
 import json
 import logging
 import os
@@ -169,3 +170,11 @@ CONTAINERFILE_SCHEMA = {
         },
     ],
 }
+
+
+def hash_file(path):
+    with open(path, "rb") as f:
+        h = hashlib.sha256()
+        while chunk := f.read(65536):
+            h.update(chunk)
+        return h.hexdigest()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -170,3 +170,16 @@ def test_get_labels_from_containerfile_stage(tmpdir, filter):
     mock_run.assert_called_once_with(
         ["skopeo", "inspect", f"docker://{image}"], check=True, stdout=subprocess.PIPE
     )
+
+
+@pytest.mark.parametrize(
+    "content,hash",
+    [
+        ("", "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"),
+        ("hello\n", "5891b5b522d5df086d0ff0b110fbd9d21bb4fc7163af34d08286a2e846f6be03"),
+    ],
+)
+def test_hash_file(content, hash, tmp_path):
+    fn = tmp_path / "something"
+    fn.write_text(content, encoding="utf-8")
+    assert utils.hash_file(fn) == hash


### PR DESCRIPTION
If any RPM included in the lockfile is modular, the lockfile will also include information about where to obtain the required modular metadata.

The metadata is specified by url, repoida, size, checksum and also carries mdtype information.

The same format could be used for comps and updateinfo if needed.

Fixes: #24