### PR TITLE
Add a Dockerfile to build and publish the image

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -22,6 +22,25 @@ jobs:
         sudo apt-get -y install podman
         podman pull registry.fedoraproject.org/fedora:${{ matrix.fedora-version }}
     - uses: actions/checkout@v4
+    - uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    - uses: docker/setup-buildx-action@v3
+    - id: meta
+      uses: docker/metadata-action@v5
+      with:
+        images: ghcr.io/${{ github.repository }}/rpm-lockfile-prototype
+        flavor: |
+          latest=true
+    - uses: docker/build-push-action@v5
+      with:
+        push: ${{ github.event_name != 'pull_request' }}
+        context: .
+        file: Dockerfile
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}
     - name: Test with pytest
       run: |
         {

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM registry.fedoraproject.org/fedora:40
+RUN dnf install -y python3 python3-pip python3-dnf skopeo rpm
+WORKDIR /app
+COPY . .
+RUN python3 -m pip install -e .
+ENTRYPOINT ["/usr/local/bin/rpm-lockfile-prototype"]


### PR DESCRIPTION
The idea is to push an image to `ghcr.io` so that one can just run `podman run -v … ghcr.io/konflux-ci/… …` instead of having to use `venv` or manage our own image.

This is probably not the best implementation — maybe we could rely on podman only and a `Containerfile` or something, and just use the metadata and login command to ease pushing to ghcr.io.