### PR TITLE
Add label interpolation into repos defined directly in the config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- The repos specified directly in the input file can now interpolate base image
+  labels too. The specification for which image to use is the same as for the
+  repofiles origin.
+
+  This only works for `baseurl`.
+
+
 ## [0.7.0] - 2024-08-05
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -80,7 +80,12 @@ contentOrigin:
   repos:
     # List of objects with repoid and baseurl
     - repoid: fedora
-      baseurl: https://kojipkgs.fedoraproject.org/compose/rawhide/latest-Fedora-Rawhide/compose/Everything/$basearch/os/
+      baseurl: https://kojipkgs.fedoraproject.org/compose/rawhide/{compose-id}/compose/Everything/$basearch/os/
+      # The baseurl can reference labels from a base image, such as the
+      # compose-id above. The image to get the labels from can be specified
+      # either directly or via a Containerfile.
+      varsFromImage: registry.fedoraproject.org/fedora:latest
+      varsFromContainerfile: Containerfile
       # You can list any option that would be in .repo file here too.
       # For example sslverify, proxy or excludepkgs might be of interest
   repofiles:

--- a/rpm_lockfile/content_origin/repos.py
+++ b/rpm_lockfile/content_origin/repos.py
@@ -1,4 +1,7 @@
+import os
+
 from . import Repo
+from .. import utils
 
 
 class RepoOrigin:
@@ -7,12 +10,24 @@ class RepoOrigin:
         "properties": {
             "repoid": {"type": "string"},
             "baseurl": {"type": "string"},
+            "varsFromImage": {"type": "string"},
+            "varsFromContainerfile": {"type": "string"},
         },
         "required": ["repoid", "baseurl"],
     }
 
-    def __init__(self, *args, **kwargs):
-        pass
+    def __init__(self, config_dir):
+        self.config_dir = config_dir
 
     def collect(self, sources):
-        yield from (Repo.from_dict(s) for s in sources)
+        for source in sources:
+            image = source.pop("varsFromImage", None)
+            containerfile = source.pop("varsFromContainerfile", None)
+            vars = utils.get_labels(image, self._get_container_file(containerfile))
+            source["baseurl"] = utils.subst_vars(source["baseurl"], vars)
+            yield Repo.from_dict(source)
+
+    def _get_container_file(self, containerfile):
+        if containerfile:
+            return os.path.join(self.config_dir, containerfile)
+        return None

--- a/tests/content_origin/test_repos.py
+++ b/tests/content_origin/test_repos.py
@@ -1,0 +1,54 @@
+from unittest.mock import patch
+
+from rpm_lockfile.content_origin import Repo
+from rpm_lockfile.content_origin.repos import RepoOrigin
+
+
+def test_collect_simple(tmpdir):
+    baseurl = "https://example.com/repo"
+    config = [{"repoid": "a", "baseurl": baseurl}]
+    origin = RepoOrigin(tmpdir)
+    repos = list(origin.collect(config))
+
+    assert repos == [Repo(repoid="a", baseurl=baseurl)]
+
+
+LABELS = {
+    "vcs-ref": "abcdef",
+    "architecture": "x86_64",
+}
+
+TEMPLATE_CONFIG = {
+    "repoid": "a", "baseurl": "https://example.com/{architecture}/repo"
+}
+EXPANDED_REPO = Repo(repoid="a", baseurl="https://example.com/x86_64/repo")
+
+
+def test_collect_with_vars_from_image(tmpdir):
+    origin = RepoOrigin(tmpdir)
+    image = "registry.example.com/image:latest"
+
+    with patch("rpm_lockfile.utils.get_labels") as mock_get_labels:
+        mock_get_labels.return_value = LABELS
+        repos = list(origin.collect([TEMPLATE_CONFIG | {"varsFromImage": image}]))
+
+    assert repos == [EXPANDED_REPO]
+    mock_get_labels.assert_called_once_with(image, None)
+
+
+def test_collect_with_vars_from_containerfile(tmpdir):
+    origin = RepoOrigin(tmpdir)
+    (tmpdir / "Containerfile").write_text(
+        "FROM registry.example.com/image:latest\nRUN date\n", encoding="utf-8"
+    )
+
+    with patch("rpm_lockfile.utils.get_labels") as mock_get_labels:
+        mock_get_labels.return_value = LABELS
+        repos = list(
+            origin.collect(
+                [TEMPLATE_CONFIG | {"varsFromContainerfile": "Containerfile"}]
+            )
+        )
+
+    assert repos == [EXPANDED_REPO]
+    mock_get_labels.assert_called_once_with(None, tmpdir / "Containerfile")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,6 @@
-from unittest.mock import patch, mock_open
+import json
+import subprocess
+from unittest.mock import patch, mock_open, Mock
 
 import pytest
 
@@ -53,3 +55,54 @@ COPY --from=build /artifact /
 def test_extract_image(file, expected):
     with patch("builtins.open", mock_open(read_data=file)):
         assert utils.extract_image(file) == expected
+
+
+@pytest.mark.parametrize(
+    "template,vars,expected",
+    [
+        ("foo{x}bar", {"x": "X"}, "fooXbar"),
+        ("{x}{y}", {"x": "X", "y": "Y"}, "XY"),
+        ("foo{x}bar}", {}, "foo{x}bar}"),
+        ("foobar", {}, "foobar"),
+        ("foobar", {"x": "X"}, "foobar"),
+    ]
+)
+def test_subst_vars(template, vars, expected):
+    assert utils.subst_vars(template, vars) == expected
+
+
+INSPECT_OUTPUT = {
+    "Labels": {
+        "vcs-ref": "abcdef",
+        "architecture": "x86_64",
+    },
+    "Os": "linux",
+}
+
+
+def test_get_labels_from_image():
+    image = "registry.example.com/image:latest"
+
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = Mock(stdout=json.dumps(INSPECT_OUTPUT))
+        labels = utils.get_labels(image, None)
+
+    assert labels == INSPECT_OUTPUT["Labels"]
+    mock_run.assert_called_once_with(
+        ["skopeo", "inspect", f"docker://{image}"], check=True, stdout=subprocess.PIPE
+    )
+
+
+def test_get_labels_from_containerfile(tmpdir):
+    image = "registry.example.com/image:latest"
+    containerfile = tmpdir / "Containerfile"
+    containerfile.write_text(f"FROM {image}\nRUN date\n", encoding="utf-8")
+
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = Mock(stdout=json.dumps(INSPECT_OUTPUT))
+        labels = utils.get_labels(None, str(containerfile))
+
+    assert labels == INSPECT_OUTPUT["Labels"]
+    mock_run.assert_called_once_with(
+        ["skopeo", "inspect", f"docker://{image}"], check=True, stdout=subprocess.PIPE
+    )


### PR DESCRIPTION
This PR should enable this (assuming the last base image used in the Containerfile has a label `compose-id`:

```
  repos:
    - repoid: rhel
      baseurl: https://example.com/rhel/nightly/rhel/{compose-id}/compose/BaseOS/$basearch/os/
      varsFromContainerfile: Containerfile
```

If there are multiple repos, the information on where to get the labels from must be provided in each one separately, which is not great but doesn't break any backwards compatibility.