### PR TITLE
Add options to select stage in containerfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@
 
   This only works for `baseurl`.
 
+- Where input configuration file specifies an image by pointing to Container
+  file, it is now possible to provide an object with additional info on which
+  stage to use. The stage can be specified by order (first, second, etc.), by
+  name, or by a pattern that must be found in the image name.
+
 
 ## [0.7.0] - 2024-08-05
 

--- a/README.md
+++ b/README.md
@@ -143,6 +143,28 @@ context:
     rpmOstreeTreefile: centos-bootc/centos-bootc.yaml
 ```
 
+The configuration file can specify a containerfile to extract a base image from
+either in the `context` section or in `varsFromContainerfile` inside
+`contentOrigin`. This containerfile can be either a simple string (file path
+relative to the config file), or a more complex object. In the complex case you
+can specify which stage you want to extract the image from, either by its
+order, name or by pattern matching the image.
+
+```yaml
+containerfile:
+  # Only the `file` key is required.
+  file: path/relative/to/rpms.yaml.in
+  # Get image from stage given by the order. Numbering starts from 1.
+  stageNum: 1
+  # Get image from a stage with the given name.
+  stageName: builder
+  # Get base image that contains a match for the given regular expression.
+  imagePattern: example.com
+```
+
+If multiple filters for selecting stage are set, the first one to match is
+used.
+
 # What does this do
 
 High-level overview: given a list of packages, repo urls and installed

--- a/rpm_lockfile/content_origin/repofiles.py
+++ b/rpm_lockfile/content_origin/repofiles.py
@@ -24,7 +24,7 @@ class RepofileOrigin:
                 "type": "object",
                 "properties": {
                     "location": {"type": "string"},
-                    "varsFromContainerfile": {"type": "string"},
+                    "varsFromContainerfile": utils.CONTAINERFILE_SCHEMA,
                     "varsFromImage": {"type": "string"},
                 },
                 "required": ["location"],
@@ -36,7 +36,7 @@ class RepofileOrigin:
                     "giturl": {"type": "string"},
                     "file": {"type": "string"},
                     "gitref": {"type": "string"},
-                    "varsFromContainerfile": {"type": "string"},
+                    "varsFromContainerfile": utils.CONTAINERFILE_SCHEMA,
                     "varsFromImage": {"type": "string"},
                 },
                 "required": ["giturl", "file", "gitref"],
@@ -57,10 +57,7 @@ class RepofileOrigin:
     def _get_repofile_path(self, source):
         if isinstance(source, str):
             return source
-        vars = utils.get_labels(
-            source.get("varsFromImage"),
-            self._get_container_file(source.get("varsFromContainerfile")),
-        )
+        vars = utils.get_labels(source, self.config_dir)
         if "location" in source:
             return utils.subst_vars(source["location"], vars)
         return utils.get_file_from_git(
@@ -68,11 +65,6 @@ class RepofileOrigin:
             utils.subst_vars(source["gitref"], vars),
             utils.subst_vars(source["file"], vars),
         )
-
-    def _get_container_file(self, containerfile):
-        if containerfile:
-            return os.path.join(self.config_dir, containerfile)
-        return None
 
     def collect_repofile(self, url):
         if url.startswith("http"):

--- a/rpm_lockfile/content_origin/repos.py
+++ b/rpm_lockfile/content_origin/repos.py
@@ -1,5 +1,3 @@
-import os
-
 from . import Repo
 from .. import utils
 
@@ -11,7 +9,7 @@ class RepoOrigin:
             "repoid": {"type": "string"},
             "baseurl": {"type": "string"},
             "varsFromImage": {"type": "string"},
-            "varsFromContainerfile": {"type": "string"},
+            "varsFromContainerfile": utils.CONTAINERFILE_SCHEMA,
         },
         "required": ["repoid", "baseurl"],
     }
@@ -21,13 +19,6 @@ class RepoOrigin:
 
     def collect(self, sources):
         for source in sources:
-            image = source.pop("varsFromImage", None)
-            containerfile = source.pop("varsFromContainerfile", None)
-            vars = utils.get_labels(image, self._get_container_file(containerfile))
+            vars = utils.get_labels(source, self.config_dir)
             source["baseurl"] = utils.subst_vars(source["baseurl"], vars)
             yield Repo.from_dict(source)
-
-    def _get_container_file(self, containerfile):
-        if containerfile:
-            return os.path.join(self.config_dir, containerfile)
-        return None

--- a/rpm_lockfile/schema.py
+++ b/rpm_lockfile/schema.py
@@ -4,7 +4,7 @@ import sys
 
 import jsonschema
 
-from . import content_origin
+from . import content_origin, utils
 
 
 STRINGS = {
@@ -54,7 +54,7 @@ def get_schema():
                     {
                         "additionalProperties": False,
                         "properties": {
-                            "containerfile": {"type": "string"},
+                            "containerfile": utils.CONTAINERFILE_SCHEMA,
                             "flatpak": {"type": "boolean"},
                         },
                     },


### PR DESCRIPTION
The code used to default to the first found stage, then it switched to the last one. But the real requirement is "stage that does RPM installation". No default can match that.

This commit adds the ability to specify the containerfile not just by path, but also by an object with path and additional stage selectors.

-----

This seems to work, but I may be making it way too complicated. Are all of these options needed?

CC @msrb 