### PR TITLE
Ignore tags for inspecting image if digest is specified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- Obtaining labels from base image now works even if the image is specified
+  using both tag and digest. The tag is ignored in such case.
+
 ## [0.7.1] - 2024-09-02
 
 ### Added

--- a/rpm_lockfile/containers.py
+++ b/rpm_lockfile/containers.py
@@ -1,7 +1,6 @@
 import json
 import logging
 import os
-import re
 import tarfile
 import tempfile
 from pathlib import Path
@@ -25,7 +24,7 @@ def _copy_image(baseimage, arch, destdir):
         "skopeo",
         f"--override-arch={arch}",
         "copy",
-        f"docker://{strip_tag(baseimage)}",
+        f"docker://{utils.strip_tag(baseimage)}",
         f"dir:{destdir}",
     ]
     utils.logged_run(cmd, check=True)

--- a/tests/test_containers.py
+++ b/tests/test_containers.py
@@ -9,19 +9,7 @@ from unittest import mock
 
 import pytest
 
-from rpm_lockfile import containers, utils
-
-
-@pytest.mark.parametrize(
-    "image_spec,expected",
-    [
-        ("example.com/image:latest", "example.com/image:latest"),
-        ("example.com/image@sha256:abcdef", "example.com/image@sha256:abcdef"),
-        ("example.com/image:latest@sha256:0123456", "example.com/image@sha256:0123456"),
-    ],
-)
-def test_strip_tag(image_spec, expected):
-    assert utils.strip_tag(image_spec) == expected
+from rpm_lockfile import containers
 
 
 @pytest.fixture


### PR DESCRIPTION
The tool can now obtain labels from a container image using skopeo. If the image is specified with both tag and digest, skopeo will fail.

This commit makes the resolver ignore the tag, so it will look up the labels based on the digest.