### PR TITLE
Fix skopeo inspect call to swallow digest & tag definition error.

### DIFF
--- a/rpm_lockfile/containers.py
+++ b/rpm_lockfile/containers.py
@@ -19,30 +19,13 @@ def _translate_arch(arch):
     return ARCHES.get(arch, arch)
 
 
-def _strip_tag(image_spec):
-    """
-    If the image specification contains both a tag and a digest, remove the
-    tag. Skopeo rejects such images. The behaviour is chosen to match podman
-    4.9.4, which silently ignores the tag if digest is available.
-
-    https://github.com/containers/image/issues/1736
-    """
-    # De don't want to validate the digest here in any way, so even wrong
-    # length should be accepted.
-    m = re.match(r'([^:]+)(:[^@]+)(@sha\d+:[a-f0-9]+)$', image_spec)
-    if m:
-        logging.info("Digest was provided, ignoring tag %s", m.group(2)[1:])
-        return f"{m.group(1)}{m.group(3)}"
-    return image_spec
-
-
 def _copy_image(baseimage, arch, destdir):
     """Download image into given location."""
     cmd = [
         "skopeo",
         f"--override-arch={arch}",
         "copy",
-        f"docker://{_strip_tag(baseimage)}",
+        f"docker://{strip_tag(baseimage)}",
         f"dir:{destdir}",
     ]
     utils.logged_run(cmd, check=True)

--- a/tests/test_containers.py
+++ b/tests/test_containers.py
@@ -9,7 +9,7 @@ from unittest import mock
 
 import pytest
 
-from rpm_lockfile import containers
+from rpm_lockfile import containers, utils
 
 
 @pytest.mark.parametrize(
@@ -21,7 +21,7 @@ from rpm_lockfile import containers
     ],
 )
 def test_strip_tag(image_spec, expected):
-    assert containers._strip_tag(image_spec) == expected
+    assert utils.strip_tag(image_spec) == expected
 
 
 @pytest.fixture


### PR DESCRIPTION
This was done in #15 for `skopeo copy`, but there is another call to `skopeo inspect` which was not updated. The _strip_tag function was moved into utils and made non-private.

Resolves #44 