### PR TITLE
Allow setting arch subset for individual packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+### Changed
+
+- The input file can now specify packages as objects, which can be used to add
+  the package only to a subset of architectures.
+
+
 ## [0.8.0] - 2024-09-05
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -120,10 +120,20 @@ contentOrigin:
 packages:
   # list of rpm names to resolve
   - vim-enhanced
+  # Either a simple string as above, or an object with specification of
+  # architectures. Either specify allow list (`only`) or deny list (`not`). The
+  # value is either a single string or a list of strings.
+  - name: librtas
+    arches:
+      only: ppc64le
+  - name: grub2
+    arches:
+      not:
+      - s390x
 
 reinstallPackages: []
-  # list of rpms already provided in the base image, but which should be
-  # reinstalled
+  # List of rpms already provided in the base image, but which should be
+  # reinstalled. Same specification as `packages` above.
 
 arches:
   # The list of architectures can be set in the config file. Any `--arch` option set

--- a/rpm_lockfile/schema.py
+++ b/rpm_lockfile/schema.py
@@ -18,21 +18,63 @@ STRINGS = {
 def get_schema():
     return {
         "$schema": "http://json-schema.org/draft-04/schema#",
+        "$defs": {
+            # Either a single string or a list of strings
+            "strings": {
+                "oneOf": [
+                    {"type": "string"},
+                    {"type": "array", "items": {"type": "string"}},
+                ],
+            },
+            # Either just a string with name, or an object with arch specification
+            "pkg": {
+                "oneOf": [
+                    {"type": "string"},
+                    {
+                        "type": "object",
+                        "properties": {
+                            "name": {"type": "string"},
+                            "arches": {
+                                "oneOf": [
+                                    {
+                                        "type": "object",
+                                        "properties": {
+                                            "only": {"$ref": "#/$defs/strings"},
+                                        },
+                                        "additionalProperties": False,
+                                        "required": ["only"],
+                                    },
+                                    {
+                                        "type": "object",
+                                        "properties": {
+                                            "not": {"$ref": "#/$defs/strings"},
+                                        },
+                                        "additionalProperties": False,
+                                        "required": ["not"],
+                                    },
+                                ],
+                            }
+                        },
+                        "required": ["name"],
+                    }
+                ],
+            }
+        },
         "type": "object",
         "properties": {
-            # TODO Packages should not be required. If possible, they should be
-            # extracted from other input files.
+
             "packages": {
                 "type": "array",
-                "items": {"type": "string"},
+                "items": {"$ref": "#/$defs/pkg"},
             },
+
             "arches": {
                 "type": "array",
                 "items": {"type": "string"},
             },
             "reinstallPackages": {
                 "type": "array",
-                "items": {"type": "string"},
+                "items": {"$ref": "#/$defs/pkg"},
             },
             "contentOrigin": {
                 "type": "object",

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,0 +1,49 @@
+from unittest.mock import patch, mock_open
+
+import pytest
+
+import rpm_lockfile
+
+
+@pytest.mark.parametrize(
+    "arch,expected",
+    [
+        pytest.param("x86_64", {"glibc", "bash", "openssl"}, id="x86_64"),
+        pytest.param("s390x", {"glibc", "zsh", "ant"}, id="s390x"),
+    ],
+)
+def test_read_container_yaml(arch, expected):
+    contents = """
+        flatpak:
+          packages:
+          - glibc
+          - name: bash
+            platforms:
+              only: x86_64
+          - name: zsh
+            platforms:
+              not: x86_64
+          - name: openssl
+            platforms:
+              only: [x86_64]
+          - name: ant
+            platforms:
+              not: [x86_64]
+        """
+    with patch("builtins.open", mock_open(read_data=contents)):
+        assert rpm_lockfile.read_packages_from_container_yaml(arch) == expected
+
+
+@pytest.mark.parametrize(
+    "input,expected",
+    [
+        (["foo", "bar"], ["foo", "bar"]),
+        ([{"name": "foo"}], ["foo"]),
+        ([{"name": "foo", "arches": {"only": ["ppc64le"]}}], ["foo"]),
+        ([{"name": "foo", "arches": {"not": ["ppc64le"]}}], []),
+        ([{"name": "foo", "arches": {"only": ["s390x"]}}], []),
+        ([{"name": "foo", "arches": {"not": ["s390x"]}}], ["foo"]),
+    ],
+)
+def test_filter_for_arch(input, expected):
+    assert sorted(rpm_lockfile.filter_for_arch("ppc64le", input)) == sorted(expected)


### PR DESCRIPTION
This is needed in case some package doesn't exist on some architectures where the lockfile will be used.

Fixes: #51