### PR TITLE
Make it possible to install modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Unreleased
+
+### Changed
+
+- The list of packages in input file can now specify groups or modules (e.g.
+  `@core` or `@container-tools:rhel8`; don't forget quotes for the yaml file to
+  be valid). Anything accepted by `dnf install` should be acceptable in there.
+  The `reinstallPackages` section still needs RPM names.
+
+
 ## [0.8.1] - 2024-09-06
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Added
+
+- Module streams can be explicitly enabled or disabled by adding
+  `moduleEnable`/`moduleDisable` directive to the input file.
+
 ### Changed
 
 - The list of packages in input file can now specify groups or modules (e.g.

--- a/README.md
+++ b/README.md
@@ -135,6 +135,10 @@ reinstallPackages: []
   # List of rpms already provided in the base image, but which should be
   # reinstalled. Same specification as `packages` above.
 
+moduleEnable: []
+  # List of module streams that should be enabled during the dependency
+  # resolution. The specification uses the same format as `packages` above.
+
 arches:
   # The list of architectures can be set in the config file. Any `--arch` option set
   # on the command line will override this list.
@@ -196,6 +200,19 @@ There are three options for how the installed packages can be handled.
 3. Extract installed packages from a container image. This would be used for
    layered images. The base image can be explicitly provided, or discovered
    from `Containerfile`.
+
+
+# Dealing with modularity and groups
+
+Creating lockfiles involving modules should work. Here's a guide on how to
+specify the input:
+
+| Dockerfile command | Input file | Comment |
+| ------------------ | ---------- | ------- |
+| `dnf module install foo:bar` | `packages: ["@foo:bar"]` | Installs all packages from default profile from the module stream |
+| `dnf module enable foo:bar` | `moduleEnable: ["foo:bar"]` | Makes the module stream available for installation |
+| `dnf module disable nodejs` | `moduleDisable: ["nodejs"]` | Added for completeness, but may not really be needed |
+| `dnf groupinstall core` | `packages: ["@core]` | Install comps group `core` |
 
 
 # Implementation details and notes

--- a/rpm_lockfile/__init__.py
+++ b/rpm_lockfile/__init__.py
@@ -142,11 +142,11 @@ def resolver(
                         f"Can not reinstall {pkg}: no package matched in configured repo"
                     )
             # Mark packages for installation
-            for solvable in solvables:
-                try:
-                    base.install(solvable)
-                except dnf.exceptions.PackageNotFoundError:
-                    raise RuntimeError(f"No match found for {solvable}")
+            try:
+                base.install_specs(solvables)
+            except dnf.exceptions.MarkingErrors as exc:
+                logging.error(exc.value)
+                raise RuntimeError(f"DNF error: {exc}")
             # And resolve the transaction
             base.resolve(allow_erasing=allow_erasing)
 

--- a/rpm_lockfile/__init__.py
+++ b/rpm_lockfile/__init__.py
@@ -113,6 +113,8 @@ def resolver(
     solvables,
     allow_erasing: bool,
     reinstall_packages: set[str],
+    module_enable: set[str],
+    module_disable: set[str],
 ):
     packages = set()
     sources = set()
@@ -131,6 +133,13 @@ def resolver(
             for repo in repos:
                 base.repos.add_new_repo(repo.repoid, conf, baseurl=[repo.baseurl], **repo.kwargs)
             base.fill_sack(load_system_repo=True)
+
+            module_base = dnf.module.module_base.ModuleBase(base)
+
+            # Enable and disable modules as requested
+            module_base.disable(module_disable)
+            module_base.enable(module_enable)
+
             # Mark packages to remove
             for pkg in reinstall_packages:
                 try:
@@ -150,7 +159,6 @@ def resolver(
             # And resolve the transaction
             base.resolve(allow_erasing=allow_erasing)
 
-            module_base = dnf.module.module_base.ModuleBase(base)
             modular_packages = set(
                 nevra
                 for module in module_base.get_modules("*")[0]
@@ -221,13 +229,27 @@ def image_rpmdb(baseimage):
 
 
 def process_arch(
-    arch, rpmdb, repos, packages, allow_erasing, reinstall_packages: set[str]
+    arch,
+    rpmdb,
+    repos,
+    packages,
+    allow_erasing,
+    reinstall_packages: set[str],
+    module_enable: set[str],
+    module_disable: set[str],
 ):
     logging.info("Running solver for %s", arch)
 
     with rpmdb(arch) as root_dir:
         packages, sources, module_metadata = resolver(
-            arch, root_dir, repos, packages, allow_erasing, reinstall_packages
+            arch,
+            root_dir,
+            repos,
+            packages,
+            allow_erasing,
+            reinstall_packages,
+            module_enable,
+            module_disable,
         )
 
     return {
@@ -421,6 +443,12 @@ def main():
                 allow_erasing=args.allowerasing,
                 reinstall_packages=set(
                     filter_for_arch(arch, config.get("reinstallPackages", []))
+                ),
+                module_enable=set(
+                    filter_for_arch(arch, config.get("moduleEnable", []))
+                ),
+                module_disable=set(
+                    filter_for_arch(arch, config.get("moduleDisable", []))
                 ),
             )
         )

--- a/rpm_lockfile/schema.py
+++ b/rpm_lockfile/schema.py
@@ -76,6 +76,14 @@ def get_schema():
                 "type": "array",
                 "items": {"$ref": "#/$defs/pkg"},
             },
+            "moduleEnable": {
+                "type": "array",
+                "items": {"$ref": "#/$defs/pkg"},
+            },
+            "moduleDisable": {
+                "type": "array",
+                "items": {"$ref": "#/$defs/pkg"},
+            },
             "contentOrigin": {
                 "type": "object",
                 "properties": {


### PR DESCRIPTION
This PR adds ability to include modules in the `packages` section, which will install them (i.e. install all RPMs listed in the default profile for the module stream, the equivalent of `dnf module install …`). A new top level key `moduleEnable` can specify which modules should be enabled (i.e. packages made available for installation, but nothing gets installed directly; the equivalent of `dnf module enable …`).

Enabled modules need to be combined with listing the desired packages in the `packages` section.

Here's an example. Imagine three module streams providing some package:
* `m:1.0` has `foo-1.0`
* `m:2.0` has `foo-2.0`
* `m:latest` has `foo-3.0`

The `latest` stream is configured as default.

If the input file contains `packages: ["foo"]`, the lockfile will end up with version 3.0, since that's the default.
By adding `moduleEnable: ["m:1.0"]` (or 2.0), you can tell resolve the lockfile for a different version.