### PR TITLE
Support arch/basearch variable substitution in repo id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@
 
 - Repositories can now use `mirrorlist` or `metalink` instead of just `baseurl`.
 
+### Fixed
+
+- Variable substition in repoid is now supported. Only `arch` and `basearch`
+  variables really make sense though, as anything else is taken from the host
+  system where the tool is running.
+
 
 ## [0.9.0] - 2024-09-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
   variables really make sense though, as anything else is taken from the host
   system where the tool is running.
 
+- `$basearch` is now set correctly in cases it's not equal to `$arch`.
+
 
 ## [0.9.0] - 2024-09-19
 

--- a/rpm_lockfile/__init__.py
+++ b/rpm_lockfile/__init__.py
@@ -129,7 +129,8 @@ def resolver(
             conf.cachedir = os.path.join(cache_dir, "cache")
             conf.logdir = mkdir(os.path.join(cache_dir, "log"))
             conf.persistdir = mkdir(os.path.join(cache_dir, "dnf"))
-            conf.substitutions["arch"] = conf.substitutions["basearch"] = arch
+            conf.substitutions["arch"] = arch
+            conf.substitutions["basearch"] = dnf.rpm.basearch(arch)
             # Configure repos
             for repo in repos:
                 base.repos.add_new_repo(

--- a/rpm_lockfile/__init__.py
+++ b/rpm_lockfile/__init__.py
@@ -14,6 +14,7 @@ from dataclasses import asdict, dataclass
 try:
     import dnf
     import hawkey
+    import libdnf.conf
 except ImportError:
     print(
         "Python bindings for DNF are missing.",
@@ -131,7 +132,13 @@ def resolver(
             conf.substitutions["arch"] = conf.substitutions["basearch"] = arch
             # Configure repos
             for repo in repos:
-                base.repos.add_new_repo(repo.repoid, conf, **repo.kwargs)
+                base.repos.add_new_repo(
+                    libdnf.conf.ConfigParser.substitute(
+                        repo.repoid, conf.substitutions
+                    ),
+                    conf,
+                    **repo.kwargs
+                )
             base.fill_sack(load_system_repo=True)
 
             module_base = dnf.module.module_base.ModuleBase(base)


### PR DESCRIPTION
The first commit adds the substitution to repoid, the second fixed basearch value if it's not equal to arch.