### PR TITLE
Warn about images with no registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- A warning is printed when the base image specification doesn't include a
+  registry. Not specifying a registry can cause confusing errors if skopeo
+  (used by this tool) uses a different default than the build process later on.
+
+
 ## [0.10.0] - 2024-11-19
 
 ### Added

--- a/rpm_lockfile/containers.py
+++ b/rpm_lockfile/containers.py
@@ -23,6 +23,15 @@ USAGE_THRESHOLD = 80
 
 def _copy_image(baseimage, arch, destdir):
     """Download image into given location."""
+    if not utils.check_image_spec(baseimage):
+        logging.warning(
+            """
+            Image specification is missing registry. Skopeo will use some
+            registry as a default. If the build system uses a different one,
+            you will see strange errors during the prefetch and build steps.
+            """
+        )
+
     cmd = [
         "skopeo",
         f"--override-arch={arch}",

--- a/rpm_lockfile/utils.py
+++ b/rpm_lockfile/utils.py
@@ -170,6 +170,14 @@ def strip_tag(image_spec):
     return image_spec
 
 
+def check_image_spec(image_spec):
+    """Check if the image is fully qualified with a registry."""
+    # We only check that there's a slash in the image name, and the part before
+    # slash contains at least one dot.
+    m = re.match(r'.+\..+/.+', image_spec)
+    return bool(m)
+
+
 def get_labels(obj, config_dir):
     """Find labels from an image or the base image used in the containerfile
     from given configuration object. The given configuration dict is modified

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -69,6 +69,33 @@ def test_make_image_spec(repo, tag, digest, expected):
 
 
 @pytest.mark.parametrize(
+    "image_spec",
+    [
+        "example.com/image:latest",
+        "example.com/image@sha256:abcdef",
+        "example.com/image:latest@sha256:0123456",
+        "registry.example.com/image:latest@sha256:0123456",
+        "registry.example.com/namespace/image:stable",
+    ],
+)
+def test_check_image_spec_correct(image_spec):
+    assert utils.check_image_spec(image_spec)
+
+
+@pytest.mark.parametrize(
+    "image_spec",
+    [
+        "fedora",
+        "image@sha256:abcdef",
+        "image:latest@sha256:0123456",
+        "namespace/image:stable",
+    ],
+)
+def test_check_image_spec_wrong(image_spec):
+    assert not utils.check_image_spec(image_spec)
+
+
+@pytest.mark.parametrize(
     "file,expected",
     [
         ("""FROM registry.io/repository/base


### PR DESCRIPTION
If user specifies a base image with no registry information, things may seem to work as skopeo will use some default value. But it may lead to confusing breakage later if the build system picks a different registry.

For example, right now using `fedora` as image spec will make skopeo download `docker.io/library/fedora:40`, but podman uses `registry.fedoraproject.org/fedora:40`.

There's no good way to automatically fix it, so let's print a big warning at least.