### PR TITLE
Add a caching wrapper

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ packages = ['rpm_lockfile', 'rpm_lockfile.content_origin']
 
 [project.scripts]
 rpm-lockfile-prototype = "rpm_lockfile:main"
+caching-rpm-lockfile-prototype = "rpm_lockfile.caching_wrapper:main"
 
 
 [build-system]

--- a/python-rpm-lockfile-prototype.spec
+++ b/python-rpm-lockfile-prototype.spec
@@ -50,6 +50,7 @@ Summary: RPM lockfile generator
 %license COPYING
 %doc README.md
 %_bindir/rpm-lockfile-prototype
+%_bindir/caching-rpm-lockfile-prototype
 %python3_sitelib/rpm_lockfile/*.py
 %python3_sitelib/rpm_lockfile/__pycache__/*.pyc
 %python3_sitelib/rpm_lockfile/content_origin/*.py

--- a/rpm_lockfile/caching_wrapper.py
+++ b/rpm_lockfile/caching_wrapper.py
@@ -1,0 +1,46 @@
+import argparse
+import hashlib
+import logging
+import os
+import shutil
+from pathlib import Path
+
+from . import utils
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("infile", metavar="INPUT_FILE", default="rpms.in.yaml")
+    parser.add_argument("--outfile", default="rpms.lock.yaml")
+
+    args, rest = parser.parse_known_args()
+
+    logging.basicConfig(level=logging.INFO)
+
+    input_hash = hashlib.sha256()
+
+    input_hash.update(b"\0".join(x.encode("utf-8") for x in rest))
+    input_hash.update(b"\0")
+    with open(args.infile, "rb") as f:
+        while chunk := f.read(65536):
+            input_hash.update(chunk)
+
+    input_digest = input_hash.hexdigest()
+    logging.info("Using %s as cache key", input_digest)
+
+    cache_file = utils.CACHE_PATH / "results" / f"{input_digest}.yaml"
+    cache_file.parent.mkdir(exist_ok=True, parents=True)
+
+    cmd = os.environ.get("RPM_LOCKFILE_PROTOTYPE_CMD", "rpm-lockfile-prototype")
+
+    if not cache_file.exists():
+        logging.info("Cached results do not exist, running resolver")
+        utils.logged_run(
+            [cmd, args.infile, "--outfile", str(cache_file)] + rest,
+            check=True,
+        )
+
+    logging.info("Copying cache results to %s", args.outfile)
+    with cache_file.open("rb") as inp:
+        with Path(args.outfile).open("wb") as outp:
+            shutil.copyfileobj(inp, outp)

--- a/rpm_lockfile/containers.py
+++ b/rpm_lockfile/containers.py
@@ -13,8 +13,6 @@ from . import utils
 # Known locations for rpmdb inside the image.
 RPMDB_PATHS = ["usr/lib/sysimage/rpm", "var/lib/rpm"]
 
-CACHE_PATH = Path.home() / ".cache" / "rpm-lockfile-prototype" / "rpmdbs"
-
 # Storage usage limit. If the filesystem with the cache fills up over this
 # limit, nothing new will be added into the cache.
 # Value in percent.
@@ -61,7 +59,7 @@ def setup_rpmdb(dest_dir, baseimage, arch):
 
     # The images need to be cached per-architecture. The same digest is used
     # reference the same image.
-    cache = CACHE_PATH / arch / digest
+    cache = utils.CACHE_PATH / "rpmdbs" / arch / digest
     if not cache.exists():
         # If we don't have anything cached, extract the rpmdb from the image
         # into the cache.

--- a/rpm_lockfile/utils.py
+++ b/rpm_lockfile/utils.py
@@ -7,12 +7,15 @@ import re
 import shlex
 import subprocess
 import tempfile
+from pathlib import Path
 
 
 # Path to where local dnf expects to find rpmdb. This is relative to /.
 RPMDB_PATH = subprocess.run(
     ["rpm", "--eval", "%_dbpath"], stdout=subprocess.PIPE, check=True, encoding="utf-8"
 ).stdout.strip()[1:]
+
+CACHE_PATH = Path.home() / ".cache" / "rpm-lockfile-prototype"
 
 
 def relative_to(directory, path):


### PR DESCRIPTION
This new executable has identical interface as the original code. It calculates a digest of all inputs (arguments and input file contents), and will only run the actual resolver once for given inputs.

This can be helpful if you need to run the tool multiple times and want to guarantee identical results.

The cache is never cleaned up.