### PR TITLE
Add disabling source inclusion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- Inclusion of source packages in the final manifest can now be disabled with a
+  toplevel config option `noSources: true`. This is mostly useful for cases
+  where there are no source repos available to silence the many warnings.
+
 ## [0.11.0] - 2024-11-20
 
 ### Added

--- a/rpm_lockfile/schema.py
+++ b/rpm_lockfile/schema.py
@@ -126,6 +126,7 @@ def get_schema():
                 ],
             },
             "allowerasing": {"type": "boolean"},
+            "noSources": {"type": "boolean"},
         },
         "required": ["contentOrigin"],
         "additionalProperties": False,


### PR DESCRIPTION
Not all users care about source packages, so let's make life easier for them. With the new option, the tool will not do anything about source rpms, including not printing a warning for each RPM.