### PR TITLE
Also look for rpmdb in files/lib/sysimage/rpm

### DIFF
--- a/rpm_lockfile/containers.py
+++ b/rpm_lockfile/containers.py
@@ -10,8 +10,9 @@ from pathlib import Path
 
 from . import utils
 
-# Known locations for rpmdb inside the image.
-RPMDB_PATHS = ["usr/lib/sysimage/rpm", "var/lib/rpm"]
+# Known locations for rpmdb inside the image; files/lib is for
+# Flatpak runtime images.
+RPMDB_PATHS = ["usr/lib/sysimage/rpm", "var/lib/rpm", "files/lib/sysimage/rpm"]
 
 # Storage usage limit. If the filesystem with the cache fills up over this
 # limit, nothing new will be added into the cache.


### PR DESCRIPTION
A Flatpak runtime image has a filesystem where the rpmdb (and all of /usr/lib) is located in files/lib and there's a symlink to /usr. Look for the rpmdb there as well.