### PR TITLE
fix: add missing percentage sign in storage usage log message

### DIFF
--- a/rpm_lockfile/containers.py
+++ b/rpm_lockfile/containers.py
@@ -132,7 +132,7 @@ def _maybe_cleanup(directory):
     """
     usage = _get_storage_usage(directory)
     if usage and usage >= USAGE_THRESHOLD:
-        logging.info("Storage is %d % full. Cleaning up cached rpmdb.", usage)
+        logging.info("Storage is %d%% full. Cleaning up cached rpmdb.", usage)
         shutil.rmtree(directory)
 
 


### PR DESCRIPTION
Double %% is required to escape the percentage sign in the string format.

Fixes this error:
  ```
    File "/usr/lib64/python3.13/logging/__init__.py", line 400, in getMessage
      msg = msg % self.args
            ~~~~^~~~~~~~~~~
  TypeError: not enough arguments for format string
  ...
      logging.info("Storage is %d % full. Cleaning up cached rpmdb.", usage)
  Message: 'Storage is %d % full. Cleaning up cached rpmdb.'
  Arguments: (98,)
  ```