### PR TITLE
fix: only enable or disable modules when requested

### DIFF
--- a/rpm_lockfile/__init__.py
+++ b/rpm_lockfile/__init__.py
@@ -146,8 +146,10 @@ def resolver(
             module_base = dnf.module.module_base.ModuleBase(base)
 
             # Enable and disable modules as requested
-            module_base.disable(module_disable)
-            module_base.enable(module_enable)
+            if module_disable:
+                module_base.disable(module_disable)
+            if module_enable:
+                module_base.enable(module_enable)
 
             # Mark packages to remove
             for pkg in reinstall_packages:


### PR DESCRIPTION
This is a workaround to another problem. That problem is:

Given the following conditions:

* We're trying to resolve a multiarch lockfile on RHEL 8, and
* The repos provided do not use `$basearch`, but instead explicitly refer to each arch.
* There is an `eclipse` module on RHEL 8 that is only available on x86_64.

Then, the tool fails. When we try to make these enable/disable calls, it complains saying that the eclipse module is not available (presumably for one of the non-x86_64 architectures).

This change is likely masking another error lower in the stack; only a workaround.