### PR TITLE
Try to detect releasever from the base image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- The `$releasever` variable is now defined if it can be discovered from the
+  base image.
+
 ## [0.13.1] - 2024-12-05
 
 ### Fixed

--- a/rpm_lockfile/__init__.py
+++ b/rpm_lockfile/__init__.py
@@ -132,6 +132,15 @@ def resolver(
             conf.persistdir = mkdir(os.path.join(cache_dir, "dnf"))
             conf.substitutions["arch"] = arch
             conf.substitutions["basearch"] = dnf.rpm.basearch(arch)
+            try:
+                releasever = dnf.rpm.detect_releasever(root_dir)
+                if releasever:
+                    logging.debug("Setting releasever to %s", releasever)
+                    conf.substitutions["releasever"] = releasever
+                else:
+                    logging.warning("Failed to detect $releasever")
+            except dnf.exceptions.Error as exc:
+                logging.warning("Failed to detect $releasever: %s", exc)
             # Configure repos
             for repo in repos:
                 base.repos.add_new_repo(


### PR DESCRIPTION
This seems to work with ubi8, ubi9 and ubi9-minimal, but not ubi9-micro.