### PR TITLE
Do not run skopeo inspect/copy on scratch image

### DIFF
--- a/rpm_lockfile/containers.py
+++ b/rpm_lockfile/containers.py
@@ -47,6 +47,14 @@ def setup_rpmdb(dest_dir, baseimage, arch):
     """
     image, _, digest = utils.split_image(baseimage)
 
+    if image.lower() == "scratch":
+        # Nothing to do for scratch image. It doesn't have any RPMs.
+        logging.warning(
+            "Image with rpmdb was expected, but got `scratch` instead. "
+            "Did you want to enable context.bare or use a different base image?"
+        )
+        return
+
     if not digest:
         # We don't have a digest yet, so find the correct one from the
         # registry.

--- a/tests/test_containers.py
+++ b/tests/test_containers.py
@@ -291,3 +291,9 @@ def test_caching_on_full_disk(tmp_path, rpmdb, baseimage, caplog, disk_is_full):
     assert (tmp_path / "dest1" / rpmdb / "foo").read_text().strip() == expected_content
 
     assert list((cache_dir / "rpmdbs" / "x86_64").iterdir()) == []
+
+
+@pytest.mark.parametrize("arch", ["aarch64", "ppc64le", "s390x", "x86_64"])
+def test_extracting_scratch_image_is_no_op(tmp_path, arch):
+    containers.setup_rpmdb(tmp_path, "scratch", arch)
+    assert list(tmp_path.iterdir()) == []


### PR DESCRIPTION
There are no RPMs in there anyway, so the code should behave same as if `--bare` was specified. However, this may indicate a user error, so let's print a warning.