### PR TITLE
Allow configuring weak dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- Added new configuration key to enable or disable installation of weak
+  dependencies.
+
+
 ## [0.13.2] - 2025-01-15
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -222,6 +222,11 @@ context:
 # Tell DNF it may erase already installed packages when resolving the
 # transaction. Defaults to false.
 allowerasing: true
+
+# Enable or disable installation of weak dependencies (Recommends,
+# Supplements). The default is to use whatever is configured for the system
+# DNF.
+installWeakDeps: false
 ```
 
 The configuration file can specify a containerfile to extract a base image from

--- a/rpm_lockfile/__init__.py
+++ b/rpm_lockfile/__init__.py
@@ -117,6 +117,7 @@ def resolver(
     module_enable: set[str],
     module_disable: set[str],
     no_sources: bool,
+    install_weak_deps: bool,
 ):
     packages = set()
     sources = set()
@@ -126,6 +127,10 @@ def resolver(
         with dnf.Base() as base:
             # Configure base
             conf = base.conf
+
+            if install_weak_deps is not None:
+                conf.install_weak_deps = install_weak_deps
+
             conf.installroot = str(root_dir)
             conf.cachedir = os.path.join(cache_dir, "cache")
             conf.logdir = mkdir(os.path.join(cache_dir, "log"))
@@ -257,6 +262,7 @@ def process_arch(
     module_enable: set[str],
     module_disable: set[str],
     no_sources: bool,
+    install_weak_deps: bool,
 ):
     logging.info("Running solver for %s", arch)
 
@@ -271,6 +277,7 @@ def process_arch(
             module_enable,
             module_disable,
             no_sources,
+            install_weak_deps,
         )
 
     return {
@@ -494,6 +501,7 @@ def main():
                     filter_for_arch(arch, config.get("moduleDisable", []))
                 ),
                 no_sources=no_sources,
+                install_weak_deps=config.get("installWeakDeps"),
             )
         )
 

--- a/rpm_lockfile/schema.py
+++ b/rpm_lockfile/schema.py
@@ -127,6 +127,7 @@ def get_schema():
             },
             "allowerasing": {"type": "boolean"},
             "noSources": {"type": "boolean"},
+            "installWeakDeps": {"type": "boolean"},
         },
         "required": ["contentOrigin"],
         "additionalProperties": False,


### PR DESCRIPTION
This patch adds a new top level key to the input file that allows user to explicitly enable or disable weak dependencies rather than just relying on the system default.

Alternatively, we could expose complete DNF config, which is not much more complicated. However, there aren't that many other options that could be useful for this tool.