### PR TITLE
WIP: Move to using dnf manifest plugin

### DIFF
--- a/rpm_lockfile/content_origin/__init__.py
+++ b/rpm_lockfile/content_origin/__init__.py
@@ -24,6 +24,12 @@ class Repo:
 
         return cls(repoid=repoid, kwargs=data)
 
+    def as_dict(self):
+        data = self.kwargs | {"repoid": self.repoid}
+        if isinstance(data["baseurl"], list):
+            data["baseurl"] = data["baseurl"][0]
+        return {k: v for k, v in data.items() if v}
+
 
 def load():
     group = "rpm_lockfile.content_origins"


### PR DESCRIPTION
Rather than calling DNF API directly, we can delegate all resolving logic to a DNF plugin.

The input to the prototype is not changed in any major way. All of the possible content origins and contexts are still supported.

The output format is obviously different: there will be one manifest file per architecture, and the file format conforms to what the DNF plugin generates and expects.

Rough description of how this works:

* For each processed architecture:
  * Set up installroot (same as before).
  * Generate a config file that the plugin will understand.
  * Run the `dnf manifest new` command on it.

There is an option to handle multiple arches in one invocation of the plugin. However, we can still pass in only one installroot, so instead there is one manifest plugin call per architecture, and this causes each arch to have a separate manifest