### PR TITLE
Be lenient if packages to be reinstalled are not already installed

### DIFF
--- a/rpm_lockfile/__init__.py
+++ b/rpm_lockfile/__init__.py
@@ -168,7 +168,7 @@ def resolver(
                 try:
                     base.reinstall(pkg)
                 except dnf.exceptions.PackagesNotInstalledError:
-                    raise RuntimeError(f"Can not reinstall {pkg}: it is not installed")
+                    logging.warning("Can not reinstall %s: it is not installed", pkg)
                 except dnf.exceptions.PackageNotFoundError:
                     raise RuntimeError(
                         f"Can not reinstall {pkg}: no package matched in configured repo"


### PR DESCRIPTION
Currently, if `rpms.in.yaml` lists a package under `reinstallPackages` that isn't already installed in the base image, then it leads to:
```
  Command failed: rpm-lockfile-prototype rpms.in.yaml
  Traceback (most recent call last):
    File "/usr/local/lib/python3.9/site-packages/rpm_lockfile/__init__.py",
        line 169, in resolver
      base.reinstall(pkg)
    File "/usr/lib/python3.9/site-packages/dnf/base.py", line 2347, in
        reinstall
      raise dnf.exceptions.PackagesNotInstalledError(
  dnf.exceptions.PackagesNotInstalledError: no package matched: pigz

  During handling of the above exception, another exception occurred:

  Traceback (most recent call last):
    File "/usr/local/bin/rpm-lockfile-prototype", line 8, in <module>
      sys.exit(main())
    File "/usr/local/lib/python3.9/site-packages/rpm_lockfile/__init__.py",
        line 488, in main
      process_arch(
    File "/usr/local/lib/python3.9/site-packages/rpm_lockfile/__init__.py",
        line 270, in process_arch
      packages, sources, module_metadata = resolver(
    File "/usr/local/lib/python3.9/site-packages/rpm_lockfile/__init__.py",
        line 171, in resolver
      raise RuntimeError(f"Can not reinstall {pkg}: it is not installed")
  RuntimeError: Can not reinstall pigz: it is not installed
```

The toolbox UBI image aims to reinstall all the packages in the base UBI image to restore the documentation and translations that were stripped out by the base image, and it enforces this with tests built into the Container/Dockerfile.  A failure to restore any content will fail the image build.  This leads to a very long list of packages under `reinstallPackages` in `rpms.in.yaml`.

In such cases, it's difficult and fragile to ensure that the packages listed under `reinstallPackages` are actually included in the latest build of the base UBI image.  Minor changes in the dependencies between packages or tweaks to the contents of the base image can affect this list.  It will require a lot of human effort and cause a lot of build failures to keep this list exactly synchronized with the current state of the base UBI image.

It's more practical to only add new packages to `reinstallPackages` and never remove any.  It takes care of cases where a package got removed from the base UBI image and then got added back, and there's no need to bother with differences across the base UBI images for RHEL X.Y versions.

Therefore, it will be better to ignore such packages to match the behaviour of `dnf reinstall`.