### PR TITLE
Add support for updating packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- Added `upgradePackages` directive for the configuration file. This allows to
+  update packages in the base image.
+
 ## [0.14.0] - 2025-03-21
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -198,6 +198,9 @@ reinstallPackages: []
   # List of rpms already provided in the base image, but which should be
   # reinstalled. Same specification as `packages` above.
 
+upgradePackages: []
+  # List of rpms to update. Same specification as `packages` above.
+
 moduleEnable: []
   # List of module streams that should be enabled during the dependency
   # resolution. The specification uses the same format as `packages` above.

--- a/rpm_lockfile/schema.py
+++ b/rpm_lockfile/schema.py
@@ -76,6 +76,10 @@ def get_schema():
                 "type": "array",
                 "items": {"$ref": "#/$defs/pkg"},
             },
+            "upgradePackages": {
+                "type": "array",
+                "items": {"$ref": "#/$defs/pkg"},
+            },
             "moduleEnable": {
                 "type": "array",
                 "items": {"$ref": "#/$defs/pkg"},


### PR DESCRIPTION
A list of packages can be provided, and the equivalent of `dnf update` will be done for each of them.

At the same time, packages to reinstall that are not available are ignored if they are also meant to be updated. This way, you can list the same package in `updatePackages` and `reinstallPackages`. If a newer version is available, it will be installed. Otherwise the same version will be reinstalled.