### PR TITLE
Handle images with no rpmdb

### DIFF
--- a/rpm_lockfile/containers.py
+++ b/rpm_lockfile/containers.py
@@ -77,6 +77,11 @@ def setup_rpmdb(dest_dir, baseimage, arch):
 def _online_setup_rpmdb(dest_dir, baseimage, arch):
     arch = utils.translate_arch(arch)
 
+    # Ensure the top destination directory exists. The base image may not
+    # contain any rpmdb, in which case we would repeatedly have to download the
+    # image instead of caching the empty data.
+    dest_dir.mkdir(parents=True)
+
     with tempfile.TemporaryDirectory() as tmpdir:
         tmpdir = Path(tmpdir)
         _copy_image(baseimage, arch, tmpdir)


### PR DESCRIPTION
Originally, if the container image did not contain any rpmdb, we would not create any cache for it, which would lead to a crash. Ensuring we cache an empty directory instead fixes the crash and avoids future downloads of the same image.

Fixes: #91