### PR TITLE
Support include as a string in treefiles

### DIFF
--- a/rpm_lockfile/__init__.py
+++ b/rpm_lockfile/__init__.py
@@ -320,7 +320,11 @@ def read_packages_from_treefile(arch, treefile):
     packages = set()
     with open(treefile) as f:
         data = yaml.safe_load(f)
-        for path in data.get("include", []):
+
+        include_raw_value = data.get("include", [])
+        treefiles_to_include = [include_raw_value] if isinstance(include_raw_value, str) else include_raw_value
+
+        for path in treefiles_to_include:
             packages.update(
                 read_packages_from_treefile(
                     arch, os.path.join(os.path.dirname(treefile), path)


### PR DESCRIPTION
As seen in Fedora bootc treefile: https://gitlab.com/fedora/bootc/base-images/-/blob/abbc4d14540bf9c143395675af4d0ec14d865d68/fedora-42.yaml