### PR TITLE
Use persistent cache for DNF

### DIFF
--- a/rpm_lockfile/__init__.py
+++ b/rpm_lockfile/__init__.py
@@ -133,7 +133,7 @@ def resolver(
                 conf.install_weak_deps = install_weak_deps
 
             conf.installroot = str(root_dir)
-            conf.cachedir = os.path.join(cache_dir, "cache")
+            conf.cachedir = str(utils.CACHE_PATH / "dnf" / arch)
             conf.logdir = mkdir(os.path.join(cache_dir, "log"))
             conf.persistdir = mkdir(os.path.join(cache_dir, "dnf"))
             conf.substitutions["arch"] = arch


### PR DESCRIPTION
This allows it to reuse repodata instead of always downloading it fresh. When running on a different input with the same name repository using a different URL, DNF notices this and re-downloads the repodata.