### PR TITLE
Download filelists when installing an absolute path

### DIFF
--- a/rpm_lockfile/__init__.py
+++ b/rpm_lockfile/__init__.py
@@ -196,6 +196,10 @@ def resolver(
             try:
                 base.install_specs(solvables)
             except dnf.exceptions.MarkingErrors as exc:
+                if any(spec.startswith("/") for spec in exc.no_match_pkg_specs):
+                    # User specified a package by absolute path, and we did not
+                    # download filelists. Let's try again.
+                    raise MissingFilelists()
                 logging.error(exc.value)
                 raise RuntimeError(f"DNF error: {exc}")
             # And resolve the transaction


### PR DESCRIPTION
If a user specifies an absolute path outside of locations covered by primary repodata, we need to retry and download filelists.