### PR TITLE
Containerfile: include git

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,7 +1,7 @@
 ARG BASE_IMAGE=registry.fedoraproject.org/fedora:latest
 
 FROM ${BASE_IMAGE}
-RUN dnf install -y python3 python3-pip python3-dnf skopeo rpm
+RUN dnf install -y python3 python3-pip python3-dnf skopeo rpm git-core
 WORKDIR /app
 ARG GIT_REF=heads/main
 RUN python3 -m pip install https://github.com/konflux-ci/rpm-lockfile-prototype/archive/refs/${GIT_REF}.tar.gz


### PR DESCRIPTION
Include `git` in the image to avoid an `FileNotFoundError` error error when
the `rpms.in.yaml` has a `repofiles` entry pointing on `git` repository (`giturl`).
