### PR TITLE
Update build targets in .packit.yaml to include aarch64

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -8,7 +8,8 @@ jobs:
       job: copr_build
       trigger: pull_request
       targets:
-        - fedora-all
+        - fedora-all-x86_64
+        - fedora-all-aarch64
 
   - <<: *pr_build
     trigger: commit


### PR DESCRIPTION
The builds are noarch, but the auto-generated repo files from copr [1] are per-arch which causes an installation on aarch64 to fail.

[1] https://copr.fedorainfracloud.org/coprs/packit/konflux-ci-rpm-lockfile-prototype-main/