### PR TITLE
Handle missing detected releasever gracefully

### DIFF
--- a/rpm_lockfile/__init__.py
+++ b/rpm_lockfile/__init__.py
@@ -147,6 +147,7 @@ def resolver(
             conf.persistdir = mkdir(os.path.join(cache_dir, "dnf"))
             conf.substitutions["arch"] = arch
             conf.substitutions["basearch"] = dnf.rpm.basearch(arch)
+            conf.substitutions["releasever"] = "unknown"
             try:
                 releasever = dnf.rpm.detect_releasever(root_dir)
                 if releasever:


### PR DESCRIPTION
If the release version cannot be detected successfully, the None default substitution is used, which will make libdnf.conf.ConfigParser.substitute() throw up with a datatype error because now the substitutions dict cannot be converted into a `std::map<std::string,std::string>`.

So set the default value for releasever to 'unknown' just in case anything goes wrong.
