### PR TITLE
Copy base image without signatures

### DIFF
--- a/rpm_lockfile/containers.py
+++ b/rpm_lockfile/containers.py
@@ -35,6 +35,7 @@ def _copy_image(baseimage, arch, destdir):
         "skopeo",
         f"--override-arch={arch}",
         "copy",
+        "--remove-signatures",
         f"docker://{baseimage}",
         f"dir:{destdir}",
     ]


### PR DESCRIPTION
We don't explicitly do anything with the signatures. The image is downloaded, rpmdb extracted and the downloaded data gets deleted. We don't have to download the signatures just to delete them later.