### PR TITLE
Add option to disable zchunk downloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+
+- Added new configuration key `zchunk` to enable or disable zchunk downloads.
+  Setting `zchunk: false` can improve performance when using a caching proxy by
+  avoiding thousands of small HTTP requests.
+
 ## [0.19.0] - 2026-01-19
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -230,6 +230,11 @@ allowerasing: true
 # Supplements). The default is to use whatever is configured for the system
 # DNF.
 installWeakDeps: false
+
+# Enable or disable zchunk downloads. Set to false to disable zchunk and use
+# standard downloads instead. This can improve performance when using a caching
+# proxy. The default is to use whatever is configured for the system DNF.
+zchunk: false
 ```
 
 The configuration file can specify a containerfile to extract a base image from

--- a/rpm_lockfile/__init__.py
+++ b/rpm_lockfile/__init__.py
@@ -124,6 +124,7 @@ def resolver(
     install_weak_deps: bool,
     upgrade_packages: set[str],
     download_filelists: bool = False,
+    zchunk: bool = None,
 ):
     packages = set()
     sources = set()
@@ -136,6 +137,9 @@ def resolver(
 
             if install_weak_deps is not None:
                 conf.install_weak_deps = install_weak_deps
+
+            if zchunk is not None:
+                conf.zchunk = zchunk
 
             if download_filelists:
                 conf.optional_metadata_types = ["filelists"]
@@ -297,6 +301,7 @@ def process_arch(
     no_sources: bool,
     install_weak_deps: bool,
     upgrade_packages: set[str],
+    zchunk: bool = None,
 ):
     logging.info("Running solver for %s", arch)
 
@@ -316,6 +321,7 @@ def process_arch(
                     install_weak_deps,
                     upgrade_packages,
                     download_filelists=download_filelists,
+                    zchunk=zchunk,
                 )
                 break
             except MissingFilelists:
@@ -553,6 +559,7 @@ def main():
                 upgrade_packages=set(
                     filter_for_arch(arch, config.get("upgradePackages", []))
                 ),
+                zchunk=config.get("zchunk"),
             )
         )
 

--- a/rpm_lockfile/schema.py
+++ b/rpm_lockfile/schema.py
@@ -132,6 +132,7 @@ def get_schema():
             "allowerasing": {"type": "boolean"},
             "noSources": {"type": "boolean"},
             "installWeakDeps": {"type": "boolean"},
+            "zchunk": {"type": "boolean"},
         },
         "required": ["contentOrigin"],
         "additionalProperties": False,


### PR DESCRIPTION
Adds a new 'zchunk' configuration option that can be set to false to disable zchunk downloads. This improves performance when using a caching proxy by avoiding thousands of small HTTP requests.

Fixes #118