### PR TITLE
Fix stage reference resolution in multi-stage Docker builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Added a better error message when no context is configured.
 
+- Fixed extraction of base image from multi-stage Dockerfiles where a stage
+  references another stage (e.g., `FROM build AS runtime`). The tool now
+  correctly resolves stage references to find the actual external base image.
+
 
 ## [0.20.0] - 2026-01-22
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -106,6 +106,18 @@ RUN build
 FROM registry.io/repository/base
 COPY --from=build /artifact /
 """, "registry.io/repository/base"),
+        ("""FROM registry.io/repository/base AS build
+RUN build
+FROM build AS runtime
+COPY --from=build /artifact /
+""", "registry.io/repository/base"),
+        ("""FROM registry.io/repository/base AS build
+RUN build
+FROM registry.io/repository/tester AS test
+RUN test
+FROM build AS runtime
+COPY --from=build /artifact /
+""", "registry.io/repository/base"),
     ]
 )
 def test_extract_image(file, expected):


### PR DESCRIPTION
When a FROM instruction references a previous stage (e.g., FROM build), resolve it to the actual external base image instead of treating the stage name as an external image.