### PR TITLE
Extract packages from Containerfile RUN commands when -f is used

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -31,7 +31,7 @@ jobs:
           echo 'FROM registry.fedoraproject.org/fedora:${{ matrix.fedora-version }}'
           echo 'RUN dnf install -y python3-pip python3-dnf gcc'
           echo 'WORKDIR /src'
-          echo 'RUN python3 -m pip install -e ".[containerfile]" pytest pytest-cov'
+          echo 'RUN python3 -m pip install -e "." pytest pytest-cov'
           echo 'RUN pytest -v --cov=rpm_lockfile --cov-report=xml:coverage.xml'
         } > podmanfile
         podman build -v $(pwd):/src --tag test -f ./podmanfile

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -31,7 +31,7 @@ jobs:
           echo 'FROM registry.fedoraproject.org/fedora:${{ matrix.fedora-version }}'
           echo 'RUN dnf install -y python3-pip python3-dnf gcc'
           echo 'WORKDIR /src'
-          echo 'RUN python3 -m pip install -e . pytest pytest-cov'
+          echo 'RUN python3 -m pip install -e ".[containerfile]" pytest pytest-cov'
           echo 'RUN pytest -v --cov=rpm_lockfile --cov-report=xml:coverage.xml'
         } > podmanfile
         podman build -v $(pwd):/src --tag test -f ./podmanfile

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ authors = [
 ]
 readme = "README.md"
 dependencies = [
+    "dockerfile-parse",
     "jsonschema",
     "productmd",
     "pyyaml",
@@ -16,14 +17,8 @@ classifiers = [
     "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)"
 ]
 
-[project.optional-dependencies]
-containerfile = [
-    "bashlex",
-    "dockerfile-parse",
-]
-
 [tool.setuptools]
-packages = ['rpm_lockfile', 'rpm_lockfile.content_origin']
+packages = ['rpm_lockfile', 'rpm_lockfile.content_origin', 'rpm_lockfile.vendor', 'rpm_lockfile.vendor.bashlex']
 
 [project.scripts]
 rpm-lockfile-prototype = "rpm_lockfile:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rpm-lockfile-prototype"
-version = "0.21.0"
+version = "0.22.0"
 description = ""
 authors = [
     {name = "Lubomír Sedlář", email = "lsedlar@redhat.com"},
@@ -14,6 +14,12 @@ dependencies = [
 ]
 classifiers = [
     "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)"
+]
+
+[project.optional-dependencies]
+containerfile = [
+    "bashlex",
+    "dockerfile-parse",
 ]
 
 [tool.setuptools]

--- a/python-rpm-lockfile-prototype.spec
+++ b/python-rpm-lockfile-prototype.spec
@@ -55,6 +55,10 @@ Summary: RPM lockfile generator
 %python3_sitelib/rpm_lockfile/__pycache__/*.pyc
 %python3_sitelib/rpm_lockfile/content_origin/*.py
 %python3_sitelib/rpm_lockfile/content_origin/__pycache__/*.pyc
+%python3_sitelib/rpm_lockfile/vendor/__init__.py
+%python3_sitelib/rpm_lockfile/vendor/__pycache__/__init__.*.pyc
+%python3_sitelib/rpm_lockfile/vendor/bashlex/*.py
+%python3_sitelib/rpm_lockfile/vendor/bashlex/__pycache__/*.pyc
 %python3_sitelib/rpm_lockfile_prototype-*dist-info
 
 

--- a/rpm_lockfile/__init__.py
+++ b/rpm_lockfile/__init__.py
@@ -27,6 +27,12 @@ import yaml
 
 from . import containers, content_origin, schema, utils
 
+try:
+    from .containerfile_packages import analyze_containerfile_stages, select_stage
+except ImportError:
+    analyze_containerfile_stages = None
+    select_stage = None
+
 CONTAINERFILE_HELP = """
 Load installed packages from base image specified in Containerfile and make
 them available during dependency resolution.
@@ -458,6 +464,50 @@ def logging_setup(debug=False):
     )
 
 
+def _extract_containerfile_packages(
+    containerfile: str,
+    context: dict,
+) -> tuple[set[str], dict[str, set[str]], set[str], set[str], set[str]]:
+    """
+    Extract RPM package names from Containerfile RUN commands.
+
+    Parses the Containerfile to find dnf/yum/microdnf install invocations
+    and returns the discovered packages grouped by type.
+
+    Arg(s):
+        containerfile (str): Path to the Containerfile.
+        context (dict): Configuration context with optional stage filters.
+    Return Value(s):
+        tuple: (common_packages, arch_packages, upgrade_packages,
+                builddep_packages, module_enable) — all empty on failure.
+    """
+    common_packages: set[str] = set()
+    arch_packages: dict[str, set[str]] = {}
+    upgrade_packages: set[str] = set()
+    builddep_packages: set[str] = set()
+    module_enable: set[str] = set()
+
+    cf_path = Path(containerfile)
+    source_dir = cf_path.parent
+    stages = analyze_containerfile_stages(cf_path, source_dir=source_dir)
+    selected = select_stage(stages, **_get_containerfile_filters(context))
+    if selected:
+        common_packages.update(selected.packages)
+        for arch, pkgs in selected.arch_packages.items():
+            arch_packages.setdefault(arch, set()).update(pkgs)
+        upgrade_packages.update(selected.update_targets)
+        builddep_packages.update(selected.builddep_packages)
+        module_enable.update(selected.module_specs)
+    if common_packages or arch_packages:
+        logging.info(
+            "Extracted %d common and %d arch-specific packages from Containerfile",
+            len(common_packages),
+            sum(len(v) for v in arch_packages.values()),
+        )
+
+    return common_packages, arch_packages, upgrade_packages, builddep_packages, module_enable
+
+
 def main():
     parser = argparse.ArgumentParser()
     group = parser.add_mutually_exclusive_group()
@@ -548,39 +598,21 @@ def main():
         args.containerfile
         or _get_containerfile_path(config_dir, context)
     )
-    if containerfile:
+    if containerfile and analyze_containerfile_stages is not None:
         try:
-            from .containerfile_packages import analyze_containerfile_stages, select_stage
-        except ImportError:
+            (
+                containerfile_common_packages,
+                containerfile_arch_packages,
+                containerfile_upgrade_packages,
+                containerfile_builddep_packages,
+                containerfile_module_enable,
+            ) = _extract_containerfile_packages(containerfile, context)
+        except Exception:
             logging.warning(
-                "bashlex and dockerfile-parse are required to extract packages "
-                "from Containerfile RUN commands. Install them with: "
-                "pip install bashlex dockerfile-parse"
-            )
-            analyze_containerfile_stages = None
-    if containerfile and analyze_containerfile_stages:
-        cf_path = Path(containerfile)
-        source_dir = cf_path.parent
-        stages = analyze_containerfile_stages(cf_path, source_dir=source_dir)
-        cf_filters = _get_containerfile_filters(context)
-        selected = select_stage(
-            stages,
-            stage_num=cf_filters.get("stage_num"),
-            stage_name=cf_filters.get("stage_name"),
-            image_pattern=cf_filters.get("image_pattern"),
-        )
-        if selected:
-            containerfile_common_packages.update(selected.packages)
-            for arch, pkgs in selected.arch_packages.items():
-                containerfile_arch_packages.setdefault(arch, set()).update(pkgs)
-            containerfile_upgrade_packages.update(selected.update_targets)
-            containerfile_builddep_packages.update(selected.builddep_packages)
-            containerfile_module_enable.update(selected.module_specs)
-        if containerfile_common_packages or containerfile_arch_packages:
-            logging.info(
-                "Extracted %d common and %d arch-specific packages from Containerfile",
-                len(containerfile_common_packages),
-                sum(len(v) for v in containerfile_arch_packages.values()),
+                "Failed to extract packages from Containerfile %s; "
+                "falling back to explicitly listed packages only.",
+                containerfile,
+                exc_info=True,
             )
 
     for arch in sorted(arches):

--- a/rpm_lockfile/__init__.py
+++ b/rpm_lockfile/__init__.py
@@ -8,8 +8,8 @@ import platform
 import shutil
 import sys
 import tempfile
-from pathlib import Path
 from dataclasses import asdict, dataclass
+from pathlib import Path
 
 try:
     import dnf
@@ -20,13 +20,12 @@ except ImportError:
         "Python bindings for DNF are missing.",
         "Please install python3-dnf (or equivalent) with system package manager.",
         sep="\n",
-        file=sys.stderr
+        file=sys.stderr,
     )
     sys.exit(127)
 import yaml
 
 from . import containers, content_origin, schema, utils
-
 from .containerfile_packages import analyze_containerfile_stages, select_stage
 
 CONTAINERFILE_HELP = """
@@ -170,7 +169,7 @@ def resolver(
                         repo.repoid, conf.substitutions
                     ),
                     conf,
-                    **repo.kwargs
+                    **repo.kwargs,
                 )
             base.fill_sack(load_system_repo=True)
 
@@ -360,7 +359,11 @@ def read_packages_from_treefile(arch, treefile):
         data = yaml.safe_load(f)
 
         include_raw_value = data.get("include", [])
-        treefiles_to_include = [include_raw_value] if isinstance(include_raw_value, str) else include_raw_value
+        treefiles_to_include = (
+            [include_raw_value]
+            if isinstance(include_raw_value, str)
+            else include_raw_value
+        )
 
         for path in treefiles_to_include:
             packages.update(
@@ -399,10 +402,7 @@ def _arch_matches(spec, arch):
     if isinstance(not_, str):
         not_ = [not_]
 
-    return (
-        (not only or arch in only) and
-        (not not_ or arch not in not_)
-    )
+    return (not only or arch in only) and (not not_ or arch not in not_)
 
 
 def read_packages_from_container_yaml(arch):
@@ -415,7 +415,7 @@ def read_packages_from_container_yaml(arch):
                 packages.add(package)
             else:
                 if _arch_matches(package.get("platforms", {}), arch):
-                    packages.add(package['name'])
+                    packages.add(package["name"])
 
     return packages
 
@@ -463,7 +463,7 @@ def logging_setup(debug=False):
 def _extract_containerfile_packages(
     containerfile: str,
     context: dict,
-) -> tuple[set[str], dict[str, set[str]], set[str], set[str], set[str]]:
+) -> tuple[set[str], dict[str, set[str]], set[str], set[str]]:
     """
     Extract RPM package names from Containerfile RUN commands.
 
@@ -475,12 +475,11 @@ def _extract_containerfile_packages(
         context (dict): Configuration context with optional stage filters.
     Return Value(s):
         tuple: (common_packages, arch_packages, upgrade_packages,
-                builddep_packages, module_enable) — all empty on failure.
+                module_enable) — all empty on failure.
     """
     common_packages: set[str] = set()
     arch_packages: dict[str, set[str]] = {}
     upgrade_packages: set[str] = set()
-    builddep_packages: set[str] = set()
     module_enable: set[str] = set()
 
     cf_path = Path(containerfile)
@@ -492,7 +491,6 @@ def _extract_containerfile_packages(
         for arch, pkgs in selected.arch_packages.items():
             arch_packages.setdefault(arch, set()).update(pkgs)
         upgrade_packages.update(selected.update_targets)
-        builddep_packages.update(selected.builddep_packages)
         module_enable.update(selected.module_specs)
     if common_packages or arch_packages:
         logging.info(
@@ -500,8 +498,21 @@ def _extract_containerfile_packages(
             len(common_packages),
             sum(len(v) for v in arch_packages.values()),
         )
+        if common_packages:
+            logging.debug("Containerfile packages: %s", sorted(common_packages))
+        for arch, pkgs in sorted(arch_packages.items()):
+            logging.debug("Containerfile packages [%s]: %s", arch, sorted(pkgs))
+        if upgrade_packages:
+            logging.debug("Containerfile upgrade packages: %s", sorted(upgrade_packages))
+        if module_enable:
+            logging.debug("Containerfile module enable: %s", sorted(module_enable))
 
-    return common_packages, arch_packages, upgrade_packages, builddep_packages, module_enable
+    return (
+        common_packages,
+        arch_packages,
+        upgrade_packages,
+        module_enable,
+    )
 
 
 def main():
@@ -526,9 +537,7 @@ def main():
     parser.add_argument(
         "--print-schema", action=schema.HelpAction, help=PRINT_SCHEMA_HELP
     )
-    parser.add_argument(
-        "--allowerasing", action="store_true", help=ALLOWERASING_HELP
-    )
+    parser.add_argument("--allowerasing", action="store_true", help=ALLOWERASING_HELP)
     args = parser.parse_args()
 
     logging_setup(args.debug)
@@ -554,6 +563,11 @@ def main():
 
     repos = collect_content_origins(config_dir, config["contentOrigin"])
 
+    containerfile_common_packages: set[str] = set()
+    containerfile_arch_packages: dict[str, set[str]] = {}
+    containerfile_upgrade_packages: set[str] = set()
+    containerfile_module_enable: set[str] = set()
+
     if args.local_system or context.get("localSystem"):
         rpmdb = local_rpmdb()
     elif args.bare or context.get("bare") or args.rpm_ostree_treefile:
@@ -578,38 +592,26 @@ def main():
                 "or ensure a Containerfile/Dockerfile exists in the current directory."
             )
         rpmdb = image_rpmdb(
-            image or utils.extract_image(
-                containerfile, **_get_containerfile_filters(context)
-            )
+            image
+            or utils.extract_image(containerfile, **_get_containerfile_filters(context))
         )
 
-    # Extract packages from Containerfile RUN commands when -f is used
-    containerfile_common_packages: set[str] = set()
-    containerfile_arch_packages: dict[str, set[str]] = {}
-    containerfile_upgrade_packages: set[str] = set()
-    containerfile_builddep_packages: set[str] = set()
-    containerfile_module_enable: set[str] = set()
-
-    containerfile = (
-        args.containerfile
-        or _get_containerfile_path(config_dir, context)
-    )
-    if containerfile:
-        try:
-            (
-                containerfile_common_packages,
-                containerfile_arch_packages,
-                containerfile_upgrade_packages,
-                containerfile_builddep_packages,
-                containerfile_module_enable,
-            ) = _extract_containerfile_packages(containerfile, context)
-        except Exception:
-            logging.warning(
-                "Failed to extract packages from Containerfile %s; "
-                "falling back to explicitly listed packages only.",
-                containerfile,
-                exc_info=True,
-            )
+        # Extract packages from Containerfile RUN commands
+        if containerfile:
+            try:
+                (
+                    containerfile_common_packages,
+                    containerfile_arch_packages,
+                    containerfile_upgrade_packages,
+                    containerfile_module_enable,
+                ) = _extract_containerfile_packages(containerfile, context)
+            except Exception:
+                logging.warning(
+                    "Failed to extract packages from Containerfile %s; "
+                    "falling back to explicitly listed packages only.",
+                    containerfile,
+                    exc_info=True,
+                )
 
     for arch in sorted(arches):
         packages = set()
@@ -636,9 +638,8 @@ def main():
                 reinstall_packages=set(
                     filter_for_arch(arch, config.get("reinstallPackages", []))
                 ),
-                module_enable=set(
-                    filter_for_arch(arch, config.get("moduleEnable", []))
-                ) | containerfile_module_enable,
+                module_enable=set(filter_for_arch(arch, config.get("moduleEnable", [])))
+                | containerfile_module_enable,
                 module_disable=set(
                     filter_for_arch(arch, config.get("moduleDisable", []))
                 ),
@@ -646,7 +647,8 @@ def main():
                 install_weak_deps=config.get("installWeakDeps"),
                 upgrade_packages=set(
                     filter_for_arch(arch, config.get("upgradePackages", []))
-                ) | containerfile_upgrade_packages,
+                )
+                | containerfile_upgrade_packages,
                 zchunk=config.get("zchunk"),
             )
         )

--- a/rpm_lockfile/__init__.py
+++ b/rpm_lockfile/__init__.py
@@ -550,7 +550,7 @@ def main():
     )
     if containerfile:
         try:
-            from .containerfile_packages import analyze_containerfile_stages
+            from .containerfile_packages import analyze_containerfile_stages, select_stage
         except ImportError:
             logging.warning(
                 "bashlex and dockerfile-parse are required to extract packages "
@@ -562,13 +562,20 @@ def main():
         cf_path = Path(containerfile)
         source_dir = cf_path.parent
         stages = analyze_containerfile_stages(cf_path, source_dir=source_dir)
-        for stage in stages:
-            containerfile_common_packages.update(stage.packages)
-            for arch, pkgs in stage.arch_packages.items():
+        cf_filters = _get_containerfile_filters(context)
+        selected = select_stage(
+            stages,
+            stage_num=cf_filters.get("stage_num"),
+            stage_name=cf_filters.get("stage_name"),
+            image_pattern=cf_filters.get("image_pattern"),
+        )
+        if selected:
+            containerfile_common_packages.update(selected.packages)
+            for arch, pkgs in selected.arch_packages.items():
                 containerfile_arch_packages.setdefault(arch, set()).update(pkgs)
-            containerfile_upgrade_packages.update(stage.update_targets)
-            containerfile_builddep_packages.update(stage.builddep_packages)
-            containerfile_module_enable.update(stage.module_specs)
+            containerfile_upgrade_packages.update(selected.update_targets)
+            containerfile_builddep_packages.update(selected.builddep_packages)
+            containerfile_module_enable.update(selected.module_specs)
         if containerfile_common_packages or containerfile_arch_packages:
             logging.info(
                 "Extracted %d common and %d arch-specific packages from Containerfile",

--- a/rpm_lockfile/__init__.py
+++ b/rpm_lockfile/__init__.py
@@ -27,11 +27,7 @@ import yaml
 
 from . import containers, content_origin, schema, utils
 
-try:
-    from .containerfile_packages import analyze_containerfile_stages, select_stage
-except ImportError:
-    analyze_containerfile_stages = None
-    select_stage = None
+from .containerfile_packages import analyze_containerfile_stages, select_stage
 
 CONTAINERFILE_HELP = """
 Load installed packages from base image specified in Containerfile and make
@@ -598,7 +594,7 @@ def main():
         args.containerfile
         or _get_containerfile_path(config_dir, context)
     )
-    if containerfile and analyze_containerfile_stages is not None:
+    if containerfile:
         try:
             (
                 containerfile_common_packages,

--- a/rpm_lockfile/__init__.py
+++ b/rpm_lockfile/__init__.py
@@ -537,7 +537,45 @@ def main():
             )
         )
 
-    # TODO maybe try extracting packages from Containerfile?
+    # Extract packages from Containerfile RUN commands when -f is used
+    containerfile_common_packages: set[str] = set()
+    containerfile_arch_packages: dict[str, set[str]] = {}
+    containerfile_upgrade_packages: set[str] = set()
+    containerfile_builddep_packages: set[str] = set()
+    containerfile_module_enable: set[str] = set()
+
+    containerfile = (
+        args.containerfile
+        or _get_containerfile_path(config_dir, context)
+    )
+    if containerfile:
+        try:
+            from .containerfile_packages import analyze_containerfile_stages
+        except ImportError:
+            logging.warning(
+                "bashlex and dockerfile-parse are required to extract packages "
+                "from Containerfile RUN commands. Install them with: "
+                "pip install bashlex dockerfile-parse"
+            )
+            analyze_containerfile_stages = None
+    if containerfile and analyze_containerfile_stages:
+        cf_path = Path(containerfile)
+        source_dir = cf_path.parent
+        stages = analyze_containerfile_stages(cf_path, source_dir=source_dir)
+        for stage in stages:
+            containerfile_common_packages.update(stage.packages)
+            for arch, pkgs in stage.arch_packages.items():
+                containerfile_arch_packages.setdefault(arch, set()).update(pkgs)
+            containerfile_upgrade_packages.update(stage.update_targets)
+            containerfile_builddep_packages.update(stage.builddep_packages)
+            containerfile_module_enable.update(stage.module_specs)
+        if containerfile_common_packages or containerfile_arch_packages:
+            logging.info(
+                "Extracted %d common and %d arch-specific packages from Containerfile",
+                len(containerfile_common_packages),
+                sum(len(v) for v in containerfile_arch_packages.values()),
+            )
+
     for arch in sorted(arches):
         packages = set()
         if args.rpm_ostree_treefile or context.get("rpmOstreeTreefile"):
@@ -548,6 +586,11 @@ def main():
             )
         elif args.flatpak or context.get("flatpak"):
             packages = read_packages_from_container_yaml(arch)
+
+        # Merge Containerfile-extracted packages
+        packages |= containerfile_common_packages
+        packages |= containerfile_arch_packages.get(arch, set())
+
         data["arches"].append(
             process_arch(
                 arch,
@@ -560,7 +603,7 @@ def main():
                 ),
                 module_enable=set(
                     filter_for_arch(arch, config.get("moduleEnable", []))
-                ),
+                ) | containerfile_module_enable,
                 module_disable=set(
                     filter_for_arch(arch, config.get("moduleDisable", []))
                 ),
@@ -568,7 +611,7 @@ def main():
                 install_weak_deps=config.get("installWeakDeps"),
                 upgrade_packages=set(
                     filter_for_arch(arch, config.get("upgradePackages", []))
-                ),
+                ) | containerfile_upgrade_packages,
                 zchunk=config.get("zchunk"),
             )
         )

--- a/rpm_lockfile/containerfile_packages.py
+++ b/rpm_lockfile/containerfile_packages.py
@@ -13,10 +13,7 @@ import shlex
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
 
-try:
-    from dockerfile_parse import DockerfileParser
-except ImportError:
-    DockerfileParser = None
+from dockerfile_parse import DockerfileParser
 
 from .shell_commands import (
     ARCH_SUBSHELL_KEYWORDS,
@@ -468,11 +465,6 @@ def analyze_containerfile_stages(
     Return Value(s):
         list[StagePackages]: Per-stage package analysis.
     """
-    if DockerfileParser is None:
-        raise ImportError(
-            "dockerfile-parse and bashlex are required for Containerfile parsing. "
-            "Install them with: pip install bashlex dockerfile-parse"
-        )
     dfp = DockerfileParser(str(containerfile_path))
     entries = dfp.structure
 

--- a/rpm_lockfile/containerfile_packages.py
+++ b/rpm_lockfile/containerfile_packages.py
@@ -246,7 +246,7 @@ def extract_packages_from_file_installs(
     arch_list = arches or DEFAULT_ARCHES
     redirect_re = re.compile(
         r"""
-        (?:xargs\s+\S+\s+)?        # optional xargs with flags
+        (?:xargs\s+(?:\S+\s+)*)?    # optional xargs with optional flags
         (?:dnf|yum)\s+              # package manager
         .*?\b(?:install)\b          # install subcommand
         .*?<\s*(\S+)               # stdin redirect: < /path/to/file
@@ -258,7 +258,7 @@ def extract_packages_from_file_installs(
         (?:grep|cat)\s+             # grep or cat command
         .*?(\S+)                    # file path argument (captured)
         \s*\|\s*                    # pipe
-        (?:xargs\s+\S+\s+)?        # optional xargs with flags
+        (?:xargs\s+(?:\S+\s+)*)?    # optional xargs with optional flags
         (?:dnf|yum)\s+              # package manager
         .*?\b(?:install)\b          # install subcommand
         """,

--- a/rpm_lockfile/containerfile_packages.py
+++ b/rpm_lockfile/containerfile_packages.py
@@ -172,7 +172,7 @@ def _read_packages_from_file(source_file: Path) -> list[str]:
         if not line or line.startswith("#"):
             continue
         pkg_name = line.split()[0]
-        if not pkg_name.startswith("-") and "*" not in pkg_name:
+        if not pkg_name.startswith("-"):
             packages.append(pkg_name)
     return packages
 

--- a/rpm_lockfile/containerfile_packages.py
+++ b/rpm_lockfile/containerfile_packages.py
@@ -10,7 +10,7 @@ commands.
 import logging
 import re
 import shlex
-from dataclasses import dataclass, field
+from dataclasses import asdict, dataclass, field
 from pathlib import Path
 
 try:
@@ -152,11 +152,13 @@ def build_copy_map(
         sources = non_flag_parts[:-1]
         dest = non_flag_parts[-1]
         for src in sources:
-            src_name = Path(src).name
-            dir_dest = dest.rstrip("/") + "/" + src_name
-            copy_map[dir_dest] = src
-            if not dest.endswith("/"):
-                copy_map[dest] = src
+            # Map as directory destination (COPY foo.sh /tmp/ → /tmp/foo.sh)
+            copy_map[dest.rstrip("/") + "/" + Path(src).name] = src
+        if len(sources) == 1 and not dest.endswith("/"):
+            # Also map as file rename (COPY foo.sh /opt/bar.sh → /opt/bar.sh).
+            # Without container filesystem context we can't distinguish
+            # file renames from directory copies, so we keep both mappings.
+            copy_map[dest] = sources[0]
     return copy_map
 
 
@@ -413,16 +415,14 @@ def extract_packages_from_scripts(
                     joined_lines.append(stripped)
             script_body = "\n".join(line for line in joined_lines if line.strip())
 
-            pkgs, script_arch_pkgs, updates, has_update, script_builddep, script_modules = analyze_run_commands(
-                [script_body]
-            )
-            all_packages.update(pkgs)
-            for arch, arch_pkgs in script_arch_pkgs.items():
+            result = analyze_run_commands([script_body])
+            all_packages.update(result.packages)
+            for arch, arch_pkgs in result.arch_packages.items():
                 all_arch_packages.setdefault(arch, set()).update(arch_pkgs)
-            all_updates.update(updates)
-            all_builddep.update(script_builddep)
-            all_modules.update(script_modules)
-            if has_update:
+            all_updates.update(result.update_targets)
+            all_builddep.update(result.builddep_packages)
+            all_modules.update(result.module_specs)
+            if result.has_update:
                 scripts_have_bare_update = True
 
             file_pkgs, file_arch_pkgs = extract_packages_from_file_installs(
@@ -515,18 +515,11 @@ def analyze_containerfile_stages(
                 base_image = resolve_bash_expansion(m.group("img"), stage_vars)
                 stage_name = m.group("name") or ""
 
-        common, arch_specific, update_targets, has_update, builddep, modules = analyze_run_commands(
-            run_values, env_vars=stage_vars
-        )
+        result = analyze_run_commands(run_values, env_vars=stage_vars)
         stage = StagePackages(
             base_image=base_image,
             stage_name=stage_name,
-            packages=common,
-            has_update=has_update,
-            arch_packages=arch_specific,
-            update_targets=update_targets,
-            builddep_packages=builddep,
-            module_specs=modules,
+            **asdict(result),
         )
 
         copy_map = build_copy_map(stage_entries, env_vars=stage_vars)

--- a/rpm_lockfile/containerfile_packages.py
+++ b/rpm_lockfile/containerfile_packages.py
@@ -1,0 +1,526 @@
+"""
+Containerfile-level parsing for RPM package extraction.
+
+Parses Containerfile/Dockerfile structure to collect ARG/ENV variables,
+build COPY/ADD mappings, locate and extract packages from shell scripts
+referenced in RUN commands, and analyze per-stage install and update
+commands.
+"""
+
+import logging
+import re
+import shlex
+from dataclasses import dataclass, field
+from pathlib import Path
+
+try:
+    from dockerfile_parse import DockerfileParser
+except ImportError:
+    DockerfileParser = None
+
+from .shell_commands import (
+    ARCH_SUBSHELL_KEYWORDS,
+    analyze_run_commands,
+    resolve_bash_expansion,
+)
+
+# Common Linux architectures for multi-arch resolution
+DEFAULT_ARCHES = ["x86_64", "s390x", "ppc64le", "aarch64"]
+
+
+@dataclass
+class StagePackages:
+    """
+    Analysis results for a single Containerfile stage.
+    """
+
+    packages: list[str] = field(default_factory=list)
+    has_update: bool = False
+    arch_packages: dict[str, list[str]] = field(default_factory=dict)
+    update_targets: list[str] = field(default_factory=list)
+    builddep_packages: list[str] = field(default_factory=list)
+    module_specs: list[str] = field(default_factory=list)
+
+    def merge(self, other: "StagePackages") -> "StagePackages":
+        """
+        Merge another StagePackages into this one, combining packages
+        and update targets.
+        """
+        merged_arch = dict(self.arch_packages)
+        for arch, pkgs in other.arch_packages.items():
+            existing = set(merged_arch.get(arch, []))
+            existing.update(pkgs)
+            merged_arch[arch] = sorted(existing)
+        return StagePackages(
+            packages=sorted(set(self.packages + other.packages)),
+            has_update=self.has_update or other.has_update,
+            arch_packages=merged_arch,
+            update_targets=sorted(set(self.update_targets + other.update_targets)),
+            builddep_packages=sorted(set(self.builddep_packages + other.builddep_packages)),
+            module_specs=sorted(set(self.module_specs + other.module_specs)),
+        )
+
+
+def _strip_quotes(value: str) -> str:
+    if len(value) >= 2 and value[0] in ("\"", "'") and value[-1] == value[0]:
+        return value[1:-1]
+    return value
+
+
+def collect_stage_vars(entries: list[dict], inherited_vars: dict[str, str] | None = None) -> dict[str, str]:
+    """
+    Collect ARG and ENV variable definitions from DockerfileParser
+    structure entries.
+
+    ARG values with defaults and ENV values are collected. ENV values
+    can reference previously defined variables via bash expansion.
+
+    Arg(s):
+        entries (list[dict]): DockerfileParser structure entries with
+            "instruction" and "value" keys.
+        inherited_vars (dict[str, str] | None): Variables inherited from
+            global scope (ARGs before first FROM).
+    Return Value(s):
+        dict[str, str]: Collected variable name-to-value mapping.
+    """
+    variables: dict[str, str] = dict(inherited_vars or {})
+
+    for entry in entries:
+        instruction = entry["instruction"]
+        value = entry["value"]
+
+        if instruction == "ARG":
+            arg_match = re.match(r"^(\w+)(?:=(.*))?$", value.strip())
+            if arg_match:
+                var_name = arg_match.group(1)
+                default_value = arg_match.group(2)
+                if default_value is not None:
+                    variables[var_name] = resolve_bash_expansion(_strip_quotes(default_value.strip()), variables)
+
+        elif instruction == "ENV":
+            env_match = re.match(r"^(\w+)(?:=|\s+)(.*)", value.strip())
+            if env_match:
+                var_name = env_match.group(1)
+                variables[var_name] = resolve_bash_expansion(_strip_quotes(env_match.group(2).strip()), variables)
+
+    return variables
+
+
+def build_copy_map(
+    stage_entries: list[dict],
+    env_vars: dict[str, str] | None = None,
+) -> dict[str, str]:
+    """
+    Build a mapping from container destination paths to source paths
+    from COPY/ADD instructions in a Containerfile stage.
+
+    Handles both file and directory destinations:
+        COPY hack/foo.sh /tmp   -> /tmp/foo.sh -> hack/foo.sh
+        COPY hack/foo.sh /opt/renamed.sh -> /opt/renamed.sh -> hack/foo.sh
+
+    Skips COPY --from=... (inter-stage copies) since those don't come
+    from the source tree.
+
+    Arg(s):
+        stage_entries (list[dict]): DockerfileParser structure entries.
+        env_vars (dict[str, str] | None): Variables for resolving
+            COPY paths that contain ARG/ENV references.
+    Return Value(s):
+        dict[str, str]: Container path to source-relative path mapping.
+    """
+    variables = dict(env_vars or {})
+    copy_map: dict[str, str] = {}
+    for entry in stage_entries:
+        if entry["instruction"] not in ("COPY", "ADD"):
+            continue
+        value = entry["value"]
+        if "--from=" in value:
+            continue
+        if variables:
+            value = resolve_bash_expansion(value, variables)
+        try:
+            parts = shlex.split(value)
+        except ValueError:
+            continue
+        non_flag_parts = [p for p in parts if not p.startswith("--")]
+        if len(non_flag_parts) < 2:
+            continue
+        sources = non_flag_parts[:-1]
+        dest = non_flag_parts[-1]
+        for src in sources:
+            src_name = Path(src).name
+            dir_dest = dest.rstrip("/") + "/" + src_name
+            copy_map[dir_dest] = src
+            if not dest.endswith("/"):
+                copy_map[dest] = src
+    return copy_map
+
+
+def _read_packages_from_file(source_file: Path) -> list[str]:
+    """
+    Read package names from a file (one per line, comments skipped).
+    Allows file paths (e.g. /usr/sbin/udevadm) since DNF can resolve
+    them via provides.
+    """
+    packages: list[str] = []
+    for line in source_file.read_text().splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        pkg_name = line.split()[0]
+        if not pkg_name.startswith("-") and "*" not in pkg_name:
+            packages.append(pkg_name)
+    return packages
+
+
+def _resolve_file_from_copy_map(
+    resolved_path: str,
+    copy_map: dict[str, str],
+    source_dir: Path,
+) -> Path | None:
+    """
+    Look up a container path in copy_map and return the source file.
+    Falls back to looking for the basename directly in source_dir
+    when copy_map uses globs (e.g. COPY ${PKGS_LIST}* /tmp/).
+    """
+    source_file = None
+    if resolved_path in copy_map:
+        source_file = source_dir / copy_map[resolved_path]
+    else:
+        basename = Path(resolved_path).name
+        for container_path, src_path in copy_map.items():
+            if container_path.endswith("/" + basename):
+                source_file = source_dir / src_path
+                break
+        if not source_file:
+            candidate = source_dir / basename
+            if candidate.exists():
+                source_file = candidate
+    if not source_file:
+        return None
+    try:
+        source_file = source_file.resolve()
+        if not source_file.is_relative_to(source_dir.resolve()):
+            return None
+    except (OSError, ValueError):
+        return None
+    return source_file if source_file.exists() else None
+
+
+def extract_packages_from_file_installs(
+    run_values: list[str],
+    copy_map: dict[str, str],
+    source_dir: Path,
+    env_vars: dict[str, str] | None = None,
+    arches: list[str] | None = None,
+) -> tuple[list[str], dict[str, list[str]]]:
+    """
+    Extract package names from install commands that read packages from
+    a file via stdin redirect or pipe.
+
+    Supported patterns:
+        xargs dnf install < /tmp/pkgs.txt
+        grep -vE '^(#|$)' /tmp/pkgs.txt | xargs dnf install -y
+        cat /tmp/pkgs.txt | xargs dnf install -y
+
+    When the file path contains an arch keyword like $(arch), resolves
+    it per-architecture and returns arch-specific packages separately.
+
+    Arg(s):
+        run_values (list[str]): RUN command bodies or joined script lines.
+        copy_map (dict[str, str]): Container path to source path mapping.
+        source_dir (Path): Source tree root.
+        env_vars (dict[str, str] | None): Variables for path resolution.
+        arches (list[str] | None): Architectures to resolve for arch-specific
+            file paths. Defaults to DEFAULT_ARCHES.
+    Return Value(s):
+        tuple[list[str], dict[str, list[str]]]:
+            - Sorted unique package names (common to all arches).
+            - Dict mapping arch to sorted unique package names for that arch only.
+    """
+    logger = logging.getLogger(__name__)
+    variables = dict(env_vars or {})
+    arch_list = arches or DEFAULT_ARCHES
+    redirect_re = re.compile(
+        r"""
+        (?:xargs\s+\S+\s+)?        # optional xargs with flags
+        (?:dnf|yum)\s+              # package manager
+        .*?\b(?:install)\b          # install subcommand
+        .*?<\s*(\S+)               # stdin redirect: < /path/to/file
+        """,
+        re.VERBOSE,
+    )
+    pipe_re = re.compile(
+        r"""
+        (?:grep|cat)\s+             # grep or cat command
+        .*?(\S+)                    # file path argument (captured)
+        \s*\|\s*                    # pipe
+        (?:xargs\s+\S+\s+)?        # optional xargs with flags
+        (?:dnf|yum)\s+              # package manager
+        .*?\b(?:install)\b          # install subcommand
+        """,
+        re.VERBOSE,
+    )
+    packages: set[str] = set()
+    arch_packages: dict[str, set[str]] = {}
+
+    for run_body in run_values:
+        for cmd in re.split(r"&&|;", run_body):
+            cmd_clean = re.sub(r"^(if\s+!\s*|if\s+|then|else|elif|do)\s*", "", cmd.strip())
+            match = redirect_re.search(cmd_clean)
+            if not match:
+                match = pipe_re.search(cmd_clean)
+            if not match:
+                continue
+            raw_path = match.group(1)
+            resolved_path = resolve_bash_expansion(raw_path, variables)
+            if not resolved_path:
+                continue
+
+            has_arch_keyword = any(kw in resolved_path for kw in ARCH_SUBSHELL_KEYWORDS)
+            if not has_arch_keyword and "$" in resolved_path:
+                continue
+
+            if has_arch_keyword:
+                for arch in arch_list:
+                    arch_path = resolved_path
+                    for kw in ARCH_SUBSHELL_KEYWORDS:
+                        arch_path = arch_path.replace(kw, arch)
+                    source_file = _resolve_file_from_copy_map(arch_path, copy_map, source_dir)
+                    if not source_file:
+                        continue
+                    logger.info(f"Extracting arch-specific packages from {source_file} for {arch}")
+                    try:
+                        arch_packages.setdefault(arch, set()).update(_read_packages_from_file(source_file))
+                    except OSError:
+                        continue
+            else:
+                source_file = _resolve_file_from_copy_map(resolved_path, copy_map, source_dir)
+                if not source_file:
+                    logger.debug(f"File install path {resolved_path} not resolved from COPY map")
+                    continue
+                logger.info(f"Extracting packages from file install: {source_file}")
+                try:
+                    packages.update(_read_packages_from_file(source_file))
+                except OSError:
+                    continue
+
+    arch_result = {arch: sorted(pkgs) for arch, pkgs in sorted(arch_packages.items())}
+    return sorted(packages), arch_result
+
+
+def extract_packages_from_scripts(
+    run_values: list[str],
+    source_dir: Path | None = None,
+    copy_map: dict[str, str] | None = None,
+    env_vars: dict[str, str] | None = None,
+) -> StagePackages:
+    """
+    Find shell scripts invoked in RUN commands and extract yum/dnf
+    install/update packages from them.
+
+    Detects patterns like:
+        RUN /src/install-deps.sh
+        RUN ./scripts/setup.sh
+        RUN . /cachi2/cachi2.env && /src/install-deps.sh
+        RUN /bin/bash /tmp/dockerfile_install_support.sh
+        RUN bash /opt/scripts/setup.sh
+
+    Uses copy_map to trace container paths back to source files when
+    the script was COPY'd into the image (e.g. COPY hack/foo.sh /tmp).
+
+    Arg(s):
+        run_values (list[str]): RUN command bodies.
+        source_dir (Path | None): Source tree root to locate script files.
+        copy_map (dict[str, str] | None): Container path to source path
+            mapping from COPY/ADD instructions.
+        env_vars (dict[str, str] | None): Variables for path resolution.
+    Return Value(s):
+        StagePackages: Extracted packages, update targets, arch-specific
+            packages, and update flag from scripts.
+    """
+    if not source_dir:
+        return StagePackages()
+
+    logger = logging.getLogger(__name__)
+    script_pattern = re.compile(
+        r"(?:^|&&\s*|;\s*)"
+        r"(?:(?:(?:/usr)?/bin/)?(?:ba)?sh\s+)?"
+        r"(/\S+\.sh|\.\/\S+\.sh|(?<!\S)[\w.-]+\.sh)"
+    )
+    copy_map = copy_map or {}
+    all_packages: set[str] = set()
+    all_updates: set[str] = set()
+    all_arch_packages: dict[str, set[str]] = {}
+    all_builddep: set[str] = set()
+    all_modules: set[str] = set()
+    scripts_have_bare_update: bool = False
+
+    for run_body in run_values:
+        for match in script_pattern.finditer(run_body):
+            script_path = match.group(1)
+            if script_path.startswith("./"):
+                candidate = source_dir / script_path[2:]
+            elif script_path.startswith("/src/"):
+                candidate = source_dir / script_path[5:]
+            elif script_path in copy_map:
+                candidate = source_dir / copy_map[script_path]
+            elif "/" not in script_path:
+                found = None
+                for container_path, src_path in copy_map.items():
+                    if Path(container_path).name == script_path:
+                        found = source_dir / src_path
+                        break
+                if found:
+                    candidate = found
+                else:
+                    logger.debug(f"Skipping bare script {script_path}: not found in COPY map")
+                    continue
+            else:
+                logger.debug(f"Skipping script {script_path}: unsupported path prefix and not in COPY map")
+                continue
+
+            try:
+                candidate = candidate.resolve()
+                if not candidate.is_relative_to(source_dir.resolve()):
+                    logger.debug(f"Skipping script {script_path}: path traversal outside source_dir")
+                    continue
+            except (OSError, ValueError):
+                continue
+
+            if not candidate.exists():
+                logger.warning(f"Script {script_path} referenced in Containerfile but not found at {candidate}")
+                continue
+
+            logger.info(f"Extracting packages from script: {candidate}")
+
+            try:
+                script_content = candidate.read_text()
+            except OSError:
+                continue
+
+            raw_lines = [line for line in script_content.splitlines() if not line.strip().startswith("#")]
+            joined_lines: list[str] = []
+            for line in raw_lines:
+                stripped = line.rstrip()
+                if joined_lines and joined_lines[-1].endswith("\\"):
+                    joined_lines[-1] = joined_lines[-1][:-1] + " " + stripped.lstrip()
+                else:
+                    joined_lines.append(stripped)
+            script_body = "\n".join(line for line in joined_lines if line.strip())
+
+            pkgs, script_arch_pkgs, updates, has_update, script_builddep, script_modules = analyze_run_commands(
+                [script_body]
+            )
+            all_packages.update(pkgs)
+            for arch, arch_pkgs in script_arch_pkgs.items():
+                all_arch_packages.setdefault(arch, set()).update(arch_pkgs)
+            all_updates.update(updates)
+            all_builddep.update(script_builddep)
+            all_modules.update(script_modules)
+            if has_update:
+                scripts_have_bare_update = True
+
+            file_pkgs, file_arch_pkgs = extract_packages_from_file_installs(
+                [script_body], copy_map, source_dir, env_vars=env_vars
+            )
+            all_packages.update(file_pkgs)
+            for arch, arch_pkgs in file_arch_pkgs.items():
+                all_arch_packages.setdefault(arch, set()).update(arch_pkgs)
+
+    return StagePackages(
+        packages=sorted(all_packages),
+        has_update=scripts_have_bare_update,
+        arch_packages={arch: sorted(pkgs) for arch, pkgs in sorted(all_arch_packages.items())},
+        update_targets=sorted(all_updates),
+        builddep_packages=sorted(all_builddep),
+        module_specs=sorted(all_modules),
+    )
+
+
+def analyze_containerfile_stages(
+    containerfile_path: Path,
+    source_dir: Path | None = None,
+) -> list[StagePackages]:
+    """
+    Parse a Containerfile and return per-stage package analysis.
+
+    Uses DockerfileParser for instruction parsing, backslash-continuation
+    joining, and stage boundary detection. Collects ARG definitions before
+    the first FROM as global variables, then per-stage ARG/ENV definitions.
+    All variables are used to resolve package names in install commands.
+
+    Also detects shell scripts invoked in RUN commands and extracts
+    packages from them if the script file exists in source_dir.
+
+    Packages inside arch-conditional blocks (if [ $(arch) = X ]) are
+    returned separately so they can be resolved only for the matching
+    architecture.
+
+    Arg(s):
+        containerfile_path (Path): Path to the Containerfile/Dockerfile.
+        source_dir (Path | None): Source tree root to locate script files
+            referenced in RUN commands.
+    Return Value(s):
+        list[StagePackages]: Per-stage package analysis.
+    """
+    if DockerfileParser is None:
+        raise ImportError(
+            "dockerfile-parse and bashlex are required for Containerfile parsing. "
+            "Install them with: pip install bashlex dockerfile-parse"
+        )
+    dfp = DockerfileParser(str(containerfile_path))
+    entries = dfp.structure
+
+    pre_from_entries: list[dict] = []
+    stage_entry_lists: list[list[dict]] = []
+    current_stage: list[dict] = []
+    seen_from = False
+
+    for entry in entries:
+        if entry["instruction"] == "FROM":
+            if seen_from and current_stage:
+                stage_entry_lists.append(current_stage)
+            seen_from = True
+            current_stage = [entry]
+        elif seen_from:
+            current_stage.append(entry)
+        else:
+            pre_from_entries.append(entry)
+
+    if current_stage:
+        stage_entry_lists.append(current_stage)
+
+    global_args = collect_stage_vars(pre_from_entries)
+    stages: list[StagePackages] = []
+
+    for stage_entries in stage_entry_lists:
+        stage_vars = collect_stage_vars(stage_entries, inherited_vars=global_args)
+        run_values = [e["value"] for e in stage_entries if e["instruction"] == "RUN"]
+
+        common, arch_specific, update_targets, has_update, builddep, modules = analyze_run_commands(
+            run_values, env_vars=stage_vars
+        )
+        stage = StagePackages(
+            packages=common,
+            has_update=has_update,
+            arch_packages=arch_specific,
+            update_targets=update_targets,
+            builddep_packages=builddep,
+            module_specs=modules,
+        )
+
+        copy_map = build_copy_map(stage_entries, env_vars=stage_vars)
+        stage = stage.merge(
+            extract_packages_from_scripts(run_values, source_dir=source_dir, copy_map=copy_map, env_vars=stage_vars)
+        )
+
+        if source_dir:
+            file_pkgs, file_arch_pkgs = extract_packages_from_file_installs(
+                run_values, copy_map, source_dir, env_vars=stage_vars
+            )
+            stage = stage.merge(StagePackages(packages=file_pkgs, arch_packages=file_arch_pkgs))
+
+        stages.append(stage)
+
+    return stages

--- a/rpm_lockfile/containerfile_packages.py
+++ b/rpm_lockfile/containerfile_packages.py
@@ -34,6 +34,8 @@ class StagePackages:
     Analysis results for a single Containerfile stage.
     """
 
+    base_image: str = ""
+    stage_name: str = ""
     packages: list[str] = field(default_factory=list)
     has_update: bool = False
     arch_packages: dict[str, list[str]] = field(default_factory=dict)
@@ -52,6 +54,8 @@ class StagePackages:
             existing.update(pkgs)
             merged_arch[arch] = sorted(existing)
         return StagePackages(
+            base_image=self.base_image or other.base_image,
+            stage_name=self.stage_name or other.stage_name,
             packages=sorted(set(self.packages + other.packages)),
             has_update=self.has_update or other.has_update,
             arch_packages=merged_arch,
@@ -494,14 +498,29 @@ def analyze_containerfile_stages(
     global_args = collect_stage_vars(pre_from_entries)
     stages: list[StagePackages] = []
 
+    from_re = re.compile(
+        r"^(--platform=\S+\s+)?(?P<img>\S+)(\s+[Aa][Ss]\s+(?P<name>\S+))?\s*$"
+    )
+
     for stage_entries in stage_entry_lists:
         stage_vars = collect_stage_vars(stage_entries, inherited_vars=global_args)
         run_values = [e["value"] for e in stage_entries if e["instruction"] == "RUN"]
+
+        base_image = ""
+        stage_name = ""
+        from_entries = [e for e in stage_entries if e["instruction"] == "FROM"]
+        if from_entries:
+            m = from_re.match(from_entries[0]["value"])
+            if m:
+                base_image = resolve_bash_expansion(m.group("img"), stage_vars)
+                stage_name = m.group("name") or ""
 
         common, arch_specific, update_targets, has_update, builddep, modules = analyze_run_commands(
             run_values, env_vars=stage_vars
         )
         stage = StagePackages(
+            base_image=base_image,
+            stage_name=stage_name,
             packages=common,
             has_update=has_update,
             arch_packages=arch_specific,
@@ -524,3 +543,45 @@ def analyze_containerfile_stages(
         stages.append(stage)
 
     return stages
+
+
+def select_stage(
+    stages: list[StagePackages],
+    stage_num: int | None = None,
+    stage_name: str | None = None,
+    image_pattern: str | None = None,
+) -> StagePackages | None:
+    """
+    Select a single stage from analysis results, using the same matching
+    logic as extract_image(): stage number (1-indexed), stage name (AS alias),
+    image pattern (regex on base image), or default to last stage.
+
+    Arg(s):
+        stages (list[StagePackages]): Per-stage analysis results.
+        stage_num (int | None): 1-indexed stage number to select.
+        stage_name (str | None): Stage alias (FROM ... AS name) to match.
+        image_pattern (str | None): Regex to match against base image.
+    Return Value(s):
+        StagePackages | None: Matching stage, or None if no match.
+    """
+    if not stages:
+        return None
+
+    if stage_num is not None:
+        if 1 <= stage_num <= len(stages):
+            return stages[stage_num - 1]
+        return None
+
+    if stage_name is not None:
+        for stage in stages:
+            if stage.stage_name == stage_name:
+                return stage
+        return None
+
+    if image_pattern is not None:
+        for stage in stages:
+            if re.search(image_pattern, stage.base_image):
+                return stage
+        return None
+
+    return stages[-1]

--- a/rpm_lockfile/shell_commands.py
+++ b/rpm_lockfile/shell_commands.py
@@ -1,0 +1,550 @@
+"""
+Shell command parsing for RPM package extraction.
+
+Provides bashlex-based AST walking to extract package names from
+yum/dnf install and update commands in RUN bodies and shell scripts.
+Handles variable assignments, arch-conditional blocks, subshell
+expansions, and bash-to-POSIX preprocessing.
+"""
+
+import logging
+import re
+from dataclasses import dataclass, field
+
+try:
+    import bashlex
+except ImportError:
+    bashlex = None
+
+
+# Shell subshell expressions that evaluate to the current architecture
+ARCH_SUBSHELL_KEYWORDS = ("$(arch)", "$(uname -m)", "$(uname -p)")
+
+# Shell variable names that hold the current architecture
+ARCH_VAR_NAMES = ("HOSTTYPE", "ARCH")
+
+# All arch keywords: subshells + variables in both $VAR and ${VAR} forms
+ARCH_KEYWORDS = ARCH_SUBSHELL_KEYWORDS + tuple(
+    form for name in ARCH_VAR_NAMES for form in (f"${name}", f"${{{name}}}")
+)
+
+
+_ARCH_PATTERN = "|".join(re.escape(kw).replace(r"\ ", r"\s+") for kw in ARCH_KEYWORDS)
+ARCH_VALUE_RE = re.compile(
+    rf"(?:{_ARCH_PATTERN})"
+    r"[\"']?\s*==?\s*[\"']?(\w+)[\"']?"
+)
+
+
+_MAX_EXPANSION_DEPTH = 10
+
+_RE_CONDITIONAL_SET = re.compile(r"\$\{(\w+):\+([^}]*)\}")  # ${VAR:+value}
+_RE_CONDITIONAL_DEFAULT = re.compile(r"\$\{(\w+):-([^}]*)\}")  # ${VAR:-default}
+_RE_BRACED_VAR = re.compile(r"\$\{(\w+)\}")  # ${VAR}
+_RE_PLAIN_VAR = re.compile(r"\$(\w+)")  # $VAR
+
+
+@dataclass
+class _WalkContext:
+    """
+    Mutable state accumulated during bashlex AST walking.
+    """
+
+    variables: dict[str, str] = field(default_factory=dict)
+    shell_vars: dict[str, str] = field(default_factory=dict)
+    arch_shell_vars: dict[str, dict[str, str]] = field(default_factory=dict)
+    packages: set[str] = field(default_factory=set)
+    arch_packages: dict[str, set[str]] = field(default_factory=dict)
+    update_targets: set[str] = field(default_factory=set)
+    has_update: bool = False
+    builddep_packages: set[str] = field(default_factory=set)
+    module_specs: set[str] = field(default_factory=set)
+
+
+def resolve_bash_expansion(text: str, variables: dict[str, str]) -> str:
+    """
+    Resolve bash-style variable expansions in text.
+
+    Supports ${VAR:+value}, ${VAR:-default}, ${VAR}, and $VAR.
+    Unresolved variables are replaced with empty string.
+    Iterates up to _MAX_EXPANSION_DEPTH times to handle nested references.
+
+    Arg(s):
+        text (str): Text containing variable references.
+        variables (dict[str, str]): Variable name to value mapping.
+    Return Value(s):
+        str: Text with variables resolved.
+    """
+    for _ in range(_MAX_EXPANSION_DEPTH):
+        prev = text
+        text = _RE_CONDITIONAL_SET.sub(lambda m: m.group(2) if variables.get(m.group(1)) else "", text)
+        text = _RE_CONDITIONAL_DEFAULT.sub(lambda m: variables.get(m.group(1)) or m.group(2), text)
+        text = _RE_BRACED_VAR.sub(lambda m: variables.get(m.group(1), ""), text)
+        text = _RE_PLAIN_VAR.sub(lambda m: variables.get(m.group(1), ""), text)
+        if text == prev:
+            break
+    return text
+
+
+def _has_arch_test(text: str) -> bool:
+    """
+    Return True if text contains a known architecture-testing expression.
+    """
+    return any(kw in text for kw in ARCH_KEYWORDS)
+
+
+def _extract_arch_values(text: str) -> list[str]:
+    """
+    Extract architecture names from conditional expressions.
+    """
+    return ARCH_VALUE_RE.findall(text)
+
+
+def _preprocess_for_bashlex(text: str) -> str:
+    """
+    Convert bash-specific syntax to POSIX equivalents for bashlex.
+
+    bashlex doesn't support ``[[ ]]`` (bash test) or ``==`` inside
+    test brackets. Convert to ``[ ]`` and ``=`` respectively.
+    """
+    text = text.replace("[[", "[").replace("]]", "]")
+    text = re.sub(r"(\[\s+\S+\s+)==(\s+\S+\s+\])", r"\1=\2", text)
+    return text
+
+
+def _is_valid_package_token(token: str) -> bool:
+    """
+    Return True if token looks like a package name or file path provide.
+    """
+    if not token or token.startswith("-") or token.endswith("-"):
+        return False
+    if "$" in token or "*" in token:
+        return False
+    if token in (">=", "<=", "==", ">", "<", "!="):
+        return False
+    return True
+
+
+def _is_valid_builddep_token(token: str) -> bool:
+    """
+    Return True if token looks like a builddep argument (package name or glob).
+    Allows glob wildcards (*) unlike _is_valid_package_token.
+    """
+    if not token or token.startswith("-") or token.endswith("-"):
+        return False
+    if "$" in token:
+        return False
+    if token in (">=", "<=", "==", ">", "<", "!="):
+        return False
+    return True
+
+
+def _extract_condition_arch(node) -> list[str]:
+    """
+    Extract architecture names from an if/elif condition node.
+
+    Looks for patterns like ``[ $(arch) = x86_64 ]`` or
+    ``[ $ARCH = aarch64 ]`` in the condition's command parts.
+    Handles ``||`` conditions by collecting arches from all branches.
+    """
+    if not hasattr(node, "parts"):
+        return []
+    arches: list[str] = []
+    for part in node.parts:
+        if hasattr(part, "parts"):
+            words = [p.word for p in part.parts if hasattr(p, "word")]
+            text = " ".join(words)
+            if _has_arch_test(text):
+                arches.extend(_extract_arch_values(text))
+    return arches
+
+
+def _walk_nodes(
+    nodes: list,
+    ctx: _WalkContext,
+    arch_context: list[str] | None = None,
+    in_conditional: bool = False,
+):
+    """
+    Recursively walk bashlex AST nodes, extracting package names,
+    variable assignments, and arch-conditional context.
+    """
+    for node in nodes:
+        kind = node.kind
+
+        if kind == "list":
+            _walk_nodes(node.parts, ctx, arch_context, in_conditional)
+
+        elif kind == "compound":
+            for child in node.list:
+                if child.kind == "if":
+                    _walk_if_node(child, ctx)
+                elif child.kind == "for":
+                    body_nodes = [p for p in child.parts if hasattr(p, "kind") and p.kind in ("list", "command")]
+                    _walk_nodes(body_nodes, ctx, arch_context, in_conditional)
+                elif child.kind == "function":
+                    body_nodes = [p for p in child.parts if hasattr(p, "kind") and p.kind == "compound"]
+                    for body in body_nodes:
+                        _walk_nodes([body], ctx, arch_context, in_conditional)
+                else:
+                    _walk_nodes([child], ctx, arch_context, in_conditional)
+
+        elif kind == "command":
+            _process_command_node(node, ctx, arch_context, in_conditional)
+
+        elif kind == "pipeline":
+            cmd_nodes = [p for p in node.parts if hasattr(p, "kind") and p.kind == "command"]
+            for cmd_node in cmd_nodes:
+                _process_command_node(cmd_node, ctx, arch_context, in_conditional)
+
+        elif kind == "if":
+            _walk_if_node(node, ctx)
+
+        elif kind == "function":
+            body_nodes = [p for p in node.parts if hasattr(p, "kind") and p.kind == "compound"]
+            for body in body_nodes:
+                _walk_nodes([body], ctx, arch_context, in_conditional)
+
+
+def _walk_if_node(node, ctx: _WalkContext):
+    """
+    Walk an IfNode, detecting arch conditionals in if/elif branches.
+    Also walks condition nodes for commands (e.g. ``if ! yum install``).
+    """
+    parts = list(node.parts)
+    i = 0
+    while i < len(parts):
+        part = parts[i]
+        if not hasattr(part, "word"):
+            i += 1
+            continue
+        word = part.word
+
+        if word in ("if", "elif"):
+            condition = parts[i + 1] if i + 1 < len(parts) else None
+            body = None
+            for j in range(i + 2, len(parts)):
+                if hasattr(parts[j], "word") and parts[j].word in ("then",):
+                    if j + 1 < len(parts):
+                        body = parts[j + 1]
+                    break
+
+            arch_ctx = None
+            if condition:
+                arch_ctx = _extract_condition_arch(condition) or None
+                _walk_nodes([condition], ctx, arch_ctx, in_conditional=not bool(arch_ctx))
+
+            if body:
+                _walk_nodes([body], ctx, arch_ctx, in_conditional=not bool(arch_ctx))
+
+        elif word == "else":
+            if i + 1 < len(parts) and hasattr(parts[i + 1], "kind"):
+                _walk_nodes([parts[i + 1]], ctx, None, in_conditional=True)
+
+        i += 1
+
+
+def _process_assignments(
+    assignments: list,
+    ctx: _WalkContext,
+    arch_context: list[str] | None,
+    in_conditional: bool,
+):
+    """
+    Process shell variable assignments from a CommandNode.
+    """
+    for assign in assignments:
+        raw = assign.word
+        eq_idx = raw.index("=")
+        var_name = raw[:eq_idx]
+        var_value = raw[eq_idx + 1:]
+
+        has_cmdsub = any(
+            hasattr(p, "kind") and p.kind == "commandsubstitution"
+            for p in (assign.parts if hasattr(assign, "parts") and assign.parts else [])
+        )
+
+        if has_cmdsub:
+            extracted = _extract_subshell_packages(var_value)
+            if extracted:
+                ctx.shell_vars[var_name] = extracted
+        elif arch_context:
+            per_arch = ctx.arch_shell_vars.setdefault(var_name, {})
+            for arch in arch_context:
+                if arch in per_arch:
+                    per_arch[arch] = f"{per_arch[arch]} {var_value}"
+                else:
+                    per_arch[arch] = var_value
+        else:
+            all_vars = {**ctx.variables, **ctx.shell_vars}
+            resolved = resolve_bash_expansion(var_value, all_vars)
+            if var_name in ctx.shell_vars and in_conditional:
+                ctx.shell_vars[var_name] = f"{ctx.shell_vars[var_name]} {resolved}"
+            else:
+                ctx.shell_vars[var_name] = resolved
+
+
+def _detect_pkg_action(word_values: list[str], ctx: _WalkContext) -> tuple[str | None, int]:
+    """
+    Detect install/update/upgrade action in a dnf/yum command.
+
+    Return Value(s):
+        tuple[str | None, int]: (action, action_index) or (None, -1).
+    """
+    first_word = word_values[0].lower() if word_values else ""
+    if first_word not in ("dnf", "yum", "microdnf"):
+        return None, -1
+
+    for idx, w in enumerate(word_values[1:], 1):
+        wl = w.lower()
+        if wl == "install":
+            return "install", idx
+        if wl in ("update", "upgrade"):
+            ctx.has_update = True
+            return "update", idx
+        if wl == "builddep":
+            return "builddep", idx
+        if wl == "module":
+            for sub_idx, sub_w in enumerate(word_values[idx + 1:], idx + 1):
+                sub_wl = sub_w.lower()
+                if sub_wl in ("install", "enable"):
+                    return "module", sub_idx
+                if not sub_wl.startswith("-"):
+                    break
+            return None, -1
+
+    return None, -1
+
+
+def _resolve_arch_specific_tokens(
+    pkg_words: list[str],
+    raw_args: str,
+    all_vars: dict[str, str],
+    ctx: _WalkContext,
+) -> set[str]:
+    """
+    Resolve arch-specific variable expansions and add per-arch packages.
+
+    Return Value(s):
+        set[str]: Tokens already classified as arch-specific (to exclude
+            from the common package list).
+    """
+    arch_resolved: set[str] = set()
+    if not ctx.arch_shell_vars:
+        return arch_resolved
+
+    used_arch_vars: dict[str, dict[str, str]] = {}
+    for var_name, per_arch in ctx.arch_shell_vars.items():
+        if f"${var_name}" in raw_args or f"${{{var_name}}}" in raw_args:
+            used_arch_vars[var_name] = per_arch
+
+    if not used_arch_vars:
+        return arch_resolved
+
+    no_arch_vars = dict.fromkeys(used_arch_vars, "")
+    common_resolved_tokens = set()
+    for pw in pkg_words:
+        r = resolve_bash_expansion(pw, {**all_vars, **no_arch_vars})
+        common_resolved_tokens.update(r.split())
+
+    all_arches: set[str] = set()
+    for per_arch in used_arch_vars.values():
+        all_arches.update(per_arch.keys())
+    for arch in all_arches:
+        arch_var_vals = {vn: pa.get(arch, "") for vn, pa in used_arch_vars.items()}
+        for pw in pkg_words:
+            r = resolve_bash_expansion(pw, {**all_vars, **arch_var_vals})
+            for token in r.split():
+                if _is_valid_package_token(token) and token not in common_resolved_tokens:
+                    ctx.arch_packages.setdefault(arch, set()).add(token)
+                    arch_resolved.add(token)
+
+    return arch_resolved
+
+
+def _classify_package_tokens(
+    resolved_tokens: list[str],
+    arch_resolved_tokens: set[str],
+    action: str,
+    ctx: _WalkContext,
+    arch_context: list[str] | None,
+):
+    """
+    Classify resolved tokens into packages, update targets, or
+    arch-specific packages.
+    """
+    skip_next = False
+    for token in resolved_tokens:
+        if skip_next:
+            skip_next = False
+            continue
+        if token in (">=", "<=", "==", ">", "<", "!="):
+            skip_next = True
+            continue
+        token = re.split(r"\s+(?:>=|<=|==|!=|>|<)\s+", token)[0].strip()
+
+        if action == "builddep":
+            if _is_valid_builddep_token(token):
+                ctx.builddep_packages.add(token)
+            continue
+
+        if action == "module":
+            if _is_valid_builddep_token(token) and ":" in token:
+                ctx.module_specs.add(token)
+            continue
+
+        if not _is_valid_package_token(token):
+            continue
+        if token in arch_resolved_tokens:
+            continue
+
+        if action == "update":
+            ctx.update_targets.add(token)
+        elif arch_context:
+            for arch in arch_context:
+                ctx.arch_packages.setdefault(arch, set()).add(token)
+        else:
+            ctx.packages.add(token)
+
+
+def _process_command_node(
+    node,
+    ctx: _WalkContext,
+    arch_context: list[str] | None = None,
+    in_conditional: bool = False,
+):
+    """
+    Process a single CommandNode — handle assignments and dnf/yum commands.
+    """
+    assignments = []
+    words = []
+
+    for part in node.parts:
+        if part.kind == "assignment":
+            assignments.append(part)
+        elif part.kind == "word":
+            words.append(part)
+
+    _process_assignments(assignments, ctx, arch_context, in_conditional)
+
+    if not words:
+        return
+
+    word_values = [w.word for w in words]
+    action, action_idx = _detect_pkg_action(word_values, ctx)
+    if not action:
+        return
+
+    pkg_words = word_values[action_idx + 1:]
+    all_vars = {**ctx.variables, **ctx.shell_vars}
+    combined_arch_vals = {k: " ".join(per_arch.values()) for k, per_arch in ctx.arch_shell_vars.items()}
+    all_vars_with_arch = {
+        **all_vars,
+        **{k: resolve_bash_expansion(v, all_vars) for k, v in combined_arch_vals.items()},
+    }
+
+    resolved_tokens: list[str] = []
+    raw_args = " ".join(pkg_words)
+    for pw in pkg_words:
+        resolved = resolve_bash_expansion(pw, all_vars_with_arch)
+        for sub in resolved.split():
+            resolved_tokens.append(sub)
+
+    arch_resolved_tokens = set[str]()
+    if not arch_context:
+        arch_resolved_tokens = _resolve_arch_specific_tokens(pkg_words, raw_args, all_vars, ctx)
+
+    _classify_package_tokens(resolved_tokens, arch_resolved_tokens, action, ctx, arch_context)
+
+
+def _extract_subshell_packages(subshell_body: str) -> str:
+    """
+    Extract package names from echo commands inside a $(...) subshell.
+
+    Handles patterns like:
+        $(if [ "$(uname -m)" != "s390x" ]; then echo -n mstflint; fi)
+    """
+    packages: list[str] = []
+    for match in re.finditer(r"\becho\s+(?:-\w+\s+)*([\w\s-]+)", subshell_body):
+        tokens = match.group(1).strip().split()
+        for token in tokens:
+            if token and not token.startswith("-") and re.match(r"^[\w][\w.\-]*$", token):
+                packages.append(token)
+    return " ".join(packages)
+
+
+def _parse_and_walk(
+    run_values: list[str],
+    env_vars: dict[str, str] | None = None,
+) -> tuple[set[str], dict[str, set[str]], set[str], bool, set[str], set[str]]:
+    """
+    Single pass: preprocess, parse with bashlex, and walk all RUN bodies.
+
+    Arg(s):
+        run_values (list[str]): RUN command bodies.
+        env_vars (dict[str, str] | None): Variables from ARG/ENV directives.
+    Return Value(s):
+        tuple[set[str], dict[str, set[str]], set[str], bool, set[str], set[str]]:
+            - Install packages (common to all arches).
+            - Arch-specific install packages.
+            - Update target packages.
+            - Whether any update command was found.
+            - Builddep package patterns.
+            - Module specs (e.g., nodejs:18, nodejs:18/development).
+    """
+    if bashlex is None:
+        raise ImportError(
+            "bashlex is required for shell command parsing. "
+            "Install it with: pip install bashlex"
+        )
+    logger = logging.getLogger(__name__)
+    ctx = _WalkContext(variables=dict(env_vars or {}))
+
+    for run_body in run_values:
+        preprocessed = _preprocess_for_bashlex(run_body)
+        try:
+            ast_nodes = bashlex.parse(preprocessed)
+        except (bashlex.errors.ParsingError, NotImplementedError, ValueError) as exc:
+            logger.warning(f"bashlex failed to parse RUN body, skipping: {exc}")
+            continue
+
+        ctx.shell_vars = {}
+        ctx.arch_shell_vars = {}
+        _walk_nodes(ast_nodes, ctx)
+
+    return ctx.packages, ctx.arch_packages, ctx.update_targets, ctx.has_update, ctx.builddep_packages, ctx.module_specs
+
+
+def analyze_run_commands(
+    run_values: list[str],
+    env_vars: dict[str, str] | None = None,
+) -> tuple[list[str], dict[str, list[str]], list[str], bool, list[str], list[str]]:
+    """
+    Single-pass analysis of RUN command bodies. Returns all install
+    packages, arch-specific packages, update targets, update flag,
+    builddep package patterns, and module specs.
+
+    Arg(s):
+        run_values (list[str]): RUN command bodies.
+        env_vars (dict[str, str] | None): Variables from ARG/ENV directives.
+    Return Value(s):
+        tuple[list[str], dict[str, list[str]], list[str], bool, list[str], list[str]]:
+            - Sorted common package names.
+            - Dict mapping arch to sorted package names.
+            - Sorted update target package names.
+            - Whether any update command was found.
+            - Sorted builddep package patterns.
+            - Sorted module specs.
+    """
+    packages, arch_packages, update_targets, found_update, builddep_packages, module_specs = _parse_and_walk(
+        run_values, env_vars
+    )
+    arch_result = {arch: sorted(pkgs) for arch, pkgs in sorted(arch_packages.items())}
+    return (
+        sorted(packages),
+        arch_result,
+        sorted(update_targets),
+        found_update,
+        sorted(builddep_packages),
+        sorted(module_specs),
+    )

--- a/rpm_lockfile/shell_commands.py
+++ b/rpm_lockfile/shell_commands.py
@@ -45,6 +45,20 @@ _RE_PLAIN_VAR = re.compile(r"\$(\w+)")  # $VAR
 
 
 @dataclass
+class RunCommandResult:
+    """
+    Aggregated result from analyzing RUN command bodies.
+    """
+
+    packages: list[str] = field(default_factory=list)
+    arch_packages: dict[str, list[str]] = field(default_factory=dict)
+    update_targets: list[str] = field(default_factory=list)
+    has_update: bool = False
+    builddep_packages: list[str] = field(default_factory=list)
+    module_specs: list[str] = field(default_factory=list)
+
+
+@dataclass
 class _WalkContext:
     """
     Mutable state accumulated during bashlex AST walking.
@@ -125,19 +139,6 @@ def _is_valid_package_token(token: str) -> bool:
         return False
     return True
 
-
-def _is_valid_builddep_token(token: str) -> bool:
-    """
-    Return True if token looks like a builddep argument (package name or glob).
-    Allows glob wildcards (*) unlike _is_valid_package_token.
-    """
-    if not token or token.startswith("-") or token.endswith("-"):
-        return False
-    if "$" in token:
-        return False
-    if token in (">=", "<=", "==", ">", "<", "!="):
-        return False
-    return True
 
 
 def _extract_condition_arch(node) -> list[str]:
@@ -385,12 +386,12 @@ def _classify_package_tokens(
         token = re.split(r"\s+(?:>=|<=|==|!=|>|<)\s+", token)[0].strip()
 
         if action == "builddep":
-            if _is_valid_builddep_token(token):
+            if _is_valid_package_token(token):
                 ctx.builddep_packages.add(token)
             continue
 
         if action == "module":
-            if _is_valid_builddep_token(token) and ":" in token:
+            if _is_valid_package_token(token) and ":" in token:
                 ctx.module_specs.add(token)
             continue
 
@@ -451,7 +452,7 @@ def _process_command_node(
         for sub in resolved.split():
             resolved_tokens.append(sub)
 
-    arch_resolved_tokens = set[str]()
+    arch_resolved_tokens: set[str] = set()
     if not arch_context:
         arch_resolved_tokens = _resolve_arch_specific_tokens(pkg_words, raw_args, all_vars, ctx)
 
@@ -477,7 +478,7 @@ def _extract_subshell_packages(subshell_body: str) -> str:
 def _parse_and_walk(
     run_values: list[str],
     env_vars: dict[str, str] | None = None,
-) -> tuple[set[str], dict[str, set[str]], set[str], bool, set[str], set[str]]:
+) -> _WalkContext:
     """
     Single pass: preprocess, parse with bashlex, and walk all RUN bodies.
 
@@ -485,13 +486,7 @@ def _parse_and_walk(
         run_values (list[str]): RUN command bodies.
         env_vars (dict[str, str] | None): Variables from ARG/ENV directives.
     Return Value(s):
-        tuple[set[str], dict[str, set[str]], set[str], bool, set[str], set[str]]:
-            - Install packages (common to all arches).
-            - Arch-specific install packages.
-            - Update target packages.
-            - Whether any update command was found.
-            - Builddep package patterns.
-            - Module specs (e.g., nodejs:18, nodejs:18/development).
+        _WalkContext: Walk context with accumulated packages and state.
     """
     if bashlex is None:
         raise ImportError(
@@ -513,39 +508,29 @@ def _parse_and_walk(
         ctx.arch_shell_vars = {}
         _walk_nodes(ast_nodes, ctx)
 
-    return ctx.packages, ctx.arch_packages, ctx.update_targets, ctx.has_update, ctx.builddep_packages, ctx.module_specs
+    return ctx
 
 
 def analyze_run_commands(
     run_values: list[str],
     env_vars: dict[str, str] | None = None,
-) -> tuple[list[str], dict[str, list[str]], list[str], bool, list[str], list[str]]:
+) -> RunCommandResult:
     """
-    Single-pass analysis of RUN command bodies. Returns all install
-    packages, arch-specific packages, update targets, update flag,
-    builddep package patterns, and module specs.
+    Single-pass analysis of RUN command bodies.
 
     Arg(s):
         run_values (list[str]): RUN command bodies.
         env_vars (dict[str, str] | None): Variables from ARG/ENV directives.
     Return Value(s):
-        tuple[list[str], dict[str, list[str]], list[str], bool, list[str], list[str]]:
-            - Sorted common package names.
-            - Dict mapping arch to sorted package names.
-            - Sorted update target package names.
-            - Whether any update command was found.
-            - Sorted builddep package patterns.
-            - Sorted module specs.
+        RunCommandResult: Sorted packages, arch-specific packages,
+            update targets, builddep patterns, and module specs.
     """
-    packages, arch_packages, update_targets, found_update, builddep_packages, module_specs = _parse_and_walk(
-        run_values, env_vars
-    )
-    arch_result = {arch: sorted(pkgs) for arch, pkgs in sorted(arch_packages.items())}
-    return (
-        sorted(packages),
-        arch_result,
-        sorted(update_targets),
-        found_update,
-        sorted(builddep_packages),
-        sorted(module_specs),
+    ctx = _parse_and_walk(run_values, env_vars)
+    return RunCommandResult(
+        packages=sorted(ctx.packages),
+        arch_packages={arch: sorted(pkgs) for arch, pkgs in sorted(ctx.arch_packages.items())},
+        update_targets=sorted(ctx.update_targets),
+        has_update=ctx.has_update,
+        builddep_packages=sorted(ctx.builddep_packages),
+        module_specs=sorted(ctx.module_specs),
     )

--- a/rpm_lockfile/shell_commands.py
+++ b/rpm_lockfile/shell_commands.py
@@ -114,11 +114,12 @@ def _preprocess_for_bashlex(text: str) -> str:
 
 def _is_valid_package_token(token: str) -> bool:
     """
-    Return True if token looks like a package name or file path provide.
+    Return True if token looks like a package name, file path provide,
+    or glob pattern (e.g. golang-*1.23*).
     """
     if not token or token.startswith("-") or token.endswith("-"):
         return False
-    if "$" in token or "*" in token:
+    if "$" in token:
         return False
     if token in (">=", "<=", "==", ">", "<", "!="):
         return False

--- a/rpm_lockfile/shell_commands.py
+++ b/rpm_lockfile/shell_commands.py
@@ -11,10 +11,7 @@ import logging
 import re
 from dataclasses import dataclass, field
 
-try:
-    import bashlex
-except ImportError:
-    bashlex = None
+from rpm_lockfile.vendor import bashlex
 
 
 # Shell subshell expressions that evaluate to the current architecture
@@ -488,11 +485,6 @@ def _parse_and_walk(
     Return Value(s):
         _WalkContext: Walk context with accumulated packages and state.
     """
-    if bashlex is None:
-        raise ImportError(
-            "bashlex is required for shell command parsing. "
-            "Install it with: pip install bashlex"
-        )
     logger = logging.getLogger(__name__)
     ctx = _WalkContext(variables=dict(env_vars or {}))
 

--- a/rpm_lockfile/vendor/bashlex/LICENSE
+++ b/rpm_lockfile/vendor/bashlex/LICENSE
@@ -1,0 +1,674 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU General Public License is a free, copyleft license for
+software and other kinds of works.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+the GNU General Public License is intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.  We, the Free Software Foundation, use the
+GNU General Public License for most of our software; it applies also to
+any other work released this way by its authors.  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  To protect your rights, we need to prevent others from denying you
+these rights or asking you to surrender the rights.  Therefore, you have
+certain responsibilities if you distribute copies of the software, or if
+you modify it: responsibilities to respect the freedom of others.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must pass on to the recipients the same
+freedoms that you received.  You must make sure that they, too, receive
+or can get the source code.  And you must show them these terms so they
+know their rights.
+
+  Developers that use the GNU GPL protect your rights with two steps:
+(1) assert copyright on the software, and (2) offer you this License
+giving you legal permission to copy, distribute and/or modify it.
+
+  For the developers' and authors' protection, the GPL clearly explains
+that there is no warranty for this free software.  For both users' and
+authors' sake, the GPL requires that modified versions be marked as
+changed, so that their problems will not be attributed erroneously to
+authors of previous versions.
+
+  Some devices are designed to deny users access to install or run
+modified versions of the software inside them, although the manufacturer
+can do so.  This is fundamentally incompatible with the aim of
+protecting users' freedom to change the software.  The systematic
+pattern of such abuse occurs in the area of products for individuals to
+use, which is precisely where it is most unacceptable.  Therefore, we
+have designed this version of the GPL to prohibit the practice for those
+products.  If such problems arise substantially in other domains, we
+stand ready to extend this provision to those domains in future versions
+of the GPL, as needed to protect the freedom of users.
+
+  Finally, every program is threatened constantly by software patents.
+States should not allow patents to restrict development and use of
+software on general-purpose computers, but in those that do, we wish to
+avoid the special danger that patents applied to a free program could
+make it effectively proprietary.  To prevent this, the GPL assures that
+patents cannot be used to render the program non-free.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Use with the GNU Affero General Public License.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU Affero General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the special requirements of the GNU Affero General Public License,
+section 13, concerning interaction through a network will apply to the
+combination as such.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If the program does terminal interaction, make it output a short
+notice like this when it starts in an interactive mode:
+
+    <program>  Copyright (C) <year>  <name of author>
+    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, your program's commands
+might be different; for a GUI interface, you would use an "about box".
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU GPL, see
+<http://www.gnu.org/licenses/>.
+
+  The GNU General Public License does not permit incorporating your program
+into proprietary programs.  If your program is a subroutine library, you
+may consider it more useful to permit linking proprietary applications with
+the library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.  But first, please read
+<http://www.gnu.org/philosophy/why-not-lgpl.html>.

--- a/rpm_lockfile/vendor/bashlex/__init__.py
+++ b/rpm_lockfile/vendor/bashlex/__init__.py
@@ -1,0 +1,5 @@
+from bashlex import parser, tokenizer
+
+parse = parser.parse
+parsesingle = parser.parsesingle
+split = parser.split

--- a/rpm_lockfile/vendor/bashlex/__init__.py
+++ b/rpm_lockfile/vendor/bashlex/__init__.py
@@ -1,4 +1,4 @@
-from bashlex import parser, tokenizer
+from . import parser, tokenizer
 
 parse = parser.parse
 parsesingle = parser.parsesingle

--- a/rpm_lockfile/vendor/bashlex/ast.py
+++ b/rpm_lockfile/vendor/bashlex/ast.py
@@ -1,0 +1,210 @@
+class node(object):
+    """
+    This class represents a node in the AST built while parsing command lines.
+    It's basically an object container for various attributes, with a slightly
+    specialised representation to make it a little easier to debug the parser.
+    """
+
+    def __init__(self, **kwargs):
+        assert 'kind' in kwargs
+        self.__dict__.update(kwargs)
+
+    def dump(self, indent='  '):
+        return _dump(self, indent)
+
+    def __repr__(self):
+        chunks = []
+        d = dict(self.__dict__)
+        kind = d.pop('kind')
+        for k, v in sorted(d.items()):
+            chunks.append('%s=%r' % (k, v))
+        return '%sNode(%s)' % (kind.title(), ' '.join(chunks))
+
+    def __eq__(self, other):
+        if not isinstance(other, node):
+            return False
+        return self.__dict__ == other.__dict__
+    
+    def __hash__(self):
+        return hash(tuple(sorted(self.__dict__)))
+
+class nodevisitor(object):
+    def _visitnode(self, n, *args, **kwargs):
+        k = n.kind
+        self.visitnode(n)
+        return getattr(self, 'visit%s' % k)(n, *args, **kwargs)
+
+    def visit(self, n):
+        k = n.kind
+        if k == 'operator':
+            self._visitnode(n, n.op)
+        elif k == 'list':
+            dochild = self._visitnode(n, n.parts)
+            if dochild is None or dochild:
+                for child in n.parts:
+                    self.visit(child)
+        elif k == 'reservedword':
+            self._visitnode(n, n.word)
+        elif k == 'pipe':
+            self._visitnode(n, n.pipe)
+        elif k == 'pipeline':
+            dochild = self._visitnode(n, n.parts)
+            if dochild is None or dochild:
+                for child in n.parts:
+                    self.visit(child)
+        elif k == 'compound':
+            dochild = self._visitnode(n, n.list, n.redirects)
+            if dochild is None or dochild:
+                for child in n.list:
+                    self.visit(child)
+                for child in n.redirects:
+                    self.visit(child)
+        elif k in ('if', 'for', 'while', 'until'):
+            dochild = self._visitnode(n, n.parts)
+            if dochild is None or dochild:
+                for child in n.parts:
+                    self.visit(child)
+        elif k == 'command':
+            dochild = self._visitnode(n, n.parts)
+            if dochild is None or dochild:
+                for child in n.parts:
+                    self.visit(child)
+        elif k == 'function':
+            dochild = self._visitnode(n, n.name, n.body, n.parts)
+            if dochild is None or dochild:
+                for child in n.parts:
+                    self.visit(child)
+        elif k == 'redirect':
+            dochild = self._visitnode(n, n.input, n.type, n.output, n.heredoc)
+            if dochild is None or dochild:
+                if isinstance(n.output, node):
+                    self.visit(n.output)
+                if n.heredoc:
+                    self.visit(n.heredoc)
+        elif k in ('word', 'assignment'):
+            dochild = self._visitnode(n, n.word)
+            if dochild is None or dochild:
+                for child in n.parts:
+                    self.visit(child)
+        elif k in ('parameter', 'tilde', 'heredoc'):
+            self._visitnode(n, n.value)
+        elif k in ('commandsubstitution', 'processsubstitution'):
+            dochild = self._visitnode(n, n.command)
+            if dochild is None or dochild:
+                self.visit(n.command)
+        else:
+            raise ValueError('unknown node kind %r' % k)
+        self.visitnodeend(n)
+
+    def visitnode(self, n):
+        pass
+    def visitnodeend(self, n):
+        pass
+    def visitoperator(self, n, op):
+        pass
+    def visitlist(self, n, parts):
+        pass
+    def visitpipe(self, n, pipe):
+        pass
+    def visitpipeline(self, n, parts):
+        pass
+    def visitcompound(self, n, list, redirects):
+        pass
+    def visitif(self, node, parts):
+        pass
+    def visitfor(self, node, parts):
+        pass
+    def visitwhile(self, node, parts):
+        pass
+    def visituntil(self, node, parts):
+        pass
+    def visitcommand(self, n, parts):
+        pass
+    def visitfunction(self, n, name, body, parts):
+        pass
+    def visitword(self, n, word):
+        pass
+    def visitassignment(self, n, word):
+        pass
+    def visitreservedword(self, n, word):
+        pass
+    def visitparameter(self, n, value):
+        pass
+    def visittilde(self, n, value):
+        pass
+    def visitredirect(self, n, input, type, output, heredoc):
+        pass
+    def visitheredoc(self, n, value):
+        pass
+    def visitprocesssubstitution(self, n, command):
+        pass
+    def visitcommandsubstitution(self, n, command):
+        pass
+
+def _dump(tree, indent='  '):
+    def _format(n, level=0):
+        if isinstance(n, node):
+            d = dict(n.__dict__)
+            kind = d.pop('kind')
+            if kind == 'list' and level > 0:
+                level = level + 1
+            fields = []
+            v = d.pop('s', None)
+            if v:
+                fields.append(('s', _format(v, level)))
+            for k, v in sorted(d.items()):
+                if not v or k == 'parts':
+                    continue
+                llevel = level
+                if isinstance(v, node):
+                    llevel += 1
+                    fields.append((k, '\n' + (indent * llevel) + _format(v, llevel)))
+                else:
+                    fields.append((k, _format(v, level)))
+            if kind == 'function':
+                fields = [f for f in fields if f[0] not in ('name', 'body')]
+            v = d.pop('parts', None)
+            if v:
+                fields.append(('parts', _format(v, level)))
+            return ''.join([
+                '%sNode' % kind.title(),
+                '(',
+                ', '.join(('%s=%s' % field for field in fields)),
+                ')'])
+        elif isinstance(n, list):
+            lines = ['[']
+            lines.extend((indent * (level + 1) + _format(x, level + 1) + ','
+                         for x in n))
+            if len(lines) > 1:
+                lines.append(indent * (level) + ']')
+            else:
+                lines[-1] += ']'
+            return '\n'.join(lines)
+        return repr(n)
+
+    if not isinstance(tree, node):
+        raise TypeError('expected node, got %r' % tree.__class__.__name__)
+    return _format(tree)
+
+def findfirstkind(parts, kind):
+    for i, node in enumerate(parts):
+        if node.kind == kind:
+            return i
+    return -1
+
+class posconverter(nodevisitor):
+    def __init__(self, string):
+        self.string = string
+
+    def visitnode(self, node):
+        assert hasattr(node, 'pos'), 'node %r is missing pos attr' % node
+        start, end = node.__dict__.pop('pos')
+        node.s = self.string[start:end]
+
+class posshifter(nodevisitor):
+    def __init__(self, count):
+        self.count = count
+
+    def visitnode(self, node):
+        #assert node.pos[1] + base <= endlimit
+        node.pos = (node.pos[0] + self.count, node.pos[1] + self.count)

--- a/rpm_lockfile/vendor/bashlex/errors.py
+++ b/rpm_lockfile/vendor/bashlex/errors.py
@@ -1,0 +1,8 @@
+class ParsingError(Exception):
+    def __init__(self, message, s, position):
+        self.message = message
+        self.s = s
+        self.position = position
+
+        assert position <= len(s)
+        super(ParsingError, self).__init__('%s (position %d)' % (message, position))

--- a/rpm_lockfile/vendor/bashlex/flags.py
+++ b/rpm_lockfile/vendor/bashlex/flags.py
@@ -1,0 +1,55 @@
+import enum
+
+parser = enum.Enum('parserflags', [
+    'CASEPAT', # in a case pattern list
+    'ALEXPNEXT', # expand next word for aliases
+    'ALLOWOPNBRC', # allow open brace for function def
+    'NEEDCLOSBRC', # need close brace
+    'DBLPAREN', # double-paren parsing
+    'SUBSHELL', # ( ... ) subshell
+    'CMDSUBST', # $( ... ) command substitution
+    'CASESTMT', # parsing a case statement
+    'CONDCMD', # parsing a [[...]] command
+    'CONDEXPR', # parsing the guts of [[...]]
+    'ARITHFOR', # parsing an arithmetic for command - unused
+    'ALEXPAND', # OK to expand aliases - unused
+    'EXTPAT', # parsing an extended shell pattern
+    'COMPASSIGN', # parsing x=(...) compound assignment
+    'ASSIGNOK', # assignment statement ok in this context
+    'EOFTOKEN', # yylex checks against shell_eof_token
+    'REGEXP', # parsing an ERE/BRE as a single word
+    'HEREDOC', # reading body of here-document
+    'REPARSE', # re-parsing in parse_string_to_word_list
+    'REDIRLIST', # parsing a list of redirections preceding a simple command name
+    ])
+
+word = enum.Enum('wordflags', [
+    'HASDOLLAR', # Dollar sign present
+    'QUOTED', # Some form of quote character is present
+    'ASSIGNMENT', # This word is a variable assignment
+    'SPLITSPACE', # Split this word on " " regardless of IFS
+    'NOSPLIT', # Do not perform word splitting on this word because ifs is empty string
+    'NOGLOB', # Do not perform globbing on this word
+    'NOSPLIT2', # Don't split word except for $@ expansion (using spaces) because context does not allow it
+    'TILDEEXP', # Tilde expand this assignment word
+    'DOLLARAT', # $@ and its special handling
+    'DOLLARSTAR', # $* and its special handling
+    'NOCOMSUB', # Don't perform command substitution on this word
+    'ASSIGNRHS', # Word is rhs of an assignment statement
+    'NOTILDE', # Don't perform tilde expansion on this word
+    'ITILDE', # Internal flag for word expansion
+    'NOEXPAND', # Don't expand at all -- do quote removal
+    'COMPASSIGN', # Compound assignment
+    'ASSNBLTIN', # word is a builtin command that takes assignments
+    'ASSIGNARG', # word is assignment argument to command
+    'HASQUOTEDNULL', # word contains a quoted null character
+    'DQUOTE', # word should be treated as if double-quoted
+    'NOPROCSUB', # don't perform process substitution
+    'HASCTLESC', # word contains literal CTLESC characters
+    'ASSIGNASSOC', # word looks like associative array assignment
+    'ASSIGNARRAY', # word looks like a compound indexed array assignment
+    'ARRAYIND', # word is an array index being expanded
+    'ASSNGLOBAL', # word is a global assignment to declare (declare/typeset -g)
+    'NOBRACE', # Don't perform brace expansion
+    'ASSIGNINT', # word is an integer assignment to declare
+    ])

--- a/rpm_lockfile/vendor/bashlex/heredoc.py
+++ b/rpm_lockfile/vendor/bashlex/heredoc.py
@@ -1,0 +1,54 @@
+from bashlex import ast, errors
+
+def gatherheredocuments(tokenizer):
+    # if we're at the end of the input and we're not strict, allow skipping
+    # reading the heredoc
+    while tokenizer.redirstack:
+        if tokenizer._peekc() is None and not tokenizer._strictmode:
+            tokenizer._shell_input_line_index += 1
+            return
+
+        redirnode, killleading = tokenizer.redirstack.pop(0)
+        makeheredoc(tokenizer, redirnode, 0, killleading)
+
+def makeheredoc(tokenizer, redirnode, lineno, killleading):
+    # redirword = string_quote_removal(redirectnode.word)
+    redirword = redirnode.output.word
+    document = []
+
+    startpos = tokenizer._shell_input_line_index
+
+    #fullline = self.tok.readline(bool(redirword.output.flags & flags.word.QUOTED))
+    fullline = tokenizer.readline(False)
+    while fullline:
+        if killleading:
+            while fullline[0] == '\t':
+                fullline = fullline[1:]
+
+        if not fullline:
+            continue
+
+        if fullline[:-1] == redirword and fullline[len(redirword)] == '\n':
+            document.append(fullline[:-1])
+            # document_done
+            break
+
+        document.append(fullline)
+        #fullline = self.readline(bool(redirnode.flags & flags.word.QUOTED))
+        fullline = tokenizer.readline(False)
+
+    if not fullline:
+        raise errors.ParsingError("here-document at line %d delimited by end-of-file (wanted %r)" % (lineno, redirword), tokenizer._shell_input_line, tokenizer._shell_input_line_index)
+
+    document = ''.join(document)
+    endpos = tokenizer._shell_input_line_index - 1
+
+    assert hasattr(redirnode, 'heredoc')
+    redirnode.heredoc = ast.node(kind='heredoc', value=document,
+                                 pos=(startpos, endpos))
+
+    # if the heredoc immediately follows this node, fix its end pos
+    if redirnode.pos[1] + 1 == startpos:
+        redirnode.pos = (redirnode.pos[0], endpos)
+
+    return document

--- a/rpm_lockfile/vendor/bashlex/heredoc.py
+++ b/rpm_lockfile/vendor/bashlex/heredoc.py
@@ -1,4 +1,4 @@
-from bashlex import ast, errors
+from . import ast, errors
 
 def gatherheredocuments(tokenizer):
     # if we're at the end of the input and we're not strict, allow skipping

--- a/rpm_lockfile/vendor/bashlex/parser.py
+++ b/rpm_lockfile/vendor/bashlex/parser.py
@@ -1,0 +1,703 @@
+import os, copy
+
+from bashlex import yacc, tokenizer, state, ast, subst, flags, errors, heredoc
+
+def _partsspan(parts):
+    return parts[0].pos[0], parts[-1].pos[1]
+
+tokens = [e.name for e in tokenizer.tokentype]
+precedence = (
+    ('left', 'AMPERSAND', 'SEMICOLON', 'NEWLINE', 'EOF'),
+    ('left', 'AND_AND', 'OR_OR'),
+    ('right', 'BAR', 'BAR_AND')
+)
+
+def handleNotImplemented(p, type):
+    if len(p) == 2:
+        raise NotImplementedError('type = {%s}, token = {%s}' % (type, p[1]))
+    else:
+        raise NotImplementedError('type = {%s}, token = {%s}, parts = {%s}' % (type, p[1], p[2]))
+
+def handleAssert(p, test):
+    if not test:
+        raise AssertionError('token = {%s}' % p[1])
+
+def p_inputunit(p):
+    '''inputunit : simple_list simple_list_terminator
+                 | NEWLINE
+                 | error NEWLINE
+                 | EOF'''
+    # XXX
+    if p.lexer._parserstate & flags.parser.CMDSUBST:
+        p.lexer._parserstate.add(flags.parser.EOFTOKEN)
+
+    if isinstance(p[1], ast.node):
+        p[0] = p[1]
+        # accept right here in case the input contains more lines that are
+        # not part of the current command
+        p.accept()
+
+def p_word_list(p):
+    '''word_list : WORD
+                 | word_list WORD'''
+    parserobj = p.context
+    if len(p) == 2:
+        p[0] = [_expandword(parserobj, p.slice[1])]
+    else:
+        p[0] = p[1]
+        p[0].append(_expandword(parserobj, p.slice[2]))
+
+def p_redirection_heredoc(p):
+    '''redirection : LESS_LESS WORD
+                   | NUMBER LESS_LESS WORD
+                   | REDIR_WORD LESS_LESS WORD
+                   | LESS_LESS_MINUS WORD
+                   | NUMBER LESS_LESS_MINUS WORD
+                   | REDIR_WORD LESS_LESS_MINUS WORD'''
+    parserobj = p.context
+    assert isinstance(parserobj, _parser)
+
+    output = ast.node(kind='word', word=p[len(p)-1], parts=[],
+                      pos=p.lexspan(len(p)-1))
+    if len(p) == 3:
+        p[0] = ast.node(kind='redirect', input=None, type=p[1], heredoc=None,
+                        output=output, pos=(p.lexpos(1), p.endlexpos(2)))
+    else:
+        p[0] = ast.node(kind='redirect', input=p[1], type=p[2], heredoc=None,
+                        output=output, pos=(p.lexpos(1), p.endlexpos(3)))
+
+    if p.slice[len(p)-2].ttype == tokenizer.tokentype.LESS_LESS:
+        parserobj.redirstack.append((p[0], False))
+    else:
+        parserobj.redirstack.append((p[0], True))
+
+def p_redirection(p):
+    '''redirection : GREATER WORD
+                   | LESS WORD
+                   | NUMBER GREATER WORD
+                   | NUMBER LESS WORD
+                   | REDIR_WORD GREATER WORD
+                   | REDIR_WORD LESS WORD
+                   | GREATER_GREATER WORD
+                   | NUMBER GREATER_GREATER WORD
+                   | REDIR_WORD GREATER_GREATER WORD
+                   | GREATER_BAR WORD
+                   | NUMBER GREATER_BAR WORD
+                   | REDIR_WORD GREATER_BAR WORD
+                   | LESS_GREATER WORD
+                   | NUMBER LESS_GREATER WORD
+                   | REDIR_WORD LESS_GREATER WORD
+                   | LESS_LESS_LESS WORD
+                   | NUMBER LESS_LESS_LESS WORD
+                   | REDIR_WORD LESS_LESS_LESS WORD
+                   | LESS_AND NUMBER
+                   | NUMBER LESS_AND NUMBER
+                   | REDIR_WORD LESS_AND NUMBER
+                   | GREATER_AND NUMBER
+                   | NUMBER GREATER_AND NUMBER
+                   | REDIR_WORD GREATER_AND NUMBER
+                   | LESS_AND WORD
+                   | NUMBER LESS_AND WORD
+                   | REDIR_WORD LESS_AND WORD
+                   | GREATER_AND WORD
+                   | NUMBER GREATER_AND WORD
+                   | REDIR_WORD GREATER_AND WORD
+                   | GREATER_AND DASH
+                   | NUMBER GREATER_AND DASH
+                   | REDIR_WORD GREATER_AND DASH
+                   | LESS_AND DASH
+                   | NUMBER LESS_AND DASH
+                   | REDIR_WORD LESS_AND DASH
+                   | AND_GREATER WORD
+                   | AND_GREATER_GREATER WORD'''
+    parserobj = p.context
+    if len(p) == 3:
+        output = p[2]
+        if p.slice[2].ttype == tokenizer.tokentype.WORD:
+            output = _expandword(parserobj, p.slice[2])
+        p[0] = ast.node(kind='redirect', input=None, type=p[1], heredoc=None,
+                        output=output, pos=(p.lexpos(1), p.endlexpos(2)))
+    else:
+        output = p[3]
+        if p.slice[3].ttype == tokenizer.tokentype.WORD:
+            output = _expandword(parserobj, p.slice[3])
+        p[0] = ast.node(kind='redirect', input=p[1], type=p[2], heredoc=None,
+                        output=output, pos=(p.lexpos(1), p.endlexpos(3)))
+
+def _expandword(parser, tokenword):
+    if parser._expansionlimit == -1:
+        # we enter this branch in the following conditions:
+        # - currently parsing a substitution as a result of an expansion
+        # - the previous expansion had limit == 0
+        #
+        # this means that this node is a descendant of a substitution in an
+        # unexpanded word and will be filtered in the limit == 0 condition below
+        #
+        # (the reason we even expand when limit == 0 is to get quote removal)
+        node = ast.node(kind='word', word=tokenword,
+                        pos=(tokenword.lexpos, tokenword.endlexpos), parts=[])
+        return node
+    else:
+        quoted = bool(tokenword.flags & flags.word.QUOTED)
+        doublequoted = quoted and tokenword.value[0] == '"'
+
+        # TODO set qheredocument
+        parts, expandedword = subst._expandwordinternal(parser,
+                                                        tokenword, 0,
+                                                        doublequoted, 0, 0)
+
+        # limit reached, don't include substitutions (still expanded to get
+        # quote removal though)
+        if parser._expansionlimit == 0:
+            parts = [node for node in parts if 'substitution' not in node.kind]
+
+        node = ast.node(kind='word', word=expandedword,
+                        pos=(tokenword.lexpos, tokenword.endlexpos), parts=parts)
+        return node
+
+def p_simple_command_element(p):
+    '''simple_command_element : WORD
+                              | ASSIGNMENT_WORD
+                              | redirection'''
+    if isinstance(p[1], ast.node):
+        p[0] = [p[1]]
+        return
+
+    parserobj = p.context
+    p[0] = [_expandword(parserobj, p.slice[1])]
+
+    # change the word node to an assignment if necessary
+    if p.slice[1].ttype == tokenizer.tokentype.ASSIGNMENT_WORD:
+        p[0][0].kind = 'assignment'
+
+def p_redirection_list(p):
+    '''redirection_list : redirection
+                        | redirection_list redirection'''
+    if len(p) == 2:
+        p[0] = [p[1]]
+    else:
+        p[0] = p[1]
+        p[0].append(p[2])
+
+def p_simple_command(p):
+    '''simple_command : simple_command_element
+                      | simple_command simple_command_element'''
+
+    p[0] = p[1]
+    if len(p) == 3:
+        p[0].extend(p[2])
+
+def p_command(p):
+    '''command : simple_command
+               | shell_command
+               | shell_command redirection_list
+               | function_def
+               | coproc'''
+    if isinstance(p[1], ast.node):
+        p[0] = p[1]
+        if len(p) == 3:
+            handleAssert(p, p[0].kind == 'compound')
+            p[0].redirects.extend(p[2])
+            handleAssert(p, p[0].pos[0] < p[0].redirects[-1].pos[1])
+            p[0].pos = (p[0].pos[0], p[0].redirects[-1].pos[1])
+    else:
+        p[0] = ast.node(kind='command', parts=p[1], pos=_partsspan(p[1]))
+
+def p_shell_command(p):
+    '''shell_command : for_command
+                     | case_command
+                     | WHILE compound_list DO compound_list DONE
+                     | UNTIL compound_list DO compound_list DONE
+                     | select_command
+                     | if_command
+                     | subshell
+                     | group_command
+                     | arith_command
+                     | cond_command
+                     | arith_for_command'''
+    if len(p) == 2:
+        p[0] = p[1]
+    else:
+        # while or until
+        handleAssert(p, p[2].kind == 'list')
+
+        parts = _makeparts(p)
+        kind = parts[0].word
+        assert kind in ('while', 'until')
+        p[0] = ast.node(kind='compound',
+                        redirects=[],
+                        list=[ast.node(kind=kind, parts=parts, pos=_partsspan(parts))],
+                        pos=_partsspan(parts))
+
+    handleAssert(p, p[0].kind == 'compound')
+
+def _makeparts(p):
+    parts = []
+    for i in range(1, len(p)):
+        if isinstance(p[i], ast.node):
+            parts.append(p[i])
+        elif isinstance(p[i], list):
+            parts.extend(p[i])
+        elif isinstance(p.slice[i], tokenizer.token):
+            if p.slice[i].ttype == tokenizer.tokentype.WORD:
+                parserobj = p.context
+                parts.append(_expandword(parserobj, p.slice[i]))
+            else:
+                parts.append(ast.node(kind='reservedword', word=p[i],
+                                      pos=p.lexspan(i)))
+        else:
+            pass
+
+    return parts
+
+def p_for_command(p):
+    '''for_command : FOR WORD newline_list DO compound_list DONE
+                   | FOR WORD newline_list LEFT_CURLY compound_list RIGHT_CURLY
+                   | FOR WORD SEMICOLON newline_list DO compound_list DONE
+                   | FOR WORD SEMICOLON newline_list LEFT_CURLY compound_list RIGHT_CURLY
+                   | FOR WORD newline_list IN word_list list_terminator newline_list DO compound_list DONE
+                   | FOR WORD newline_list IN word_list list_terminator newline_list LEFT_CURLY compound_list RIGHT_CURLY
+                   | FOR WORD newline_list IN list_terminator newline_list DO compound_list DONE
+                   | FOR WORD newline_list IN list_terminator newline_list LEFT_CURLY compound_list RIGHT_CURLY'''
+    parts = _makeparts(p)
+    # find the operatornode that we might have there due to
+    # list_terminator/newline_list and convert it to a reservedword so its
+    # considered as part of the for loop
+    for i, part in enumerate(parts):
+        if part.kind == 'operator' and part.op == ';':
+            parts[i] = ast.node(kind='reservedword', word=';', pos=part.pos)
+            break # there could be only one in there...
+
+    p[0] = ast.node(kind='compound',
+                    redirects=[],
+                    list=[ast.node(kind='for', parts=parts, pos=_partsspan(parts))],
+                    pos=_partsspan(parts))
+
+def p_arith_for_command(p):
+    '''arith_for_command : FOR ARITH_FOR_EXPRS list_terminator newline_list DO compound_list DONE
+                         | FOR ARITH_FOR_EXPRS list_terminator newline_list LEFT_CURLY compound_list RIGHT_CURLY
+                         | FOR ARITH_FOR_EXPRS DO compound_list DONE
+                         | FOR ARITH_FOR_EXPRS LEFT_CURLY compound_list RIGHT_CURLY'''
+    handleNotImplemented(p, 'arithmetic for')
+
+def p_select_command(p):
+    '''select_command : SELECT WORD newline_list DO list DONE
+                      | SELECT WORD newline_list LEFT_CURLY list RIGHT_CURLY
+                      | SELECT WORD SEMICOLON newline_list DO list DONE
+                      | SELECT WORD SEMICOLON newline_list LEFT_CURLY list RIGHT_CURLY
+                      | SELECT WORD newline_list IN word_list list_terminator newline_list DO list DONE
+                      | SELECT WORD newline_list IN word_list list_terminator newline_list LEFT_CURLY list RIGHT_CURLY'''
+    handleNotImplemented(p, 'select command')
+
+def p_case_command(p):
+    '''case_command : CASE WORD newline_list IN newline_list ESAC
+                    | CASE WORD newline_list IN case_clause_sequence newline_list ESAC
+                    | CASE WORD newline_list IN case_clause ESAC'''
+    handleNotImplemented(p, 'case command')
+
+def p_function_def(p):
+    '''function_def : WORD LEFT_PAREN RIGHT_PAREN newline_list function_body
+                    | FUNCTION WORD LEFT_PAREN RIGHT_PAREN newline_list function_body
+                    | FUNCTION WORD newline_list function_body'''
+    parts = _makeparts(p)
+    body = parts[-1]
+    name = parts[ast.findfirstkind(parts, 'word')]
+
+    p[0] = ast.node(kind='function', name=name, body=body, parts=parts,
+                    pos=_partsspan(parts))
+
+def p_function_body(p):
+    '''function_body : shell_command
+                     | shell_command redirection_list'''
+    handleAssert(p, p[1].kind == 'compound')
+
+    p[0] = p[1]
+    if len(p) == 3:
+        p[0].redirects.extend(p[2])
+        handleAssert(p, p[0].pos[0] < p[0].redirects[-1].pos[1])
+        p[0].pos = (p[0].pos[0], p[0].redirects[-1].pos[1])
+
+def p_subshell(p):
+    '''subshell : LEFT_PAREN compound_list RIGHT_PAREN'''
+    lparen = ast.node(kind='reservedword', word=p[1], pos=p.lexspan(1))
+    rparen = ast.node(kind='reservedword', word=p[3], pos=p.lexspan(3))
+    parts = [lparen, p[2], rparen]
+    p[0] = ast.node(kind='compound', list=parts, redirects=[],
+                    pos=_partsspan(parts))
+
+def p_coproc(p):
+    '''coproc : COPROC shell_command
+              | COPROC shell_command redirection_list
+              | COPROC WORD shell_command
+              | COPROC WORD shell_command redirection_list
+              | COPROC simple_command'''
+    handleNotImplemented(p, 'coproc')
+
+def p_if_command(p):
+    '''if_command : IF compound_list THEN compound_list FI
+                  | IF compound_list THEN compound_list ELSE compound_list FI
+                  | IF compound_list THEN compound_list elif_clause FI'''
+    # we currently don't distinguish the various lists that make up the
+    # command, because it's not needed later on. if there will be a need
+    # we can always add different nodes for elif/else.
+    parts = _makeparts(p)
+    p[0] = ast.node(kind='compound',
+                    redirects=[],
+                    list=[ast.node(kind='if', parts=parts, pos=_partsspan(parts))],
+                    pos=_partsspan(parts))
+
+def p_group_command(p):
+    '''group_command : LEFT_CURLY compound_list RIGHT_CURLY'''
+    lcurly = ast.node(kind='reservedword', word=p[1], pos=p.lexspan(1))
+    rcurly = ast.node(kind='reservedword', word=p[3], pos=p.lexspan(3))
+    parts = [lcurly, p[2], rcurly]
+    p[0] = ast.node(kind='compound', list=parts, redirects=[],
+                    pos=_partsspan(parts))
+
+def p_arith_command(p):
+    '''arith_command : ARITH_CMD'''
+    handleNotImplemented(p, 'arithmetic command')
+
+def p_cond_command(p):
+    '''cond_command : COND_START COND_CMD COND_END'''
+    handleNotImplemented(p, 'cond command')
+
+def p_elif_clause(p):
+    '''elif_clause : ELIF compound_list THEN compound_list
+                   | ELIF compound_list THEN compound_list ELSE compound_list
+                   | ELIF compound_list THEN compound_list elif_clause'''
+    parts = []
+    for i in range(1, len(p)):
+        if isinstance(p[i], ast.node):
+            parts.append(p[i])
+        else:
+            parts.append(ast.node(kind='reservedword', word=p[i], pos=p.lexspan(i)))
+    p[0] = parts
+
+def p_case_clause(p):
+    '''case_clause : pattern_list
+                   | case_clause_sequence pattern_list'''
+    handleNotImplemented(p, 'case clause')
+
+def p_pattern_list(p):
+    '''pattern_list : newline_list pattern RIGHT_PAREN compound_list
+                    | newline_list pattern RIGHT_PAREN newline_list
+                    | newline_list LEFT_PAREN pattern RIGHT_PAREN compound_list
+                    | newline_list LEFT_PAREN pattern RIGHT_PAREN newline_list'''
+    handleNotImplemented(p, 'pattern list')
+
+def p_case_clause_sequence(p):
+    '''case_clause_sequence : pattern_list SEMI_SEMI
+                            | case_clause_sequence pattern_list SEMI_SEMI
+                            | pattern_list SEMI_AND
+                            | case_clause_sequence pattern_list SEMI_AND
+                            | pattern_list SEMI_SEMI_AND
+                            | case_clause_sequence pattern_list SEMI_SEMI_AND'''
+    handleNotImplemented(p, 'case clause')
+
+def p_pattern(p):
+    '''pattern : WORD
+               | pattern BAR WORD'''
+    handleNotImplemented(p, 'pattern')
+
+def p_list(p):
+    '''list : newline_list list0'''
+    p[0] = p[2]
+
+def p_compound_list(p):
+    '''compound_list : list
+                     | newline_list list1'''
+    if len(p) == 2:
+        p[0] = p[1]
+    else:
+        parts = p[2]
+        if len(parts) > 1:
+            p[0] = ast.node(kind='list', parts=parts, pos=_partsspan(parts))
+        else:
+            p[0] = parts[0]
+
+def p_list0(p):
+    '''list0 : list1 NEWLINE newline_list
+             | list1 AMPERSAND newline_list
+             | list1 SEMICOLON newline_list'''
+    parts = p[1]
+    if len(parts) > 1 or p.slice[2].ttype != tokenizer.tokentype.NEWLINE:
+        parts.append(ast.node(kind='operator', op=p[2], pos=p.lexspan(2)))
+        p[0] = ast.node(kind='list', parts=parts, pos=_partsspan(parts))
+    else:
+        p[0] = parts[0]
+
+def p_list1(p):
+    '''list1 : list1 AND_AND newline_list list1
+             | list1 OR_OR newline_list list1
+             | list1 AMPERSAND newline_list list1
+             | list1 SEMICOLON newline_list list1
+             | list1 NEWLINE newline_list list1
+             | pipeline_command'''
+    if len(p) == 2:
+        p[0] = [p[1]]
+    else:
+        p[0] = p[1]
+        # XXX newline
+        p[0].append(ast.node(kind='operator', op=p[2], pos=p.lexspan(2)))
+        p[0].extend(p[len(p) - 1])
+
+def p_simple_list_terminator(p):
+    '''simple_list_terminator : NEWLINE
+                              | EOF'''
+    pass
+
+def p_list_terminator(p):
+    '''list_terminator : NEWLINE
+                       | SEMICOLON
+                       | EOF'''
+    if p[1] == ';':
+        p[0] = ast.node(kind='operator', op=';', pos=p.lexspan(1))
+
+def p_newline_list(p):
+    '''newline_list : empty
+                    | newline_list NEWLINE'''
+    pass
+
+def p_simple_list(p):
+    '''simple_list : simple_list1
+                   | simple_list1 AMPERSAND
+                   | simple_list1 SEMICOLON'''
+    tok = p.lexer
+    heredoc.gatherheredocuments(tok)
+
+    if len(p) == 3 or len(p[1]) > 1:
+        parts = p[1]
+        if len(p) == 3:
+            parts.append(ast.node(kind='operator', op=p[2], pos=p.lexspan(2)))
+        p[0] = ast.node(kind='list', parts=parts, pos=_partsspan(parts))
+    else:
+        assert len(p[1]) == 1
+        p[0] = p[1][0]
+
+    if (len(p) == 2 and p.lexer._parserstate & flags.parser.CMDSUBST and
+            p.lexer._current_token.nopos() == p.lexer._shell_eof_token):
+        # accept the input
+        p.accept()
+
+def p_simple_list1(p):
+    '''simple_list1 : simple_list1 AND_AND newline_list simple_list1
+                    | simple_list1 OR_OR newline_list simple_list1
+                    | simple_list1 AMPERSAND simple_list1
+                    | simple_list1 SEMICOLON simple_list1
+                    | pipeline_command'''
+    if len(p) == 2:
+        p[0] = [p[1]]
+    else:
+        p[0] = p[1]
+        p[0].append(ast.node(kind='operator', op=p[2], pos=p.lexspan(2)))
+        p[0].extend(p[len(p) - 1])
+
+def p_pipeline_command(p):
+    '''pipeline_command : pipeline
+                        | BANG pipeline_command
+                        | timespec pipeline_command
+                        | timespec list_terminator
+                        | BANG list_terminator'''
+    if len(p) == 2:
+        if len(p[1]) == 1:
+            p[0] = p[1][0]
+        else:
+            p[0] = ast.node(kind='pipeline', parts=p[1],
+                            pos=(p[1][0].pos[0], p[1][-1].pos[1]))
+    else:
+        # XXX timespec
+        node = ast.node(kind='reservedword', word='!', pos=p.lexspan(1))
+        if p[2].kind == 'pipeline':
+            p[0] = p[2]
+            p[0].parts.insert(0, node)
+            p[0].pos = (p[0].parts[0].pos[0], p[0].parts[-1].pos[1])
+        else:
+            p[0] = ast.node(kind='pipeline', parts=[node, p[2]],
+                            pos=(node.pos[0], p[2].pos[1]))
+
+def p_pipeline(p):
+    '''pipeline : pipeline BAR newline_list pipeline
+                | pipeline BAR_AND newline_list pipeline
+                | command'''
+    if len(p) == 2:
+        p[0] = [p[1]]
+    else:
+        p[0] = p[1]
+        p[0].append(ast.node(kind='pipe', pipe=p[2], pos=p.lexspan(2)))
+        p[0].extend(p[len(p) - 1])
+
+def p_timespec(p):
+    '''timespec : TIME
+                | TIME TIMEOPT
+                | TIME TIMEOPT TIMEIGN'''
+    handleNotImplemented(p, 'time command')
+
+def p_empty(p):
+    '''empty :'''
+    pass
+
+def p_error(p):
+    assert isinstance(p, tokenizer.token)
+
+    if p.ttype == tokenizer.tokentype.EOF:
+        raise errors.ParsingError('unexpected EOF',
+                                  p.lexer.source,
+                                  len(p.lexer.source))
+    else:
+        raise errors.ParsingError('unexpected token %r' % p.value,
+                                  p.lexer.source, p.lexpos)
+
+yaccparser = yacc.yacc(outputdir=os.path.dirname(__file__),         
+                        debug=False)
+
+# some hack to fix yacc's reduction on command substitutions:
+# which state to fix is derived from static transition tables
+# as states are changeable among python versions and architectures
+# the only state that is considered fixed is the initial state: 0
+def get_correction_states():
+    reduce = yaccparser.goto[0]['simple_list'] #~10
+    state2 = yaccparser.action[reduce]['NEWLINE'] #63
+    state1 = yaccparser.goto[reduce]['simple_list_terminator'] #~10
+    return state1, state2
+
+def get_correction_rightparen_states():
+    state1 = yaccparser.goto[0]['pipeline_command']
+    state2 = yaccparser.goto[0]['simple_list1'] #11
+    state_temp = yaccparser.action[state2]['SEMICOLON'] #65
+    state3 = yaccparser.goto[state_temp]['simple_list1']
+    return state1, state2, state3
+
+for tt in tokenizer.tokentype:
+    states = get_correction_states()
+    yaccparser.action[states[0]][tt.name] = -1
+    yaccparser.action[states[1]][tt.name] = -141
+
+states = get_correction_rightparen_states()
+yaccparser.action[states[0]]['RIGHT_PAREN'] = -155
+yaccparser.action[states[1]]['RIGHT_PAREN'] = -148
+yaccparser.action[states[2]]['RIGHT_PAREN'] = -154
+
+def parsesingle(s, strictmode=True, expansionlimit=None, convertpos=False):
+    '''like parse, but only consumes a single top level node, e.g. parsing
+    'a\nb' will only return a node for 'a', leaving b unparsed'''
+    p = _parser(s, strictmode=strictmode, expansionlimit=expansionlimit)
+    tree = p.parse()
+    if convertpos:
+        ast.posconverter(s).visit(tree)
+    return tree
+
+def parse(s, strictmode=True, expansionlimit=None, convertpos=False):
+    '''parse the input string, returning a list of nodes
+
+    top level node kinds are:
+
+    - command - a simple command
+    - pipeline - a series of simple commands
+    - list - a series of one or more pipelines
+    - compound - contains constructs for { list; }, (list), if, for..
+
+    leafs are word nodes (which in turn can also contain any of the
+    aforementioned nodes due to command substitutions).
+
+    when strictmode is set to False, we will:
+    - skip reading a heredoc if we're at the end of the input
+
+    expansionlimit is used to limit the amount of recursive parsing done due to
+    command substitutions found during word expansion.
+    '''
+    p = _parser(s, strictmode=strictmode, expansionlimit=expansionlimit)
+    parts = [p.parse()]
+
+    class endfinder(ast.nodevisitor):
+        def __init__(self):
+            self.end = -1
+        def visitheredoc(self, node, value):
+            self.end = node.pos[1]
+
+    # find the 'real' end incase we have a heredoc in there
+    ef = _endfinder()
+    ef.visit(parts[-1])
+    index = max(parts[-1].pos[1], ef.end) + 1
+    while index < len(s):
+        part = _parser(s[index:], strictmode=strictmode).parse()
+
+        if not isinstance(part, ast.node):
+            break
+
+        ast.posshifter(index).visit(part)
+        parts.append(part)
+        ef = _endfinder()
+        ef.visit(parts[-1])
+        index = max(parts[-1].pos[1], ef.end) + 1
+
+    if convertpos:
+        for tree in parts:
+            ast.posconverter(s).visit(tree)
+
+    return parts
+
+def split(s):
+    '''a utility function that mimics shlex.split but handles more
+    complex shell constructs such as command substitutions inside words
+
+    >>> list(split('a b"c"\\'d\\''))
+    ['a', 'bcd']
+    >>> list(split('a "b $(c)" $(d) \\'$(e)\\''))
+    ['a', 'b $(c)', '$(d)', '$(e)']
+    >>> list(split('a b\\n'))
+    ['a', 'b', '\\n']
+    '''
+    p = _parser(s)
+    for t in p.tok:
+        if t.ttype == tokenizer.tokentype.WORD:
+            quoted = bool(t.flags & flags.word.QUOTED)
+            doublequoted = quoted and t.value[0] == '"'
+            parts, expandedword = subst._expandwordinternal(p, t, 0,
+                                                            doublequoted, 0, 0)
+            yield expandedword
+        else:
+            yield s[t.lexpos:t.endlexpos]
+
+class _parser(object):
+    '''
+    this class is mainly used to provide context to the productions
+    when we're in the middle of parsing. as a hack, we shove it into the
+    YaccProduction context attribute to make it accessible.
+    '''
+    def __init__(self, s, strictmode=True, expansionlimit=None, tokenizerargs=None):
+        assert expansionlimit is None or isinstance(expansionlimit, int)
+
+        self.s = s
+        self._strictmode = strictmode
+        self._expansionlimit = expansionlimit
+
+        if tokenizerargs is None:
+            tokenizerargs = {}
+        self.parserstate = tokenizerargs.pop('parserstate', state.parserstate())
+
+        self.tok = tokenizer.tokenizer(s,
+                                       parserstate=self.parserstate,
+                                       strictmode=strictmode,
+                                       **tokenizerargs)
+
+        self.redirstack = self.tok.redirstack
+
+    def parse(self):
+        # yacc.yacc returns a parser object that is not reentrant, it has
+        # some mutable state. we make a shallow copy of it so no
+        # state spills over to the next call to parse on it
+        theparser = copy.copy(yaccparser)
+        tree = theparser.parse(lexer=self.tok, context=self)
+
+        return tree
+
+class _endfinder(ast.nodevisitor):
+    '''helper class to find the "real" end pos of a node that contains
+    a heredoc. this is a hack because heredoc aren't really part of any node
+    since they don't always follow the end of a node and might appear on
+    a different line'''
+    def __init__(self):
+        self.end = -1
+    def visitheredoc(self, node, value):
+        self.end = node.pos[1]

--- a/rpm_lockfile/vendor/bashlex/parser.py
+++ b/rpm_lockfile/vendor/bashlex/parser.py
@@ -1,6 +1,6 @@
 import os, copy
 
-from bashlex import yacc, tokenizer, state, ast, subst, flags, errors, heredoc
+from . import yacc, tokenizer, state, ast, subst, flags, errors, heredoc
 
 def _partsspan(parts):
     return parts[0].pos[0], parts[-1].pos[1]

--- a/rpm_lockfile/vendor/bashlex/shutils.py
+++ b/rpm_lockfile/vendor/bashlex/shutils.py
@@ -1,0 +1,63 @@
+def single_quote(s):
+    if s[0] == "'" and len(s) == 1:
+        return "\\'"
+
+    l = ["'"]
+
+    for c in s:
+        l.append(c)
+        if c == "'":
+            l.extend(["\\''"])
+
+    l.append("'")
+
+    return ''.join(l)
+
+def double_quote(s):
+    return s
+
+def legal_number(s):
+    try:
+        x = int(s)
+        return True
+    except ValueError:
+        return False
+
+def legal_identifier(name):
+    pass
+
+def removequotes(s, heredoc=False, doublequotes=False):
+    r = ''
+    sindex = 0
+    dquote = False
+    while sindex < len(s):
+        c = s[sindex]
+        if c == '\\':
+            sindex += 1
+            if sindex == len(s):
+                r += '\\'
+                return r
+            c = s[sindex]
+            if ((heredoc and doublequotes) or dquote) and not _shellquote(c):
+                r += '\\'
+            r += c
+        elif c == "'":
+            if (heredoc and doublequotes) or dquote:
+                r += c
+                sindex += 1
+            else:
+                t = s.find("'", sindex + 1)
+                if t == -1:
+                    t = len(s)
+                else:
+                    t += 1
+
+                r += s[sindex + 1:t-1]
+                sindex = t
+        elif c == '"':
+            dquote = not dquote
+            sindex += 1
+        else:
+            r += c
+            sindex += 1
+    return r

--- a/rpm_lockfile/vendor/bashlex/state.py
+++ b/rpm_lockfile/vendor/bashlex/state.py
@@ -1,0 +1,3 @@
+from bashlex import flags, utils
+
+parserstate = lambda: utils.typedset(flags.parser)

--- a/rpm_lockfile/vendor/bashlex/state.py
+++ b/rpm_lockfile/vendor/bashlex/state.py
@@ -1,3 +1,3 @@
-from bashlex import flags, utils
+from . import flags, utils
 
 parserstate = lambda: utils.typedset(flags.parser)

--- a/rpm_lockfile/vendor/bashlex/subst.py
+++ b/rpm_lockfile/vendor/bashlex/subst.py
@@ -1,0 +1,381 @@
+import copy
+
+from bashlex import ast, flags, tokenizer, errors
+
+def _recursiveparse(parserobj, base, sindex, tokenizerargs=None):
+    # TODO: fix this hack that prevents mutual import
+    from bashlex import parser
+
+    tok = parserobj.tok
+
+    if tokenizerargs is None:
+        tokenizerargs = {'parserstate' : copy.copy(tok._parserstate),
+                         'lastreadtoken' : tok._last_read_token,
+                         'tokenbeforethat' : tok._token_before_that,
+                         'twotokensago' : tok._two_tokens_ago}
+
+    string = base[sindex:]
+    newlimit = parserobj._expansionlimit
+    if newlimit is not None:
+        newlimit -= 1
+    p = parser._parser(string, tokenizerargs=tokenizerargs,
+                       expansionlimit=newlimit)
+    node = p.parse()
+
+    endp = node.pos[1]
+    _adjustpositions(node, sindex, len(base))
+
+    return node, endp
+
+def _parsedolparen(parserobj, base, sindex):
+    copiedps = copy.copy(parserobj.parserstate)
+    copiedps.add(flags.parser.CMDSUBST)
+    copiedps.add(flags.parser.EOFTOKEN)
+    string = base[sindex:]
+
+    tokenizerargs = {'eoftoken' : tokenizer.token(tokenizer.tokentype.RIGHT_PAREN, ')'),
+                     'parserstate' : copiedps,
+                     'lastreadtoken' : parserobj.tok._last_read_token,
+                     'tokenbeforethat' : parserobj.tok._token_before_that,
+                     'twotokensago' : parserobj.tok._two_tokens_ago}
+
+    node, endp = _recursiveparse(parserobj, base, sindex, tokenizerargs)
+
+    if string[endp] != ')':
+        while endp > 0 and string[endp-1] == '\n':
+            endp -= 1
+
+    return node, sindex + endp
+
+def _extractcommandsubst(parserobj, string, sindex, sxcommand=False):
+    if string[sindex] == '(':
+        raise NotImplementedError('arithmetic expansion')
+        #return _extractdelimitedstring(parserobj, string, sindex, '$(', '(', '(', sxcommand=True)
+    else:
+        node, si = _parsedolparen(parserobj, string, sindex)
+        si += 1
+        return ast.node(kind='commandsubstitution', command=node, pos=(sindex-2, si)), si
+
+def _extractprocesssubst(parserobj, string, sindex):
+    #return _extractdelimitedstring(tok, string, sindex, starter, '(', ')', sxcommand=True)
+    node, si = _parsedolparen(parserobj, string, sindex)
+    return node, si + 1
+
+#def _extractdelimitedstring(parserobj, string, sindex, opener, altopener, closer,
+#                            sxcommand=False):
+#    parts = []
+#    incomment = False
+#    passchar = False
+#    nestinglevel = 1
+#    i = sindex
+
+#    while nestinglevel:
+#        if i >= len(string):
+#            break
+#        c = string[i]
+#        if incomment:
+#            if c == '\n':
+#                incomment = False
+#            i += 1
+#            continue
+#        elif passchar:
+#            passchar = False
+#            i += 1
+#            continue
+
+#        if sxcommand and c == '#' and (i == 0 or string[i-1] == '\n' or
+#                                       tokenizer._shellblank(string[i-1])):
+#            incomment = True
+#            i += 1
+#            continue
+
+#        if c == '\\':
+#            passchar = True
+#            i += 1
+#            continue
+
+#        if sxcommand and string[i:i+2] == '$(':
+#            si = i + 2
+#            node, si = _extractcommandsubst(parserobj, string, si, sxcommand=sxcommand)
+#            parts.append(node)
+#            i = si + 1
+#            continue
+
+#        if string.startswith(opener, i):
+#            si = i + len(opener)
+#            nodes, si = _extractdelimitedstring(parserobj, string, si, opener, altopener,
+#                                                closer, sxcommand=sxcommand)
+#            parts.extend(nodes)
+#            i = si + 1
+#            continue
+
+#        if string.startswith(altopener, i):
+#            si = i + len(altopener)
+#            nodes, si = _extractdelimitedstring(parserobj, string, si, altopener, altopener,
+#                                                closer, sxcommand=sxcommand)
+#            parts.extend(nodes)
+#            i = si + 1
+#            continue
+
+#        # 1327
+#        if string.startswith(closer, i):
+#            i += len(closer) - 1
+#            nestinglevel -= 1
+#            if nestinglevel == 0:
+#                break
+
+#        if c == '`':
+#            si = i + 1
+#            t = _stringextract(string, si, '`', sxcommand=sxcommand)
+#            i = si + 1
+#            continue
+
+#        if c in "'\"":
+#            si = i +1
+#            if c == '"':
+#                i = _skipsinglequoted(string, si)
+#            else:
+#                i = _skipdoublequoted(string, si)
+#            continue
+
+#        i += 1
+
+#    if i == len(string) and nestinglevel:
+#        raise errors.ParsingError('bad substitution: no closing %r in %s' % (closer, string))
+
+#    return parts, i
+
+def _paramexpand(parserobj, string, sindex):
+    node = None
+    zindex = sindex + 1
+    c = string[zindex] if zindex < len(string) else None
+    if c and c in '0123456789$#?-!*@':
+        # XXX 7685
+        node = ast.node(kind='parameter', value=c,
+                        pos=(sindex, zindex+1))
+    elif c == '{':
+        # XXX 7863
+        # TODO not start enough, doesn't consider escaping
+        zindex = string.find('}', zindex + 1)
+        node = ast.node(kind='parameter', value=string[sindex+2:zindex],
+                        pos=(sindex, zindex+1))
+        # TODO
+        # return _parameterbraceexpand(string, zindex)
+    elif c == '(':
+        return _extractcommandsubst(parserobj, string, zindex + 1)
+    elif c == '[':
+        raise NotImplementedError('arithmetic substitution')
+        #return _extractarithmeticsubst(string, zindex + 1)
+    else:
+        tindex = zindex
+        for zindex in range(tindex, len(string) + 1):
+            if zindex == len(string):
+                break
+            if not string[zindex].isalnum() and not string[zindex] == '_':
+                break
+        temp1 = string[sindex:zindex]
+        if temp1:
+            return (ast.node(kind='parameter', value=temp1[1:], pos=(sindex, zindex)),
+                    zindex)
+
+    if zindex < len(string):
+        zindex += 1
+
+    return node, zindex
+
+def _adjustpositions(node_, base, endlimit):
+    class v(ast.nodevisitor):
+        def visitnode(self, node):
+            assert node.pos[1] + base <= endlimit
+            node.pos = (node.pos[0] + base, node.pos[1] + base)
+    visitor = v()
+    visitor.visit(node_)
+
+def _expandwordinternal(parserobj, wordtoken, qheredocument, qdoublequotes, quoted, isexp):
+    # bash/subst.c L8132
+    istring = ''
+    parts = []
+    tindex = [0]
+    sindex = [0]
+    string = wordtoken.value
+    def nextchar():
+        sindex[0] += 1
+        if sindex[0] < len(string):
+            return string[sindex[0]]
+    def peekchar():
+        if sindex[0]+1 < len(string):
+            return string[sindex[0]+1]
+
+    while True:
+        if sindex[0] == len(string):
+            break
+            # goto finished_with_string
+        c = string[sindex[0]]
+        if c in '<>':
+            if (nextchar() != '(' or qheredocument or qdoublequotes or
+                (wordtoken.flags & set([flags.word.DQUOTE, flags.word.NOPROCSUB]))):
+                sindex[0] -= 1
+
+                # goto add_character
+                sindex[0] += 1
+                istring += c
+            else:
+                tindex = sindex[0] + 1
+
+                node, sindex[0] = _extractprocesssubst(parserobj, string, tindex)
+
+                parts.append(ast.node(kind='processsubstitution', command=node,
+                                      pos=(tindex - 2, sindex[0])))
+                istring += string[tindex - 2:sindex[0]]
+                # goto dollar_add_string
+        # TODO
+        # elif c == '=':
+        #     pass
+        # elif c == ':':
+        #     pass
+        elif c == '~':
+            if (wordtoken.flags & set([flags.word.NOTILDE, flags.word.DQUOTE]) or
+                (sindex[0] > 0 and not (wordtoken.flags & flags.word.NOTILDE)) or
+                qdoublequotes or qheredocument):
+                wordtoken.flags.clear()
+                wordtoken.flags.add(flags.word.ITILDE)
+                sindex[0] += 1
+                istring += c
+            else:
+                stopatcolon = wordtoken.flags & set([flags.word.ASSIGNRHS,
+                                                    flags.word.ASSIGNMENT,
+                                                    flags.word.TILDEEXP])
+                expand = True
+                for i in range(sindex[0], len(string)):
+                    r = string[i]
+                    if r == '/':
+                        break
+                    if r in "\\'\"":
+                        expand = False
+                        break
+                    if stopatcolon and r == ':':
+                        break
+                else:
+                    # go one past the end if we didn't exit early
+                    i += 1
+
+                if i > sindex[0] and expand:
+                    node = ast.node(kind='tilde', value=string[sindex[0]:i],
+                                    pos=(sindex[0], i))
+                    parts.append(node)
+                istring += string[sindex[0]:i]
+                sindex[0] = i
+
+        elif c == '$' and len(string) > 1:
+            tindex = sindex[0]
+            node, sindex[0] = _paramexpand(parserobj, string, sindex[0])
+            if node:
+                parts.append(node)
+            istring += string[tindex:sindex[0]]
+        elif c == '`':
+            tindex = sindex[0]
+            # bare instance of ``
+            if nextchar() == '`':
+                sindex[0] += 1
+                istring += '``'
+            else:
+                x = _stringextract(string, sindex[0], "`")
+                if x == -1:
+                    raise errors.ParsingError('bad substitution: no closing "`" '
+                                              'in %s' % string)
+                else:
+                    if wordtoken.flags & flags.word.NOCOMSUB:
+                        pass
+                    else:
+                        sindex[0] = x
+
+                        word = string[tindex+1:sindex[0]]
+                        command, ttindex = _recursiveparse(parserobj, word, 0)
+                        _adjustpositions(command, tindex+1, len(string))
+                        ttindex += 1 # ttindex is on the closing char
+
+                        # assert sindex[0] == ttindex
+                        # go one past the closing `
+                        sindex[0] += 1
+
+                        node = ast.node(kind='commandsubstitution',
+                                        command=command,
+                                        pos=(tindex, sindex[0]))
+                        parts.append(node)
+                        istring += string[tindex:sindex[0]]
+
+        elif c == '\\':
+            istring += string[sindex[0]+1:sindex[0]+2]
+            sindex[0] += 2
+        elif c == '"':
+            sindex[0] += 1
+            continue
+
+            # 8513
+            #if qdoublequotes or qheredocument:
+            #    sindex[0] += 1
+            #else:
+            #    tindex = sindex[0] + 1
+            #    parts, sindex[0] = _stringextractdoublequoted(string, sindex[0])
+            #    if tindex == 1 and sindex[0] == len(string):
+            #        quotedstate = 'wholly'
+            #    else:
+            #        quotedstate = 'partially'
+
+        elif c == "'":
+            # entire string surronded by single quotes, no expansion is
+            # going to happen
+            if sindex[0] == 0 and string[-1] == "'":
+                return [], string[1:-1]
+
+            # check if we're inside double quotes
+            if not qdoublequotes:
+                # look for the closing ', we know we have one or otherwise
+                # this wouldn't tokenize due to unmatched '
+                tindex = sindex[0]
+                sindex[0] = string.find("'", sindex[0]) + 1
+
+                istring += string[tindex+1:sindex[0]-1]
+            else:
+                # this is a single quote inside double quotes, add it
+                istring += c
+                sindex[0] += 1
+        else:
+            istring += string[sindex[0]:sindex[0]+1]
+            sindex[0] += 1
+
+    if parts:
+        class v(ast.nodevisitor):
+            def visitnode(self, node):
+                assert node.pos[1] + wordtoken.lexpos <= wordtoken.endlexpos
+                node.pos = (node.pos[0] + wordtoken.lexpos,
+                            node.pos[1] + wordtoken.lexpos)
+        visitor = v()
+        for node in parts:
+            visitor.visit(node)
+
+    return parts, istring
+
+def _stringextract(string, sindex, charlist, sxvarname=False):
+    found = False
+    i = sindex
+    while i < len(string):
+        c = string[i]
+        if c == '\\':
+            if i + 1 < len(string):
+                i += 1
+            else:
+                break
+        elif sxvarname and c == '[':
+            ni = _skipsubscript(string, i, 0)
+            if string[ni] == ']':
+                i = ni
+        elif c in charlist:
+            found = True
+            break
+        else:
+            i += 1
+    if found:
+        return i
+    else:
+        return -1

--- a/rpm_lockfile/vendor/bashlex/subst.py
+++ b/rpm_lockfile/vendor/bashlex/subst.py
@@ -1,10 +1,10 @@
 import copy
 
-from bashlex import ast, flags, tokenizer, errors
+from . import ast, flags, tokenizer, errors
 
 def _recursiveparse(parserobj, base, sindex, tokenizerargs=None):
     # TODO: fix this hack that prevents mutual import
-    from bashlex import parser
+    from . import parser
 
     tok = parserobj.tok
 

--- a/rpm_lockfile/vendor/bashlex/tokenizer.py
+++ b/rpm_lockfile/vendor/bashlex/tokenizer.py
@@ -1,0 +1,1160 @@
+import re, collections, enum
+
+from bashlex import flags, shutils, utils, errors, heredoc, state
+
+sh_syntaxtab = collections.defaultdict(set)
+
+def _addsyntax(chars, symbol):
+    for c in chars:
+        sh_syntaxtab[c].add(symbol)
+
+_addsyntax('\\`$"\n', 'dquote')
+_addsyntax('()<>;&|', 'meta')
+_addsyntax('"`\'', 'quote')
+_addsyntax('$<>', 'exp')
+_addsyntax("()<>;&| \t\n", 'break')
+
+def _shellblank(c):
+    return c in ' \t'
+
+def _shellmeta(c):
+    return 'meta' in sh_syntaxtab[c]
+
+def _shellquote(c):
+    return 'quote' in sh_syntaxtab[c]
+
+def _shellexp(c):
+    return 'exp' in sh_syntaxtab[c]
+
+def _shellbreak(c):
+    return 'break' in sh_syntaxtab[c]
+
+class tokentype(enum.Enum):
+    IF = 1
+    THEN = 2
+    ELSE = 3
+    ELIF = 4
+    FI = 5
+    CASE = 6
+    ESAC = 7
+    FOR = 8
+    SELECT = 9
+    WHILE = 10
+    UNTIL = 11
+    DO = 12
+    DONE = 13
+    FUNCTION = 14
+    COPROC = 15
+    COND_START = 16
+    COND_END = 17
+    # https://github.com/idank/bashlex/issues/20
+    # COND_ERROR = 18
+    IN = 19
+    BANG = '!'
+    TIME = 21
+    TIMEOPT = 22
+    TIMEIGN = 23
+    WORD = 24
+    ASSIGNMENT_WORD = 25
+    REDIR_WORD = 26
+    NUMBER = 27
+    ARITH_CMD = 28
+    ARITH_FOR_EXPRS = 29
+    COND_CMD = 30
+    AND_AND = '&&'
+    OR_OR = '||'
+    GREATER_GREATER = '>>'
+    LESS_LESS = '<<'
+    LESS_AND = '<&'
+    LESS_LESS_LESS = '<<<'
+    GREATER_AND = '>&'
+    SEMI_SEMI = ';;'
+    SEMI_AND = ';&'
+    SEMI_SEMI_AND = ';;&'
+    LESS_LESS_MINUS = '<<-'
+    AND_GREATER = '&>'
+    AND_GREATER_GREATER = '&>>'
+    LESS_GREATER = '<>'
+    GREATER_BAR = '>|'
+    BAR_AND = '|&'
+    LEFT_CURLY = 47
+    RIGHT_CURLY = 48
+    EOF = '$end'
+    LEFT_PAREN = '('
+    RIGHT_PAREN = ')'
+    BAR = '|'
+    SEMICOLON = ';'
+    DASH = '-'
+    NEWLINE = '\n'
+    LESS = '<'
+    GREATER = '>'
+    AMPERSAND = '&'
+
+_reserved = set([
+    tokentype.AND_AND, tokentype.BANG, tokentype.BAR_AND, tokentype.DO,
+    tokentype.DONE, tokentype.ELIF, tokentype.ELSE, tokentype.ESAC,
+    tokentype.FI, tokentype.IF, tokentype.OR_OR, tokentype.SEMI_SEMI,
+    tokentype.SEMI_AND, tokentype.SEMI_SEMI_AND, tokentype.THEN,
+    tokentype.TIME, tokentype.TIMEOPT, tokentype.TIMEIGN, tokentype.COPROC,
+    tokentype.UNTIL, tokentype.WHILE])
+
+for c in '\n;()|&{}':
+    _reserved.add(c)
+
+# word_token_alist
+valid_reserved_first_command = {
+    "if" : tokentype.IF,
+    "then" : tokentype.THEN,
+    "else" : tokentype.ELSE,
+    "elif" : tokentype.ELIF,
+    "fi" : tokentype.FI,
+    "case" : tokentype.CASE,
+    "esac" : tokentype.ESAC,
+    "for" : tokentype.FOR,
+    "select" : tokentype.SELECT,
+    "while" : tokentype.WHILE,
+    "until" : tokentype.UNTIL,
+    "do" : tokentype.DO,
+    "done" : tokentype.DONE,
+    "in" : tokentype.IN,
+    "function" : tokentype.FUNCTION,
+    "time" : tokentype.TIME,
+    "{" : tokentype.LEFT_CURLY,
+    "}" : tokentype.RIGHT_CURLY,
+    "!" : tokentype.BANG,
+    "[[" : tokentype.COND_START,
+    "]]" : tokentype.COND_END,
+    "coproc" : tokentype.COPROC
+}
+
+class MatchedPairError(errors.ParsingError):
+    def __init__(self, startline, message, tokenizer):
+        # TODO use startline?
+        super(MatchedPairError, self).__init__(message,
+                                               tokenizer.source,
+                                               tokenizer._shell_input_line_index - 1)
+
+wordflags = flags.word
+parserflags = flags.parser
+
+class token(object):
+    def __init__(self, type_, value, pos=None, flags=None):
+        if type_ is not None:
+            assert isinstance(type_, tokentype)
+
+        if flags is None:
+            flags = set()
+
+        self.ttype = type_
+
+        self.value = value
+        if pos is not None:
+            self.lexpos = pos[0]
+            self.endlexpos = pos[1]
+            assert self.lexpos < self.endlexpos, (self.lexpos, self.endlexpos)
+        else:
+            self.lexpos = self.endlexpos = None
+
+        self.flags = flags
+
+    @property
+    def type(self):
+        if self.ttype:
+            # make yacc see our EOF token as its own special one $end
+            if self.ttype == tokentype.EOF:
+                return '$end'
+            else:
+                return self.ttype.name
+
+    def __nonzero__(self):
+        return not (self.ttype is None and self.value is None)
+
+    __bool__ = __nonzero__
+
+    def __eq__(self, other):
+        return isinstance(other, token) and (self.type == other.type and
+                                             self.value == other.value and
+                                             self.lexpos == other.lexpos and
+                                             self.endlexpos == other.endlexpos and
+                                             self.flags == other.flags)
+
+    def __repr__(self):
+        s = ['<', self.type]
+        if self.lexpos is not None and self.endlexpos is not None:
+            s.append('@%d:%d' % (self.lexpos, self.endlexpos))
+        if self.value:
+            s.append(' ')
+            s.append(repr(self.value))
+
+        if self.flags:
+            prettyflags = ' '.join([e.name for e in self.flags])
+            s.append(' (%s)' % prettyflags)
+        s.append('>')
+        return ''.join(s)
+
+    def nopos(self):
+        return self.__class__(self.ttype, self.value, flags=self.flags)
+
+eoftoken = token(tokentype.EOF, None)
+
+class tokenizer(object):
+    def __init__(self, s, parserstate, strictmode=True, eoftoken=None,
+                 lastreadtoken=None, tokenbeforethat=None, twotokensago=None):
+        self._shell_eof_token = eoftoken
+        self._shell_input_line = s
+        self._added_newline = False
+        if self._shell_input_line and self._shell_input_line[-1] != '\n':
+            self._shell_input_line += '\n' # bash/parse.y L2431
+            self._added_newline = True
+        self._shell_input_line_index = 0
+        # self._shell_input_line_terminator = None
+        self._two_tokens_ago = twotokensago or token(None, None)
+        self._token_before_that = tokenbeforethat or token(None, None)
+        self._last_read_token = lastreadtoken or token(None, None)
+        self._current_token = token(None, None)
+
+        # This implements one-character lookahead/lookbehind across physical
+        # input lines, to avoid something being lost because it's pushed back
+        # with shell_ungetc when we're at the start of a line.
+        self._eol_ungetc_lookahead = None
+
+        # token waiting to be read
+        self._token_to_read = None
+
+        self._parserstate = parserstate
+        self._line_number = 0
+        self._open_brace_count = 0
+        self._esacs_needed_count = 0
+
+        self._dstack = []
+
+        # a stack of positions to record the start and end of a token
+        self._positions = []
+
+        self._strictmode = strictmode
+
+        # hack: the tokenizer needs access to the stack of redirection
+        # nodes when it reads heredocs. this instance is shared between
+        # the tokenizer and the parser, which also needs it
+        self.redirstack = []
+
+    @property
+    def source(self):
+        if self._added_newline:
+            return self._shell_input_line[:-1]
+        return self._shell_input_line
+
+    def __iter__(self):
+        while True:
+            t = self.token()
+            # we're finished when we see the eoftoken OR when we added a newline
+            # to the input and we're there now
+            if t is eoftoken or (self._added_newline and
+                                 t.lexpos + 1 == len(self._shell_input_line)):
+                break
+            yield t
+
+    def _createtoken(self, type_, value, flags=None):
+        '''create a token with position information'''
+        pos = None
+        assert len(self._positions) >= 2, (type_, value)
+        p2 = self._positions.pop()
+        p1 = self._positions.pop()
+        pos = [p1, p2]
+        return token(type_, value, pos, flags)
+
+    def token(self):
+        self._two_tokens_ago, self._token_before_that, self._last_read_token = \
+            self._token_before_that, self._last_read_token, self._current_token
+
+        self._current_token = self._readtoken()
+        if isinstance(self._current_token, tokentype):
+            self._recordpos()
+            self._current_token = self._createtoken(self._current_token,
+                                                    self._current_token.value)
+
+        if (self._parserstate & parserflags.EOFTOKEN and
+            self._current_token.ttype == self._shell_eof_token):
+            self._current_token = eoftoken
+            # bash/parse.y L2626
+        self._parserstate.discard(parserflags.EOFTOKEN)
+
+        return self._current_token
+
+    def _readtoken(self):
+        character = None
+        peek_char = None
+
+        if self._token_to_read is not None:
+            t = self._token_to_read
+            self._token_to_read = None
+            return t
+
+        # bashlex/parse.y L2989 COND_COMMAND
+        character = self._getc(True)
+        while character is not None and _shellblank(character):
+            character = self._getc(True)
+
+        if character is None:
+            return eoftoken
+
+        if character == '#':
+            self._discard_until('\n')
+            self._getc(False)
+            character = '\n'
+
+        self._recordpos(1)
+
+        if character == '\n':
+            # bashlex/parse.y L3034 ALIAS
+            heredoc.gatherheredocuments(self)
+
+            self._parserstate.discard(parserflags.ASSIGNOK)
+            return tokentype(character)
+
+        if self._parserstate & parserflags.REGEXP:
+            return self._readtokenword(character)
+
+        if _shellmeta(character) and not (self._parserstate & parserflags.DBLPAREN):
+            self._parserstate.discard(parserflags.ASSIGNOK)
+            peek_char = self._getc(True)
+
+            both = character
+            if peek_char:
+                both += peek_char
+            if character == peek_char:
+                if character == '<':
+                    peek_char = self._getc()
+                    if peek_char == '-':
+                        return tokentype.LESS_LESS_MINUS
+                    elif peek_char == '<':
+                        return tokentype.LESS_LESS_LESS
+                    else:
+                        self._ungetc(peek_char)
+                        return tokentype.LESS_LESS
+                elif character == '>':
+                    return tokentype.GREATER_GREATER
+                elif character == ';':
+                    self._parserstate |= parserflags.CASEPAT
+                    # bashlex/parse.y L3085 ALIAS
+                    peek_char = self._getc()
+                    if peek_char == '&':
+                        return tokentype.SEMI_SEMI_AND
+                    else:
+                        self._ungetc(peek_char)
+                        return tokentype.SEMI_SEMI
+                elif character == '&':
+                    return tokentype.AND_AND
+                elif character == '|':
+                    return tokentype.OR_OR
+                # bashlex/parse.y L3105
+            elif both == '<&':
+                return tokentype.LESS_AND
+            elif both == '>&':
+                return tokentype.GREATER_AND
+            elif both == '<>':
+                return tokentype.LESS_GREATER
+            elif both == '>|':
+                return tokentype.GREATER_BAR
+            elif both == '&>':
+                peek_char = self._getc()
+                if peek_char == '>':
+                    return tokentype.AND_GREATER_GREATER
+                else:
+                    self._ungetc(peek_char)
+                    return tokentype.AND_GREATER
+            elif both == '|&':
+                return tokentype.BAR_AND
+            elif both == ';&':
+                return tokentype.SEMI_AND
+
+            self._ungetc(peek_char)
+            if character == ')' and self._last_read_token.value == '(' and self._token_before_that.ttype == tokentype.WORD:
+                self._parserstate.add(parserflags.ALLOWOPNBRC)
+                # bashlex/parse.y L3155
+
+            if character == '(' and not self._parserstate & parserflags.CASEPAT:
+                self._parserstate.add(parserflags.SUBSHELL)
+            elif self._parserstate & parserflags.CASEPAT and character == ')':
+                self._parserstate.discard(parserflags.CASEPAT)
+            elif self._parserstate & parserflags.SUBSHELL and character == ')':
+                self._parserstate.discard(parserflags.SUBSHELL)
+
+            if character not in '<>' or peek_char != '(':
+                return tokentype(character)
+
+        if character == '-' and (self._last_read_token.ttype == tokentype.LESS_AND or self._last_read_token.ttype == tokentype.GREATER_AND):
+            return tokentype(character)
+
+        return self._readtokenword(character)
+
+    def _readtokenword(self, c):
+        d = {}
+        d['all_digit_token'] = c.isdigit()
+        d['dollar_present'] = d['quoted'] = d['pass_next_character'] = d['compound_assignment'] = False
+
+        tokenword = []
+
+        def handleshellquote():
+            self._push_delimiter(c)
+            try:
+                ttok = self._parse_matched_pair(c, c, c, parsingcommand=(c == '`'))
+            finally:
+                self._pop_delimiter()
+
+            tokenword.append(c)
+            tokenword.extend(ttok)
+            d['all_digit_token'] = False
+            d['quoted'] = True
+            if not d['dollar_present']:
+                d['dollar_present'] = c == '"' and '$' in ttok
+
+        def handleshellexp():
+            peek_char = self._getc()
+            if peek_char == '(' or (c == '$' and peek_char in '{['):
+                # try:
+                if peek_char == '{':
+                    ttok = self._parse_matched_pair(cd, '{', '}', firstclose=True, dolbrace=True)
+                elif peek_char == '(':
+                    self._push_delimiter(peek_char)
+                    ttok = self._parse_comsub(cd, '(', ')', parsingcommand=True)
+                    self._pop_delimiter()
+                else:
+                    ttok = self._parse_matched_pair(cd, '[', ']')
+                # except MatchedPairError:
+                #   return -1
+
+                tokenword.append(c)
+                tokenword.append(peek_char)
+                tokenword.extend(ttok)
+                d['dollar_present'] = True
+                d['all_digit_token'] = False
+
+                # goto next_character
+            elif c == '$' and peek_char in '\'"':
+                self._push_delimiter(peek_char)
+                try:
+                    ttok = self._parse_matched_pair(peek_char, peek_char, peek_char,
+                                                    allowesc=(peek_char == "'"))
+                # except MatchedPairError:
+                #    return -1
+                finally:
+                    self._pop_delimiter()
+
+                #if peek_char == "'":
+                #    # XXX ansiexpand
+                #    ttok = shutils.single_quote(ttok)
+                #else:
+                #    ttok = shutils.double_quote(ttok)
+
+                tokenword.append(c)
+                tokenword.append(peek_char)
+                tokenword.extend(ttok)
+                d['quoted'] = True
+                d['all_digit_token'] = False
+
+                # goto next_character
+            elif c == '$' and peek_char == '$':
+                tokenword.append('$')
+                tokenword.append('$')
+                d['dollar_present'] = True
+                d['all_digit_token'] = False
+
+                # goto next_character
+            else:
+                self._ungetc(peek_char)
+                return True
+
+            # bashlex/parse.y L4699 ARRAY_VARS
+
+        def handleescapedchar():
+            tokenword.append(c)
+            d['all_digit_token'] &= c.isdigit()
+            if not d['dollar_present']:
+                d['dollar_present'] = c == '$'
+
+        while True:
+            if c is None:
+                break
+
+            if d['pass_next_character']:
+                d['pass_next_character'] = False
+                handleescapedchar()
+                # goto escaped_character
+            else:
+                cd = self._current_delimiter()
+                gotonext = False
+                if c == '\\':
+                    peek_char = self._getc(False)
+
+                    if peek_char == '\n':
+                        c = '\n'
+                        gotonext = True
+                        # goto next_character
+                    else:
+                        self._ungetc(peek_char)
+
+                        if (cd is None or cd == '`' or
+                            (cd == '"' and peek_char is not None and
+                             'dquote' in sh_syntaxtab[peek_char])):
+                            d['pass_next_character'] = True
+                            d['quoted'] = True
+
+                            handleescapedchar()
+                            gotonext = True
+                            # goto got_character
+                elif _shellquote(c):
+                    handleshellquote()
+                    gotonext = True
+                    # goto next_character
+                # bashlex/parse.y L4542
+                # bashlex/parse.y L4567
+                elif _shellexp(c):
+                    gotonext = not handleshellexp()
+                    # bashlex/parse.y L4699
+                if not gotonext:
+                    if _shellbreak(c):
+                        self._ungetc(c)
+                        break
+                    else:
+                        handleescapedchar()
+
+            # got_character
+            # got_escaped_character
+
+            # tokenword.append(c)
+            # all_digit_token &= c.isdigit()
+            # if not dollar_present:
+            #     dollar_present = c == '$'
+
+            # next_character
+            cd = self._current_delimiter()
+            c = self._getc(cd != "'" and not d['pass_next_character'])
+
+        # got_token
+        self._recordpos()
+
+        tokenword = ''.join(tokenword)
+
+        if d['all_digit_token'] and (c in '<>' or self._last_read_token.ttype in (tokentype.LESS_AND, tokentype.GREATER_AND)) and shutils.legal_number(tokenword):
+            return self._createtoken(tokentype.NUMBER, int(tokenword))
+
+        # bashlex/parse.y L4811
+        specialtokentype = self._specialcasetokens(tokenword)
+        if specialtokentype:
+            return self._createtoken(specialtokentype, tokenword)
+
+        if not d['dollar_present'] and not d['quoted'] and self._reserved_word_acceptable(self._last_read_token):
+            if tokenword in valid_reserved_first_command:
+                ttype = valid_reserved_first_command[tokenword]
+                ps = self._parserstate
+                if ps & parserflags.CASEPAT and ttype != tokentype.ESAC:
+                    pass
+                elif ttype == tokentype.TIME and not self._time_command_acceptable():
+                    pass
+                elif ttype == tokentype.ESAC:
+                    ps.discard(parserflags.CASEPAT)
+                    ps.discard(parserflags.CASESTMT)
+                elif ttype == tokentype.CASE:
+                    ps.add(parserflags.CASESTMT)
+                elif ttype == tokentype.COND_END:
+                    ps.discard(parserflags.CONDCMD)
+                    ps.discard(parserflags.CONDEXPR)
+                elif ttype == tokentype.COND_START:
+                    ps.add(parserflags.CONDCMD)
+                elif ttype == tokentype.LEFT_CURLY:
+                    self._open_brace_count += 1
+                elif ttype == tokentype.RIGHT_CURLY and self._open_brace_count:
+                    self._open_brace_count -= 1
+                return self._createtoken(ttype, tokenword)
+
+        tokenword = self._createtoken(tokentype.WORD, tokenword, utils.typedset(wordflags))
+        if d['dollar_present']:
+            tokenword.flags.add(wordflags.HASDOLLAR)
+        if d['quoted']:
+            tokenword.flags.add(wordflags.QUOTED)
+        if d['compound_assignment'] and tokenword[-1] == ')':
+            tokenword.flags.add(wordflags.COMPASSIGN)
+        if self._is_assignment(tokenword.value, bool(self._parserstate & parserflags.COMPASSIGN)):
+            tokenword.flags.add(wordflags.ASSIGNMENT)
+            if self._assignment_acceptable(self._last_read_token):
+                tokenword.flags.add(wordflags.NOSPLIT)
+                if self._parserstate & parserflags.COMPASSIGN:
+                    tokenword.flags.add(wordflags.NOGLOB)
+
+        # bashlex/parse.y L4865
+        if self._command_token_position(self._last_read_token):
+            pass
+
+        if tokenword.value[0] == '{' and tokenword.value[-1] == '}' and c in '<>':
+            if shutils.legal_identifier(tokenword.value[1:]):
+                # XXX is this needed?
+                tokenword.value = tokenword.value[1:]
+                tokenword.ttype = tokentype.REDIR_WORD
+
+            return tokenword
+
+        if len(tokenword.flags & set([wordflags.ASSIGNMENT, wordflags.NOSPLIT])) == 2:
+            tokenword.ttype = tokentype.ASSIGNMENT_WORD
+
+        if self._last_read_token.ttype == tokentype.FUNCTION:
+            self._parserstate.add(parserflags.ALLOWOPNBRC)
+            self._function_dstart = self._line_number
+        elif self._last_read_token.ttype in (tokentype.CASE, tokentype.SELECT, tokentype.FOR):
+            pass # bashlex/parse.y L4907
+
+        return tokenword
+
+    def _parse_comsub(self, doublequotes, open, close, parsingcommand=False,
+                      dquote=False, firstclose=False):
+        peekc = self._getc(False)
+        self._ungetc(peekc)
+
+        if peekc == '(':
+            return self._parse_matched_pair(doublequotes, open, close)
+
+        count = 1
+        dollarok = True
+
+        checkcase = bool(parsingcommand and (doublequotes is None or doublequotes not in "'\"") and not dquote)
+        checkcomment = checkcase
+
+        startlineno = self._line_number
+        heredelim = ''
+        stripdoc = insideheredoc = insidecomment = insideword = insidecase = False
+        readingheredocdelim = False
+        wasdollar = passnextchar = False
+        reservedwordok = True
+        lexfirstind = -1
+        lexrwlen = 0
+
+        ret = ''
+
+        while count:
+            c = self._getc(doublequotes != "'" and not insidecomment and not passnextchar)
+
+            if c is None:
+                raise MatchedPairError(startlineno, 'unexpected EOF while looking for matching %r' % close, self)
+
+            # bashlex/parse.y L3571
+            if c == '\n':
+                if readingheredocdelim and heredelim:
+                    readingheredocdelim = False
+                    insideheredoc = True
+                    lexfirstind = len(ret) + 1
+                elif insideheredoc:
+                    tind = lexfirstind
+                    while stripdoc and ret[tind] == '\t':
+                        tind += 1
+                    if ret[tind:] == heredelim:
+                        stripdoc = insideheredoc = False
+                        heredelim = ''
+                        lexfirstind = -1
+                    else:
+                        lexfirstind = len(ret) + 1
+            # bashlex/parse.y L3599
+            if insideheredoc and c == close and count == 1:
+                tind = lexfirstind
+                while stripdoc and ret[tind] == '\t':
+                    tind += 1
+                if ret[tind:] == heredelim:
+                    stripdoc = insideheredoc = False
+                    heredelim = ''
+                    lexfirstind = -1
+
+            if insidecomment or insideheredoc:
+                ret += c
+
+                if insidecomment and c == '\n':
+                    insidecomment = False
+
+                continue
+
+            if passnextchar:
+                passnextchar = False
+                # XXX is this needed?
+                # if doublequotes != "'" and c == '\n':
+                #     if ret:
+                #         ret = ret[:-1]
+                # else:
+                #     ret += c
+                ret += c
+                continue
+
+            if _shellbreak(c):
+                insideword = False
+            else:
+                if insideword:
+                    lexwlen += 1
+                else:
+                    insideword = True
+                    lexwlen = 0
+
+            if _shellblank(c) and not readingheredocdelim and not lexrwlen:
+                ret += c
+                continue
+
+            # bashlex/parse.y L3686
+            if readingheredocdelim:
+                if lexfirstind == -1 and not _shellbreak(c):
+                    lexfirstind = len(ret)
+                elif lexfirstind >= 0 and not passnextchar and _shellbreak(c):
+                    if not heredelim:
+                        nestret = ret[lexfirstind:]
+                        heredelim = shutils.removequotes(nestret)
+                    if c == '\n':
+                        insideheredoc = True
+                        readingheredocdelim = False
+                        lexfirstind = len(ret) + 1
+                    else:
+                        lexfirstind = -1
+
+            if not reservedwordok and checkcase and not insidecomment and (_shellmeta(c) or c == '\n'):
+                ret += c
+                peekc = self._getc(True)
+                if c == peekc and c in '&|;':
+                    ret += peekc
+                    reservedwordok = True
+                    lexrwlen = 0
+                    continue
+                elif c == '\n' or c in '&|;':
+                    self._ungetc(peekc)
+                    reservedwordok = True
+                    lexrwlen = 0
+                    continue
+                elif c is None:
+                    raise MatchedPairError(startlineno, 'unexpected EOF while looking for matching %r' % close, self) # pragma: no coverage
+                else:
+                    ret = ret[:-1]
+                    self._ungetc(peekc)
+
+            # bashlex/parse.y L3761
+            if reservedwordok:
+                if c.islower():
+                    ret += c
+                    lexrwlen += 1
+                    continue
+                elif lexrwlen == 4 and _shellbreak(c):
+                    if ret[-4:] == 'case':
+                        insidecase = True
+                    elif ret[-4:] == 'esac':
+                        insidecase = False
+                    reservedwordok = False
+                elif (checkcomment and c == '#' and (lexrwlen == 0 or
+                        (insideword and lexwlen == 0))):
+                    pass
+                elif (not insidecase and (_shellblank(c) or c == '\n') and
+                    lexrwlen == 2 and ret[-2:] == 'do'):
+                    lexrwlen = 0
+                elif insidecase and c != '\n':
+                    reservedwordok = False
+                elif not _shellbreak(c):
+                    reservedwordok = False
+
+            if not insidecomment and checkcase and c == '<':
+                ret += c
+                peekc = self._getc(True)
+                if peekc is None:
+                    raise MatchedPairError(startlineno, 'unexpected EOF while looking for matching %r' % close, self)
+                if peekc == c:
+                    ret += peekc
+                    peekc = self._getc(True)
+                    if peekc is None:
+                        raise MatchedPairError(startlineno, 'unexpected EOF while looking for matching %r' % close, self)
+                    elif peekc == '-':
+                        ret += peekc
+                        stripdoc = True
+                    else:
+                        self._ungetc(peekc)
+
+                    if peekc != '<':
+                        readingheredocdelim = True
+                        lexfirstind = -1
+
+                    continue
+                else:
+                    c = peekc
+            elif checkcomment and not insidecomment and c == '#' and ((reservedwordok
+                    and lexrwlen == 0) or insideword or lexwlen == 0):
+                insidecomment = True
+
+            if c == close and not insidecase:
+                count -= 1
+            elif not firstclose and not insidecase and c == open:
+                count += 1
+
+            ret += c
+
+            if count == 0:
+                break
+
+            if c == '\\':
+                passnextchar = True
+
+            # bashlex/parse.y L3897
+            if _shellquote(c):
+                self._push_delimiter(c)
+                try:
+                    if wasdollar and c == "'":
+                        nestret = self._parse_matched_pair(c, c, c,
+                                                           allowesc=True,
+                                                           dquote=True)
+                    else:
+                        nestret = self._parse_matched_pair(c, c, c,
+                                                           dquote=True)
+                finally:
+                    self._pop_delimiter()
+
+                # XXX is this necessary?
+                # if wasdollar and c == "'" and not rdquote:
+                #     if not rdquote:
+                #         nestret = shutils.single_quote(nestret)
+                #     ret = ret[:-2]
+                # elif wasdollar and c == '"' and not rdquote:
+                #     nestret = shutils.double_quote(nestret)
+                #     ret = ret[:-2]
+
+                ret += nestret
+            # check for $(), $[], or ${} inside command substitution
+            elif wasdollar and c in '({[':
+                if not insidecase and open == c:
+                    count -= 1
+                if c == '(':
+                    nestret = self._parse_comsub(None, '(', ')',
+                                                 parsingcommand=True,
+                                                 dquote=False)
+                elif c == '{':
+                    nestret = self._parse_matched_pair(None, '{', '}',
+                                                       firstclose=True,
+                                                       dolbrace=True,
+                                                       dquote=True)
+                elif c == '[':
+                    nestret = self._parse_matched_pair(None, '[', ']',
+                                                       dquote=True)
+
+                ret += nestret
+
+            wasdollar = c == '$'
+
+        return ret
+
+    def _parse_matched_pair(self, doublequotes, open, close, parsingcommand=False, allowesc=False, dquote=False, firstclose=False, dolbrace=False, arraysub=False):
+        count = 1
+        dolbracestate = ''
+        if dolbrace:
+            dolbracestate = 'param'
+
+        insidecomment = False
+        lookforcomments = False
+        sawdollar = False
+
+        if parsingcommand and doublequotes not in "`'\"" and dquote:
+            lookforcomments = True
+
+        rdquote = True if doublequotes == '"' else dquote
+        passnextchar = False
+        startlineno = self._line_number
+
+        ret = ''
+
+        def handledollarword():
+            if open == c:
+                count -= 1
+
+            # bashlex/parse.y L3486
+            if c == '(':
+                return self._parse_comsub(None, '(', ')',
+                                          parsingcommand=True,
+                                          dquote=False)
+            elif c == '{':
+                return self._parse_matched_pair(None, '{', '}',
+                                                firstclose=True,
+                                                dquote=rdquote,
+                                                dolbrace=True)
+            elif c == '[':
+                return self._parse_matched_pair(None, '[', ']', dquote=rdquote)
+            else:
+                assert False # pragma: no cover
+
+        while count:
+            c = self._getc(doublequotes != "'" and not passnextchar)
+            if c is None:
+                raise MatchedPairError(startlineno, 'unexpected EOF while looking for matching %r' % close, self)
+
+            # bashlex/parse.y L3285
+            # if c == '\n':
+            #    continue
+
+            if insidecomment:
+                ret += c
+                if c == '\n':
+                    insidecomment = False
+                continue
+            elif lookforcomments and not insidecomment and c == '#' and (not ret
+                    or ret[-1] == '\n' or _shellblank(ret[-1])):
+                insidecomment = True
+
+            # last char was backslash
+            if passnextchar:
+                passnextchar = False
+                #if doublequotes != "'" and c == '\n':
+                #    if ret:
+                #        ret = ret[:-1]
+                #    continue
+                ret += c
+                continue
+            elif c == close:
+                count -= 1
+            elif open != close and sawdollar and open == '{' and c == open:
+                count += 1
+            elif not firstclose and c == open:
+                count += 1
+
+            ret += c
+            if count == 0:
+                break
+
+            if open == "'":
+                if allowesc and c == "\\":
+                    passnextchar = True
+                continue
+            if c == "\\":
+                passnextchar = True
+            if dolbrace:
+                if dolbracestate == 'param':
+                    if len(ret) > 1:
+                        dd = {'%' : 'quote', '#' : 'quote', '/' : 'quote2', '^' : 'quote',
+                                ',' : 'quote'}
+                        if c in dd:
+                            dolbracestate = dd[c]
+                    elif c in '#%^,~:-=?+/':
+                        dolbracestate = 'op'
+                if dolbracestate == 'op' and c in '#%^,~:-=?+/':
+                    dolbracestate = 'word'
+
+            if dolbracestate not in 'quote2' and dquote and dolbrace and c == "'":
+                continue
+
+            if open != close:
+                if _shellquote(c):
+                    self._push_delimiter(c)
+                    try:
+                        if sawdollar and "'":
+                            nestret = self._parse_matched_pair(c, c, c, parsingcommand=parsingcommand, allowesc=True, dquote=dquote, firstclose=firstclose, dolbrace=dolbrace)
+                        else:
+                            nestret = self._parse_matched_pair(c, c, c, parsingcommand=parsingcommand, allowesc=allowesc, dquote=dquote, firstclose=firstclose, dolbrace=dolbrace)
+                    finally:
+                        self._pop_delimiter()
+
+                    # bashlex/parse.y L3419
+                    if sawdollar and c == "'":
+                        pass
+                    elif sawdollar and c == '"':
+                        ret = ret[:-2] # back up before the $"
+
+                    ret += nestret
+                elif arraysub and sawdollar and c in '({[':
+                    # goto parse_dollar_word
+                    ret += handledollarword()
+            elif open == '"' and c == '`':
+                ret += self._parse_matched_pair(None, '`', '`', parsingcommand=parsingcommand, allowesc=allowesc, dquote=dquote, firstclose=firstclose, dolbrace=dolbrace)
+            elif open != '`' and sawdollar and c in '({[':
+                ret += handledollarword()
+
+            sawdollar = c == '$'
+
+        return ret
+
+
+    def _is_assignment(self, value, iscompassign):
+        c = value[0]
+
+        def legalvariablechar(x):
+            return x.isalnum() or x == '_'
+
+        if not c.isalpha() and c != '_':
+            return
+
+        for i, c in enumerate(value):
+            if c == '=':
+                return i
+
+            # bash/general.c L289
+            if c == '+' and i + 1 < len(value) and value[i+1] == '=':
+                return i+1
+
+            if not legalvariablechar(c):
+                return False
+
+    def _command_token_position(self, token):
+        return (token.ttype == tokentype.ASSIGNMENT_WORD or
+                self._parserstate & parserflags.REDIRLIST or
+                (token.ttype not in (tokentype.SEMI_SEMI, tokentype.SEMI_AND, tokentype.SEMI_SEMI_AND) and self._reserved_word_acceptable(token)))
+
+    def _assignment_acceptable(self, token):
+        return self._command_token_position(token) and not self._parserstate & parserflags.CASEPAT
+
+    def _time_command_acceptable(self):
+        pass
+
+    def _reserved_word_acceptable(self, tok):
+        if not tok or (tok.ttype in _reserved or tok.value in _reserved):
+            return True
+        # bash/parse.y L4955 cOPROCESS_SUPPORT
+
+        if (self._last_read_token.ttype == tokentype.WORD and
+            self._token_before_that.ttype == tokentype.FUNCTION):
+            return True
+
+        return False
+
+    def _pop_delimiter(self):
+        self._dstack.pop()
+
+    def _push_delimiter(self, c):
+        self._dstack.append(c)
+
+    def _current_delimiter(self):
+        if self._dstack:
+            return self._dstack[-1]
+
+    def _ungetc(self, c):
+        if (self._shell_input_line and self._shell_input_line_index
+            and self._shell_input_line_index <= len(self._shell_input_line)):
+            self._shell_input_line_index -= 1
+        else:
+            self._eol_ungetc_lookahead = c
+
+    def _getc(self, remove_quoted_newline=True):
+        if self._eol_ungetc_lookahead is not None:
+            c = self._eol_ungetc_lookahead
+            self._eol_ungetc_lookahead = None
+            return c
+
+        # bash/parse.y L2220
+
+        while True:
+            if self._shell_input_line_index < len(self._shell_input_line):
+                c = self._shell_input_line[self._shell_input_line_index]
+                self._shell_input_line_index += 1
+            else:
+                c = None
+
+            if c == '\\' and remove_quoted_newline and self._shell_input_line[self._shell_input_line_index] == '\n':
+                self._line_number += 1
+                # skip past the newline
+                self._shell_input_line_index += 1
+                continue
+            else:
+                return c
+
+            #if c is None and self._shell_input_line_terminator is None:
+            #    if self._shell_input_line_index != 0:
+            #        return '\n'
+            #    else:
+            #        return None
+
+            #return c
+
+    def _discard_until(self, character):
+        c = self._getc(False)
+        while c is not None and c != character:
+            c = self._getc(False)
+        if c is not None:
+            self._ungetc(c)
+
+    def _recordpos(self, relativeoffset=0):
+        '''record the current index of the tokenizer into the positions stack
+        while adding relativeoffset from it'''
+        self._positions.append(self._shell_input_line_index - relativeoffset)
+
+    def readline(self, removequotenewline):
+        linebuffer = []
+        passnext = indx = 0
+        while True:
+            c = self._getc()
+            if c is None:
+                if indx == 0:
+                    return None
+                c = '\n'
+
+            if passnext:
+                linebuffer.append(c)
+                indx += 1
+                passnext = False
+            elif c == '\\' and removequotenewline:
+                peekc = self._getc()
+                if peekc == '\n':
+                    self._line_number += 1
+                    continue
+                else:
+                    self._ungetc(peekc)
+                    passnext = True
+                    linebuffer.append(c)
+                    indx += 1
+            else:
+                linebuffer.append(c)
+                indx += 1
+
+            if c == '\n':
+                return ''.join(linebuffer)
+
+    def _peekc(self, *args):
+        peek_char = self._getc(*args)
+        # only unget if we actually read something
+        if peek_char is not None:
+            self._ungetc(peek_char)
+        return peek_char
+
+    def _specialcasetokens(self, tokstr):
+        if (self._last_read_token.ttype == tokentype.WORD and
+            self._token_before_that.ttype in (tokentype.FOR,
+                                              tokentype.CASE,
+                                              tokentype.SELECT) and
+            tokstr == 'in'):
+                if self._token_before_that.ttype == tokentype.CASE:
+                    self._parserstate.add(parserflags.CASEPAT)
+                    self._esacs_needed_count += 1
+                return tokentype.IN
+
+        if (self._last_read_token.ttype == tokentype.WORD and
+            self._token_before_that.ttype in (tokentype.FOR, tokentype.SELECT) and
+            tokstr == 'do'):
+            return tokentype.DO
+
+        if self._esacs_needed_count:
+            self._esacs_needed_count -= 1
+            if tokstr == 'esac':
+                self._parserstate.discard(parserflags.CASEPAT)
+                return tokentype.ESAC
+
+        if self._parserstate & parserflags.ALLOWOPNBRC:
+            self._parserstate.discard(parserflags.ALLOWOPNBRC)
+            if tokstr == '{':
+                self._open_brace_count += 1
+                # bash/parse.y L2887
+                return tokentype.LEFT_CURLY
+
+        if (self._last_read_token.ttype == tokentype.ARITH_FOR_EXPRS and
+            tokstr == 'do'):
+            return tokentype.DO
+
+        if (self._last_read_token.ttype == tokentype.ARITH_FOR_EXPRS and
+            tokstr == '{'):
+            self._open_brace_count += 1
+            return tokentype.LEFT_CURLY
+
+        if (self._open_brace_count and
+            self._reserved_word_acceptable(self._last_read_token) and
+            tokstr == '}'):
+            self._open_brace_count -= 1
+            return tokentype.RIGHT_CURLY
+
+        if self._last_read_token.ttype == tokentype.TIME and tokstr == '-p':
+            return tokentype.TIMEOPT
+
+        if self._last_read_token.ttype == tokentype.TIMEOPT and tokstr == '--':
+            return tokentype.TIMEIGN
+
+        if self._parserstate & parserflags.CONDEXPR and tokstr == ']]':
+            return tokentype.COND_END

--- a/rpm_lockfile/vendor/bashlex/tokenizer.py
+++ b/rpm_lockfile/vendor/bashlex/tokenizer.py
@@ -1,6 +1,6 @@
 import re, collections, enum
 
-from bashlex import flags, shutils, utils, errors, heredoc, state
+from . import flags, shutils, utils, errors, heredoc, state
 
 sh_syntaxtab = collections.defaultdict(set)
 

--- a/rpm_lockfile/vendor/bashlex/utils.py
+++ b/rpm_lockfile/vendor/bashlex/utils.py
@@ -1,0 +1,74 @@
+try:
+    from collections.abc import MutableSet, Mapping
+except ImportError:
+    # Python 2 fallback
+    from collections import MutableSet, Mapping
+
+
+class typedset(MutableSet):
+    def __init__(self, type_, iterable=[]):
+        self._s = set()
+        self._type = type_
+        for v in iterable:
+            self.add(v)
+
+    def add(self, value):
+        if not isinstance(value, self._type):
+            raise ValueError('can only add items of type %s to this set' % self._type)
+        self._s.add(value)
+
+    def discard(self, value):
+        self._s.discard(value)
+
+    def __contains__(self, value):
+        return self._s.__contains__(value)
+
+    def __iter__(self):
+        return self._s.__iter__()
+
+    def __len__(self):
+        return len(self._s)
+
+    def __and__(self, value):
+        if isinstance(value, self._type):
+            value = set([value])
+        return self._s.__and__(value)
+
+    def __or__(self, value):
+        if isinstance(value, self._type):
+            value = set([value])
+        return self._s.__or__(value)
+
+    def __ior__(self, value):
+        if isinstance(value, self._type):
+            value = set([value])
+        self._s.__ior__(value)
+        return self
+
+    #def __sub__(self, value):
+    #    if isinstance(value, self._type):
+    #        value = set([value])
+    #    return self._s.__sub__(value)
+
+    def __repr__(self):
+        return self._s.__repr__()
+
+class frozendict(Mapping):
+    def __init__(self, *args, **kwargs):
+        self.__dict = dict(*args, **kwargs)
+        self.__hash = None
+
+    def __getitem__(self, key):
+        return self.__dict[key]
+
+    def copy(self, **add_or_replace):
+        return frozendict(self, **add_or_replace)
+
+    def __iter__(self):
+        return iter(self.__dict)
+
+    def __len__(self):
+        return len(self.__dict)
+
+    def __repr__(self):
+        return '<frozendict %s>' % repr(self.__dict)

--- a/rpm_lockfile/vendor/bashlex/yacc.py
+++ b/rpm_lockfile/vendor/bashlex/yacc.py
@@ -1,0 +1,2520 @@
+# -----------------------------------------------------------------------------
+# ply: yacc.py
+#
+# Copyright (C) 2001-2022
+# David M. Beazley (Dabeaz LLC)
+# All rights reserved.
+#
+# Latest version: https://github.com/dabeaz/ply
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+# * Redistributions of source code must retain the above copyright notice,
+#   this list of conditions and the following disclaimer.
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+# * Neither the name of David Beazley or Dabeaz LLC may be used to
+#   endorse or promote products derived from this software without
+#   specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+# -----------------------------------------------------------------------------
+#
+# This implements an LR parser that is constructed from grammar rules defined
+# as Python functions. The grammar is specified by supplying the BNF inside
+# Python documentation strings.  The inspiration for this technique was borrowed
+# from John Aycock's Spark parsing system.  PLY might be viewed as cross between
+# Spark and the GNU bison utility.
+#
+# The current implementation is only somewhat object-oriented. The
+# LR parser itself is defined in terms of an object (which allows multiple
+# parsers to co-exist).  However, most of the variables used during table
+# construction are defined in terms of global variables.  Users shouldn't
+# notice unless they are trying to define multiple parsers at the same
+# time using threads (in which case they should have their head examined).
+#
+# This implementation supports both SLR and LALR(1) parsing.  LALR(1)
+# support was originally implemented by Elias Ioup (ezioup@alumni.uchicago.edu),
+# using the algorithm found in Aho, Sethi, and Ullman "Compilers: Principles,
+# Techniques, and Tools" (The Dragon Book).  LALR(1) has since been replaced
+# by the more efficient DeRemer and Pennello algorithm.
+#
+# :::::::: WARNING :::::::
+#
+# Construction of LR parsing tables is fairly complicated and expensive.
+# To make this module run fast, a *LOT* of work has been put into
+# optimization---often at the expensive of readability and what might
+# consider to be good Python "coding style."   Modify the code at your
+# own risk!
+# ----------------------------------------------------------------------------
+
+import re
+import types
+import sys
+import inspect
+
+#-----------------------------------------------------------------------------
+#                     === User configurable parameters ===
+#
+# Change these to modify the default behavior of yacc (if you wish)
+#-----------------------------------------------------------------------------
+
+yaccdebug   = False            # Debugging mode.  If set, yacc generates a
+                               # a 'parser.out' file in the current directory
+
+debug_file  = 'parser.out'     # Default name of the debugging file
+error_count = 3                # Number of symbols that must be shifted to leave recovery mode
+resultlimit = 40               # Size limit of results when running in debug mode.
+
+MAXINT = sys.maxsize
+
+# This object is a stand-in for a logging object created by the
+# logging module.   PLY will use this by default to create things
+# such as the parser.out file.  If a user wants more detailed
+# information, they can create their own logging object and pass
+# it into PLY.
+
+from bashlex import utils
+
+class PlyLogger(object):
+    def __init__(self, f):
+        self.f = f
+
+    def debug(self, msg, *args, **kwargs):
+        self.f.write((msg % args) + '\n')
+
+    info = debug
+
+    def warning(self, msg, *args, **kwargs):
+        self.f.write('WARNING: ' + (msg % args) + '\n')
+
+    def error(self, msg, *args, **kwargs):
+        self.f.write('ERROR: ' + (msg % args) + '\n')
+
+    critical = debug
+
+# Null logger is used when no output is generated. Does nothing.
+class NullLogger(object):
+    def __getattribute__(self, name):
+        return self
+
+    def __call__(self, *args, **kwargs):
+        return self
+
+# Exception raised for yacc-related errors
+class YaccError(Exception):
+    pass
+
+class YaccAccept(Exception):
+    pass
+
+# Format the result message that the parser produces when running in debug mode.
+def format_result(r):
+    repr_str = repr(r)
+    if '\n' in repr_str:
+        repr_str = repr(repr_str)
+    if len(repr_str) > resultlimit:
+        repr_str = repr_str[:resultlimit] + ' ...'
+    result = '<%s @ 0x%x> (%s)' % (type(r).__name__, id(r), repr_str)
+    return result
+
+# Format stack entries when the parser is running in debug mode
+def format_stack_entry(r):
+    repr_str = repr(r)
+    if '\n' in repr_str:
+        repr_str = repr(repr_str)
+    if len(repr_str) < 16:
+        return repr_str
+    else:
+        return '<%s @ 0x%x>' % (type(r).__name__, id(r))
+
+#-----------------------------------------------------------------------------
+#                        ===  LR Parsing Engine ===
+#
+# The following classes are used for the LR parser itself.  These are not
+# used during table construction and are independent of the actual LR
+# table generation algorithm
+#-----------------------------------------------------------------------------
+
+# This class is used to hold non-terminal grammar symbols during parsing.
+# It normally has the following attributes set:
+#        .type       = Grammar symbol type
+#        .value      = Symbol value
+#        .lineno     = Starting line number
+#        .endlineno  = Ending line number (optional, set automatically)
+#        .lexpos     = Starting lex position
+#        .endlexpos  = Ending lex position (optional, set automatically)
+
+class YaccSymbol:
+    def __str__(self):
+        return self.type
+
+    def __repr__(self):
+        return str(self)
+
+# This class is a wrapper around the objects actually passed to each
+# grammar rule.   Index lookup and assignment actually assign the
+# .value attribute of the underlying YaccSymbol object.
+# The lineno() method returns the line number of a given
+# item (or 0 if not defined).   The linespan() method returns
+# a tuple of (startline,endline) representing the range of lines
+# for a symbol.  The lexspan() method returns a tuple (lexpos,endlexpos)
+# representing the range of positional information for a symbol.
+
+class YaccProduction:
+    def __init__(self, s, stack=None):
+        self.slice = s
+        self.stack = stack
+        self.lexer = None
+        self.parser = None
+        self.context = None
+
+    def __getitem__(self, n):
+        if isinstance(n, slice):
+            return [s.value for s in self.slice[n]]
+        elif n >= 0:
+            return self.slice[n].value
+        else:
+            return self.stack[n].value
+
+    def __setitem__(self, n, v):
+        self.slice[n].value = v
+
+    def __getslice__(self, i, j):
+        return [s.value for s in self.slice[i:j]]
+
+    def __len__(self):
+        return len(self.slice)
+
+    def lineno(self, n):
+        return getattr(self.slice[n], 'lineno', 0)
+
+    def set_lineno(self, n, lineno):
+        self.slice[n].lineno = lineno
+
+    def linespan(self, n):
+        startline = getattr(self.slice[n], 'lineno', 0)
+        endline = getattr(self.slice[n], 'endlineno', startline)
+        return startline, endline
+
+    def lexpos(self, n):
+        return getattr(self.slice[n], 'lexpos', 0)
+    
+    def endlexpos(self,n):
+        return getattr(self.slice[n],"endlexpos",0)
+
+    def set_lexpos(self, n, lexpos):
+        self.slice[n].lexpos = lexpos
+
+    def lexspan(self, n):
+        startpos = getattr(self.slice[n], 'lexpos', 0)
+        endpos = getattr(self.slice[n], 'endlexpos', startpos)
+        return startpos, endpos
+
+    def error(self):
+        raise SyntaxError
+    
+    def accept(self):
+        raise YaccAccept
+
+# -----------------------------------------------------------------------------
+#                               == LRParser ==
+#
+# The LR Parsing engine.
+# -----------------------------------------------------------------------------
+
+class LRParser:
+    def __init__(self, lrtab, errorf):
+        self.productions = tuple(lrtab.lr_productions)
+        self.action = utils.frozendict(lrtab.lr_action)
+        self.goto = utils.frozendict(lrtab.lr_goto)
+        self.errorfunc = errorf
+        self.set_defaulted_states()
+        self.errorok = True
+
+    def errok(self):
+        self.errorok = True
+
+    def restart(self):
+        del self.statestack[:]
+        del self.symstack[:]
+        sym = YaccSymbol()
+        sym.type = '$end'
+        self.symstack.append(sym)
+        self.statestack.append(0)
+
+    # Defaulted state support.
+    # This method identifies parser states where there is only one possible reduction action.
+    # For such states, the parser can make a choose to make a rule reduction without consuming
+    # the next look-ahead token.  This delayed invocation of the tokenizer can be useful in
+    # certain kinds of advanced parsing situations where the lexer and parser interact with
+    # each other or change states (i.e., manipulation of scope, lexer states, etc.).
+    #
+    # See:  http://www.gnu.org/software/bison/manual/html_node/Default-Reductions.html#Default-Reductions
+    def set_defaulted_states(self):
+        self.defaulted_states = {}
+        for state, actions in self.action.items():
+            rules = list(actions.values())
+            if len(rules) == 1 and rules[0] < 0:
+                self.defaulted_states[state] = rules[0]
+
+    def disable_defaulted_states(self):
+        self.defaulted_states = {}
+
+    # parse().
+    #
+    # This is the core parsing engine.  To operate, it requires a lexer object.
+    # Two options are provided.  The debug flag turns on debugging so that you can
+    # see the various rule reductions and parsing steps.  tracking turns on position
+    # tracking.  In this mode, symbols will record the starting/ending line number and
+    # character index.
+
+    def parse(self, input=None, lexer=None, debug=False, tracking=False, context=None):
+        # If debugging has been specified as a flag, turn it into a logging object
+        if isinstance(debug, int) and debug:
+            debug = PlyLogger(sys.stderr)
+
+        lookahead = None                         # Current lookahead symbol
+        lookaheadstack = []                      # Stack of lookahead symbols
+        actions = self.action                    # Local reference to action table (to avoid lookup on self.)
+        goto    = self.goto                      # Local reference to goto table (to avoid lookup on self.)
+        prod    = self.productions               # Local reference to production list (to avoid lookup on self.)
+        defaulted_states = self.defaulted_states # Local reference to defaulted states
+        pslice  = YaccProduction(None)           # Production object passed to grammar rules
+        errorcount = 0                           # Used during error recovery
+
+        if debug:
+            debug.info('PLY: PARSE DEBUG START')
+
+        # If no lexer was given, we will try to use the lex module
+        if not lexer:
+            from . import lex
+            lexer = lex.lexer
+
+        # Set up the lexer and parser objects on pslice
+        pslice.lexer = lexer
+        pslice.parser = self
+        pslice.context = context
+
+        # If input was supplied, pass to lexer
+        if input is not None:
+            lexer.input(input)
+
+        # Set the token function
+        get_token = self.token = lexer.token
+
+        # Set up the state and symbol stacks
+        statestack = self.statestack = []   # Stack of parsing states
+        symstack = self.symstack = []       # Stack of grammar symbols
+        pslice.stack = symstack             # Put in the production
+        errtoken   = None                   # Err token
+
+        # The start state is assumed to be (0,$end)
+
+        statestack.append(0)
+        sym = YaccSymbol()
+        sym.type = '$end'
+        symstack.append(sym)
+        state = 0
+                
+        # get number assignment to newline action
+        # cannot hardcode as python2 and python3 produce different
+        # numbers
+        newline = actions[state].get('NEWLINE')
+        while True:
+            # Get the next symbol on the input.  If a lookahead symbol
+            # is already set, we just use that. Otherwise, we'll pull
+            # the next token off of the lookaheadstack or from the lexer
+
+            if debug:
+                debug.debug('State  : %s', state)
+
+            if state not in defaulted_states:
+                if not lookahead:
+                    if not lookaheadstack:
+                        lookahead = get_token()     # Get the next token
+                    else:
+                        lookahead = lookaheadstack.pop()
+                    if not lookahead:
+                        lookahead = YaccSymbol()
+                        lookahead.type = '$end'
+
+                # Check the action table
+                ltype = lookahead.type
+                t = actions[state].get(ltype)
+            else:
+                t = defaulted_states[state]
+                if debug:
+                    debug.debug('Defaulted state %s: Reduce using %d', state, -t)
+
+            if debug:
+                debug.debug('Stack  : %s',
+                            ('%s . %s' % (' '.join([xx.type for xx in symstack][1:]), str(lookahead))).lstrip())
+
+            if state == 0 and ltype == '$end' and all([xx.type == 'NEWLINE' for xx in symstack[1:]]):
+                # we're at the end and everything else is a newline
+                # so we're going to return
+                # fixes multiple newlines at end
+                t = 0
+            if t is not None:
+                if t > 0:
+                    if t == newline and state == 0:
+                        # If in init state and \n is encountered, then shift the \n off the stack and continue
+                        # The shift off the stack is accomplished by just never adding it in the first place
+                        state = 0
+                    else:
+                        # shift a symbol on the stack
+                        statestack.append(t)
+                        state = t
+
+                    if debug:
+                        debug.debug('Action : Shift and goto state %s', t)
+
+                    symstack.append(lookahead)
+                    lookahead = None
+
+                    # Decrease error count on successful shift
+                    if errorcount:
+                        errorcount -= 1
+                    continue
+
+                if t < 0:
+                    # reduce a symbol on the stack, emit a production
+                    p = prod[-t]
+                    pname = p.name
+                    plen  = p.len
+                    accept = False
+
+                    # Get production function
+                    sym = YaccSymbol()
+                    sym.type = pname       # Production name
+                    sym.value = None
+
+                    if debug:
+                        if plen:
+                            debug.info('Action : Reduce rule [%s] with %s and goto state %d', p.str,
+                                       '['+','.join([format_stack_entry(_v.value) for _v in symstack[-plen:]])+']',
+                                       goto[statestack[-1-plen]][pname])
+                        else:
+                            debug.info('Action : Reduce rule [%s] with %s and goto state %d', p.str, [],
+                                       goto[statestack[-1]][pname])
+
+                    if plen:
+                        targ = symstack[-plen-1:]
+                        targ[0] = sym
+
+                        if tracking:
+                            t1 = targ[1]
+                            sym.lineno = t1.lineno
+                            sym.lexpos = t1.lexpos
+                            t1 = targ[-1]
+                            sym.endlineno = getattr(t1, 'endlineno', t1.lineno)
+                            sym.endlexpos = getattr(t1, 'endlexpos', t1.lexpos)
+
+                        # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+                        # The code enclosed in this section is duplicated
+                        # below as a performance optimization.  Make sure
+                        # changes get made in both locations.
+
+                        pslice.slice = targ
+
+                        try:
+                            # Call the grammar rule with our special slice object
+                            del symstack[-plen:]
+                            self.state = state
+                            try:
+                                p.callable(pslice)
+                            except YaccAccept:
+                                accept = True
+                            del statestack[-plen:]
+                            if debug:
+                                debug.info('Result : %s', format_result(pslice[0]))
+                            symstack.append(sym)
+                            state = goto[statestack[-1]][pname]
+                            statestack.append(state)
+                        except SyntaxError:
+                            # If an error was set. Enter error recovery state
+                            lookaheadstack.append(lookahead)    # Save the current lookahead token
+                            symstack.extend(targ[1:-1])         # Put the production slice back on the stack
+                            statestack.pop()                    # Pop back one state (before the reduce)
+                            state = statestack[-1]
+                            sym.type = 'error'
+                            sym.value = 'error'
+                            lookahead = sym
+                            errorcount = error_count
+                            self.errorok = False
+                        
+                        if not accept:
+                            continue
+
+                    else:
+
+                        if tracking:
+                            sym.lineno = lexer.lineno
+                            sym.lexpos = lexer.lexpos
+
+                        targ = [sym]
+
+                        # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+                        # The code enclosed in this section is duplicated
+                        # above as a performance optimization.  Make sure
+                        # changes get made in both locations.
+
+                        pslice.slice = targ
+
+                        try:
+                            # Call the grammar rule with our special slice object
+                            self.state = state
+                            p.callable(pslice)
+                            if debug:
+                                debug.info('Result : %s', format_result(pslice[0]))
+                            symstack.append(sym)
+                            state = goto[statestack[-1]][pname]
+                            statestack.append(state)
+                        except SyntaxError:
+                            # If an error was set. Enter error recovery state
+                            lookaheadstack.append(lookahead)    # Save the current lookahead token
+                            statestack.pop()                    # Pop back one state (before the reduce)
+                            state = statestack[-1]
+                            sym.type = 'error'
+                            sym.value = 'error'
+                            lookahead = sym
+                            errorcount = error_count
+                            self.errorok = False
+
+                        continue
+
+                if t == 0 or accept:
+                    n = symstack[-1]
+                    result = getattr(n, 'value', None)
+
+                    if debug:
+                        debug.info('Done   : Returning %s', format_result(result))
+                        debug.info('PLY: PARSE DEBUG END')
+
+                    return result
+
+            if t is None:
+
+                if debug:
+                    debug.error('Error  : %s',
+                                ('%s . %s' % (' '.join([xx.type for xx in symstack][1:]), str(lookahead))).lstrip())
+
+                # We have some kind of parsing error here.  To handle
+                # this, we are going to push the current token onto
+                # the tokenstack and replace it with an 'error' token.
+                # If there are any synchronization rules, they may
+                # catch it.
+                #
+                # In addition to pushing the error token, we call call
+                # the user defined p_error() function if this is the
+                # first syntax error.  This function is only called if
+                # errorcount == 0.
+                if errorcount == 0 or self.errorok:
+                    errorcount = error_count
+                    self.errorok = False
+                    errtoken = lookahead
+                    if errtoken.type == '$end':
+                        # errtoken = None               # End of file!
+                        pass
+                    if self.errorfunc:
+                        if errtoken and not hasattr(errtoken, 'lexer'):
+                            errtoken.lexer = lexer
+                        self.state = state
+                        tok = self.errorfunc(errtoken)
+                        if self.errorok:
+                            # User must have done some kind of panic
+                            # mode recovery on their own.  The
+                            # returned token is the next lookahead
+                            lookahead = tok
+                            errtoken = None
+                            continue
+                    else:
+                        if errtoken:
+                            if hasattr(errtoken, 'lineno'):
+                                lineno = lookahead.lineno
+                            else:
+                                lineno = 0
+                            if lineno:
+                                sys.stderr.write('yacc: Syntax error at line %d, token=%s\n' % (lineno, errtoken.type))
+                            else:
+                                sys.stderr.write('yacc: Syntax error, token=%s' % errtoken.type)
+                        else:
+                            sys.stderr.write('yacc: Parse error in input. EOF\n')
+                            return
+
+                else:
+                    errorcount = error_count
+
+                # case 1:  the statestack only has 1 entry on it.  If we're in this state, the
+                # entire parse has been rolled back and we're completely hosed.   The token is
+                # discarded and we just keep going.
+
+                if len(statestack) <= 1 and lookahead.type != '$end':
+                    lookahead = None
+                    errtoken = None
+                    state = 0
+                    # Nuke the pushback stack
+                    del lookaheadstack[:]
+                    continue
+
+                # case 2: the statestack has a couple of entries on it, but we're
+                # at the end of the file. nuke the top entry and generate an error token
+
+                # Start nuking entries on the stack
+                if lookahead.type == '$end':
+                    # Whoa. We're really hosed here. Bail out
+                    return
+
+                if lookahead.type != 'error':
+                    sym = symstack[-1]
+                    if sym.type == 'error':
+                        # Hmmm. Error is on top of stack, we'll just nuke input
+                        # symbol and continue
+                        if tracking:
+                            sym.endlineno = getattr(lookahead, 'lineno', sym.lineno)
+                            sym.endlexpos = getattr(lookahead, 'lexpos', sym.lexpos)
+                        lookahead = None
+                        continue
+
+                    # Create the error symbol for the first time and make it the new lookahead symbol
+                    t = YaccSymbol()
+                    t.type = 'error'
+
+                    if hasattr(lookahead, 'lineno'):
+                        t.lineno = t.endlineno = lookahead.lineno
+                    if hasattr(lookahead, 'lexpos'):
+                        t.lexpos = t.endlexpos = lookahead.lexpos
+                    t.value = lookahead
+                    lookaheadstack.append(lookahead)
+                    lookahead = t
+                else:
+                    sym = symstack.pop()
+                    if tracking:
+                        lookahead.lineno = sym.lineno
+                        lookahead.lexpos = sym.lexpos
+                    statestack.pop()
+                    state = statestack[-1]
+
+                continue
+
+            # If we'r here, something really bad happened
+            raise RuntimeError('yacc: internal parser error!!!\n')
+
+# -----------------------------------------------------------------------------
+#                          === Grammar Representation ===
+#
+# The following functions, classes, and variables are used to represent and
+# manipulate the rules that make up a grammar.
+# -----------------------------------------------------------------------------
+
+# regex matching identifiers
+_is_identifier = re.compile(r'^[a-zA-Z0-9_-]+$')
+
+# -----------------------------------------------------------------------------
+# class Production:
+#
+# This class stores the raw information about a single production or grammar rule.
+# A grammar rule refers to a specification such as this:
+#
+#       expr : expr PLUS term
+#
+# Here are the basic attributes defined on all productions
+#
+#       name     - Name of the production.  For example 'expr'
+#       prod     - A list of symbols on the right side ['expr','PLUS','term']
+#       prec     - Production precedence level
+#       number   - Production number.
+#       func     - Function that executes on reduce
+#       file     - File where production function is defined
+#       lineno   - Line number where production function is defined
+#
+# The following attributes are defined or optional.
+#
+#       len       - Length of the production (number of symbols on right hand side)
+#       usyms     - Set of unique symbols found in the production
+# -----------------------------------------------------------------------------
+
+class Production(object):
+    reduced = 0
+    def __init__(self, number, name, prod, precedence=('right', 0), func=None, file='', line=0):
+        self.name     = name
+        self.prod     = tuple(prod)
+        self.number   = number
+        self.func     = func
+        self.callable = None
+        self.file     = file
+        self.line     = line
+        self.prec     = precedence
+
+        # Internal settings used during table construction
+
+        self.len  = len(self.prod)   # Length of the production
+
+        # Create a list of unique production symbols used in the production
+        self.usyms = []
+        for s in self.prod:
+            if s not in self.usyms:
+                self.usyms.append(s)
+
+        # List of all LR items for the production
+        self.lr_items = []
+        self.lr_next = None
+
+        # Create a string representation
+        if self.prod:
+            self.str = '%s -> %s' % (self.name, ' '.join(self.prod))
+        else:
+            self.str = '%s -> <empty>' % self.name
+
+    def __str__(self):
+        return self.str
+
+    def __repr__(self):
+        return 'Production(' + str(self) + ')'
+
+    def __len__(self):
+        return len(self.prod)
+
+    def __nonzero__(self):
+        return 1
+
+    def __getitem__(self, index):
+        return self.prod[index]
+
+    # Return the nth lr_item from the production (or None if at the end)
+    def lr_item(self, n):
+        if n > len(self.prod):
+            return None
+        p = LRItem(self, n)
+        # Precompute the list of productions immediately following.
+        try:
+            p.lr_after = self.Prodnames[p.prod[n+1]]
+        except (IndexError, KeyError):
+            p.lr_after = []
+        try:
+            p.lr_before = p.prod[n-1]
+        except IndexError:
+            p.lr_before = None
+        return p
+
+    # Bind the production function name to a callable
+    def bind(self, pdict):
+        if self.func:
+            self.callable = pdict[self.func]
+
+# -----------------------------------------------------------------------------
+# class LRItem
+#
+# This class represents a specific stage of parsing a production rule.  For
+# example:
+#
+#       expr : expr . PLUS term
+#
+# In the above, the "." represents the current location of the parse.  Here
+# basic attributes:
+#
+#       name       - Name of the production.  For example 'expr'
+#       prod       - A list of symbols on the right side ['expr','.', 'PLUS','term']
+#       number     - Production number.
+#
+#       lr_next      Next LR item. Example, if we are ' expr -> expr . PLUS term'
+#                    then lr_next refers to 'expr -> expr PLUS . term'
+#       lr_index   - LR item index (location of the ".") in the prod list.
+#       lookaheads - LALR lookahead symbols for this item
+#       len        - Length of the production (number of symbols on right hand side)
+#       lr_after    - List of all productions that immediately follow
+#       lr_before   - Grammar symbol immediately before
+# -----------------------------------------------------------------------------
+
+class LRItem(object):
+    def __init__(self, p, n):
+        self.name       = p.name
+        self.prod       = list(p.prod)
+        self.number     = p.number
+        self.lr_index   = n
+        self.lookaheads = {}
+        self.prod.insert(n, '.')
+        self.prod       = tuple(self.prod)
+        self.len        = len(self.prod)
+        self.usyms      = p.usyms
+
+    def __str__(self):
+        if self.prod:
+            s = '%s -> %s' % (self.name, ' '.join(self.prod))
+        else:
+            s = '%s -> <empty>' % self.name
+        return s
+
+    def __repr__(self):
+        return 'LRItem(' + str(self) + ')'
+
+# -----------------------------------------------------------------------------
+# rightmost_terminal()
+#
+# Return the rightmost terminal from a list of symbols.  Used in add_production()
+# -----------------------------------------------------------------------------
+def rightmost_terminal(symbols, terminals):
+    i = len(symbols) - 1
+    while i >= 0:
+        if symbols[i] in terminals:
+            return symbols[i]
+        i -= 1
+    return None
+
+# -----------------------------------------------------------------------------
+#                           === GRAMMAR CLASS ===
+#
+# The following class represents the contents of the specified grammar along
+# with various computed properties such as first sets, follow sets, LR items, etc.
+# This data is used for critical parts of the table generation process later.
+# -----------------------------------------------------------------------------
+
+class GrammarError(YaccError):
+    pass
+
+class Grammar(object):
+    def __init__(self, terminals):
+        self.Productions  = [None]  # A list of all of the productions.  The first
+                                    # entry is always reserved for the purpose of
+                                    # building an augmented grammar
+
+        self.Prodnames    = {}      # A dictionary mapping the names of nonterminals to a list of all
+                                    # productions of that nonterminal.
+
+        self.Prodmap      = {}      # A dictionary that is only used to detect duplicate
+                                    # productions.
+
+        self.Terminals    = {}      # A dictionary mapping the names of terminal symbols to a
+                                    # list of the rules where they are used.
+
+        for term in terminals:
+            self.Terminals[term] = []
+
+        self.Terminals['error'] = []
+
+        self.Nonterminals = {}      # A dictionary mapping names of nonterminals to a list
+                                    # of rule numbers where they are used.
+
+        self.First        = {}      # A dictionary of precomputed FIRST(x) symbols
+
+        self.Follow       = {}      # A dictionary of precomputed FOLLOW(x) symbols
+
+        self.Precedence   = {}      # Precedence rules for each terminal. Contains tuples of the
+                                    # form ('right',level) or ('nonassoc', level) or ('left',level)
+
+        self.UsedPrecedence = set() # Precedence rules that were actually used by the grammer.
+                                    # This is only used to provide error checking and to generate
+                                    # a warning about unused precedence rules.
+
+        self.Start = None           # Starting symbol for the grammar
+
+
+    def __len__(self):
+        return len(self.Productions)
+
+    def __getitem__(self, index):
+        return self.Productions[index]
+
+    # -----------------------------------------------------------------------------
+    # set_precedence()
+    #
+    # Sets the precedence for a given terminal. assoc is the associativity such as
+    # 'left','right', or 'nonassoc'.  level is a numeric level.
+    #
+    # -----------------------------------------------------------------------------
+
+    def set_precedence(self, term, assoc, level):
+        assert self.Productions == [None], 'Must call set_precedence() before add_production()'
+        if term in self.Precedence:
+            raise GrammarError('Precedence already specified for terminal %r' % term)
+        if assoc not in ['left', 'right', 'nonassoc']:
+            raise GrammarError("Associativity must be one of 'left','right', or 'nonassoc'")
+        self.Precedence[term] = (assoc, level)
+
+    # -----------------------------------------------------------------------------
+    # add_production()
+    #
+    # Given an action function, this function assembles a production rule and
+    # computes its precedence level.
+    #
+    # The production rule is supplied as a list of symbols.   For example,
+    # a rule such as 'expr : expr PLUS term' has a production name of 'expr' and
+    # symbols ['expr','PLUS','term'].
+    #
+    # Precedence is determined by the precedence of the right-most non-terminal
+    # or the precedence of a terminal specified by %prec.
+    #
+    # A variety of error checks are performed to make sure production symbols
+    # are valid and that %prec is used correctly.
+    # -----------------------------------------------------------------------------
+
+    def add_production(self, prodname, syms, func=None, file='', line=0):
+
+        if prodname in self.Terminals:
+            raise GrammarError('%s:%d: Illegal rule name %r. Already defined as a token' % (file, line, prodname))
+        if prodname == 'error':
+            raise GrammarError('%s:%d: Illegal rule name %r. error is a reserved word' % (file, line, prodname))
+        if not _is_identifier.match(prodname):
+            raise GrammarError('%s:%d: Illegal rule name %r' % (file, line, prodname))
+
+        # Look for literal tokens
+        for n, s in enumerate(syms):
+            if s[0] in "'\"":
+                try:
+                    c = eval(s)
+                    if (len(c) > 1):
+                        raise GrammarError('%s:%d: Literal token %s in rule %r may only be a single character' %
+                                           (file, line, s, prodname))
+                    if c not in self.Terminals:
+                        self.Terminals[c] = []
+                    syms[n] = c
+                    continue
+                except SyntaxError:
+                    pass
+            if not _is_identifier.match(s) and s != '%prec':
+                raise GrammarError('%s:%d: Illegal name %r in rule %r' % (file, line, s, prodname))
+
+        # Determine the precedence level
+        if '%prec' in syms:
+            if syms[-1] == '%prec':
+                raise GrammarError('%s:%d: Syntax error. Nothing follows %%prec' % (file, line))
+            if syms[-2] != '%prec':
+                raise GrammarError('%s:%d: Syntax error. %%prec can only appear at the end of a grammar rule' %
+                                   (file, line))
+            precname = syms[-1]
+            prodprec = self.Precedence.get(precname)
+            if not prodprec:
+                raise GrammarError('%s:%d: Nothing known about the precedence of %r' % (file, line, precname))
+            else:
+                self.UsedPrecedence.add(precname)
+            del syms[-2:]     # Drop %prec from the rule
+        else:
+            # If no %prec, precedence is determined by the rightmost terminal symbol
+            precname = rightmost_terminal(syms, self.Terminals)
+            prodprec = self.Precedence.get(precname, ('right', 0))
+
+        # See if the rule is already in the rulemap
+        map = '%s -> %s' % (prodname, syms)
+        if map in self.Prodmap:
+            m = self.Prodmap[map]
+            raise GrammarError('%s:%d: Duplicate rule %s. ' % (file, line, m) +
+                               'Previous definition at %s:%d' % (m.file, m.line))
+
+        # From this point on, everything is valid.  Create a new Production instance
+        pnumber  = len(self.Productions)
+        if prodname not in self.Nonterminals:
+            self.Nonterminals[prodname] = []
+
+        # Add the production number to Terminals and Nonterminals
+        for t in syms:
+            if t in self.Terminals:
+                self.Terminals[t].append(pnumber)
+            else:
+                if t not in self.Nonterminals:
+                    self.Nonterminals[t] = []
+                self.Nonterminals[t].append(pnumber)
+
+        # Create a production and add it to the list of productions
+        p = Production(pnumber, prodname, syms, prodprec, func, file, line)
+        self.Productions.append(p)
+        self.Prodmap[map] = p
+
+        # Add to the global productions list
+        try:
+            self.Prodnames[prodname].append(p)
+        except KeyError:
+            self.Prodnames[prodname] = [p]
+
+    # -----------------------------------------------------------------------------
+    # set_start()
+    #
+    # Sets the starting symbol and creates the augmented grammar.  Production
+    # rule 0 is S' -> start where start is the start symbol.
+    # -----------------------------------------------------------------------------
+
+    def set_start(self, start=None):
+        if not start:
+            start = self.Productions[1].name
+        if start not in self.Nonterminals:
+            raise GrammarError('start symbol %s undefined' % start)
+        self.Productions[0] = Production(0, "S'", [start])
+        self.Nonterminals[start].append(0)
+        self.Start = start
+
+    # -----------------------------------------------------------------------------
+    # find_unreachable()
+    #
+    # Find all of the nonterminal symbols that can't be reached from the starting
+    # symbol.  Returns a list of nonterminals that can't be reached.
+    # -----------------------------------------------------------------------------
+
+    def find_unreachable(self):
+
+        # Mark all symbols that are reachable from a symbol s
+        def mark_reachable_from(s):
+            if s in reachable:
+                return
+            reachable.add(s)
+            for p in self.Prodnames.get(s, []):
+                for r in p.prod:
+                    mark_reachable_from(r)
+
+        reachable = set()
+        mark_reachable_from(self.Productions[0].prod[0])
+        return [s for s in self.Nonterminals if s not in reachable]
+
+    # -----------------------------------------------------------------------------
+    # infinite_cycles()
+    #
+    # This function looks at the various parsing rules and tries to detect
+    # infinite recursion cycles (grammar rules where there is no possible way
+    # to derive a string of only terminals).
+    # -----------------------------------------------------------------------------
+
+    def infinite_cycles(self):
+        terminates = {}
+
+        # Terminals:
+        for t in self.Terminals:
+            terminates[t] = True
+
+        terminates['$end'] = True
+
+        # Nonterminals:
+
+        # Initialize to false:
+        for n in self.Nonterminals:
+            terminates[n] = False
+
+        # Then propagate termination until no change:
+        while True:
+            some_change = False
+            for (n, pl) in self.Prodnames.items():
+                # Nonterminal n terminates iff any of its productions terminates.
+                for p in pl:
+                    # Production p terminates iff all of its rhs symbols terminate.
+                    for s in p.prod:
+                        if not terminates[s]:
+                            # The symbol s does not terminate,
+                            # so production p does not terminate.
+                            p_terminates = False
+                            break
+                    else:
+                        # didn't break from the loop,
+                        # so every symbol s terminates
+                        # so production p terminates.
+                        p_terminates = True
+
+                    if p_terminates:
+                        # symbol n terminates!
+                        if not terminates[n]:
+                            terminates[n] = True
+                            some_change = True
+                        # Don't need to consider any more productions for this n.
+                        break
+
+            if not some_change:
+                break
+
+        infinite = []
+        for (s, term) in terminates.items():
+            if not term:
+                if s not in self.Prodnames and s not in self.Terminals and s != 'error':
+                    # s is used-but-not-defined, and we've already warned of that,
+                    # so it would be overkill to say that it's also non-terminating.
+                    pass
+                else:
+                    infinite.append(s)
+
+        return infinite
+
+    # -----------------------------------------------------------------------------
+    # undefined_symbols()
+    #
+    # Find all symbols that were used the grammar, but not defined as tokens or
+    # grammar rules.  Returns a list of tuples (sym, prod) where sym in the symbol
+    # and prod is the production where the symbol was used.
+    # -----------------------------------------------------------------------------
+    def undefined_symbols(self):
+        result = []
+        for p in self.Productions:
+            if not p:
+                continue
+
+            for s in p.prod:
+                if s not in self.Prodnames and s not in self.Terminals and s != 'error':
+                    result.append((s, p))
+        return result
+
+    # -----------------------------------------------------------------------------
+    # unused_terminals()
+    #
+    # Find all terminals that were defined, but not used by the grammar.  Returns
+    # a list of all symbols.
+    # -----------------------------------------------------------------------------
+    def unused_terminals(self):
+        unused_tok = []
+        for s, v in self.Terminals.items():
+            if s != 'error' and not v:
+                unused_tok.append(s)
+
+        return unused_tok
+
+    # ------------------------------------------------------------------------------
+    # unused_rules()
+    #
+    # Find all grammar rules that were defined,  but not used (maybe not reachable)
+    # Returns a list of productions.
+    # ------------------------------------------------------------------------------
+
+    def unused_rules(self):
+        unused_prod = []
+        for s, v in self.Nonterminals.items():
+            if not v:
+                p = self.Prodnames[s][0]
+                unused_prod.append(p)
+        return unused_prod
+
+    # -----------------------------------------------------------------------------
+    # unused_precedence()
+    #
+    # Returns a list of tuples (term,precedence) corresponding to precedence
+    # rules that were never used by the grammar.  term is the name of the terminal
+    # on which precedence was applied and precedence is a string such as 'left' or
+    # 'right' corresponding to the type of precedence.
+    # -----------------------------------------------------------------------------
+
+    def unused_precedence(self):
+        unused = []
+        for termname in self.Precedence:
+            if not (termname in self.Terminals or termname in self.UsedPrecedence):
+                unused.append((termname, self.Precedence[termname][0]))
+
+        return unused
+
+    # -------------------------------------------------------------------------
+    # _first()
+    #
+    # Compute the value of FIRST1(beta) where beta is a tuple of symbols.
+    #
+    # During execution of compute_first1, the result may be incomplete.
+    # Afterward (e.g., when called from compute_follow()), it will be complete.
+    # -------------------------------------------------------------------------
+    def _first(self, beta):
+
+        # We are computing First(x1,x2,x3,...,xn)
+        result = []
+        for x in beta:
+            x_produces_empty = False
+
+            # Add all the non-<empty> symbols of First[x] to the result.
+            for f in self.First[x]:
+                if f == '<empty>':
+                    x_produces_empty = True
+                else:
+                    if f not in result:
+                        result.append(f)
+
+            if x_produces_empty:
+                # We have to consider the next x in beta,
+                # i.e. stay in the loop.
+                pass
+            else:
+                # We don't have to consider any further symbols in beta.
+                break
+        else:
+            # There was no 'break' from the loop,
+            # so x_produces_empty was true for all x in beta,
+            # so beta produces empty as well.
+            result.append('<empty>')
+
+        return result
+
+    # -------------------------------------------------------------------------
+    # compute_first()
+    #
+    # Compute the value of FIRST1(X) for all symbols
+    # -------------------------------------------------------------------------
+    def compute_first(self):
+        if self.First:
+            return self.First
+
+        # Terminals:
+        for t in self.Terminals:
+            self.First[t] = [t]
+
+        self.First['$end'] = ['$end']
+
+        # Nonterminals:
+
+        # Initialize to the empty set:
+        for n in self.Nonterminals:
+            self.First[n] = []
+
+        # Then propagate symbols until no change:
+        while True:
+            some_change = False
+            for n in self.Nonterminals:
+                for p in self.Prodnames[n]:
+                    for f in self._first(p.prod):
+                        if f not in self.First[n]:
+                            self.First[n].append(f)
+                            some_change = True
+            if not some_change:
+                break
+
+        return self.First
+
+    # ---------------------------------------------------------------------
+    # compute_follow()
+    #
+    # Computes all of the follow sets for every non-terminal symbol.  The
+    # follow set is the set of all symbols that might follow a given
+    # non-terminal.  See the Dragon book, 2nd Ed. p. 189.
+    # ---------------------------------------------------------------------
+    def compute_follow(self, start=None):
+        # If already computed, return the result
+        if self.Follow:
+            return self.Follow
+
+        # If first sets not computed yet, do that first.
+        if not self.First:
+            self.compute_first()
+
+        # Add '$end' to the follow list of the start symbol
+        for k in self.Nonterminals:
+            self.Follow[k] = []
+
+        if not start:
+            start = self.Productions[1].name
+
+        self.Follow[start] = ['$end']
+
+        while True:
+            didadd = False
+            for p in self.Productions[1:]:
+                # Here is the production set
+                for i, B in enumerate(p.prod):
+                    if B in self.Nonterminals:
+                        # Okay. We got a non-terminal in a production
+                        fst = self._first(p.prod[i+1:])
+                        hasempty = False
+                        for f in fst:
+                            if f != '<empty>' and f not in self.Follow[B]:
+                                self.Follow[B].append(f)
+                                didadd = True
+                            if f == '<empty>':
+                                hasempty = True
+                        if hasempty or i == (len(p.prod)-1):
+                            # Add elements of follow(a) to follow(b)
+                            for f in self.Follow[p.name]:
+                                if f not in self.Follow[B]:
+                                    self.Follow[B].append(f)
+                                    didadd = True
+            if not didadd:
+                break
+        return self.Follow
+
+
+    # -----------------------------------------------------------------------------
+    # build_lritems()
+    #
+    # This function walks the list of productions and builds a complete set of the
+    # LR items.  The LR items are stored in two ways:  First, they are uniquely
+    # numbered and placed in the list _lritems.  Second, a linked list of LR items
+    # is built for each production.  For example:
+    #
+    #   E -> E PLUS E
+    #
+    # Creates the list
+    #
+    #  [E -> . E PLUS E, E -> E . PLUS E, E -> E PLUS . E, E -> E PLUS E . ]
+    # -----------------------------------------------------------------------------
+
+    def build_lritems(self):
+        for p in self.Productions:
+            lastlri = p
+            i = 0
+            lr_items = []
+            while True:
+                if i > len(p):
+                    lri = None
+                else:
+                    lri = LRItem(p, i)
+                    # Precompute the list of productions immediately following
+                    try:
+                        lri.lr_after = self.Prodnames[lri.prod[i+1]]
+                    except (IndexError, KeyError):
+                        lri.lr_after = []
+                    try:
+                        lri.lr_before = lri.prod[i-1]
+                    except IndexError:
+                        lri.lr_before = None
+
+                lastlri.lr_next = lri
+                if not lri:
+                    break
+                lr_items.append(lri)
+                lastlri = lri
+                i += 1
+            p.lr_items = lr_items
+
+# -----------------------------------------------------------------------------
+#                           === LR Generator ===
+#
+# The following classes and functions are used to generate LR parsing tables on
+# a grammar.
+# -----------------------------------------------------------------------------
+
+# -----------------------------------------------------------------------------
+# digraph()
+# traverse()
+#
+# The following two functions are used to compute set valued functions
+# of the form:
+#
+#     F(x) = F'(x) U U{F(y) | x R y}
+#
+# This is used to compute the values of Read() sets as well as FOLLOW sets
+# in LALR(1) generation.
+#
+# Inputs:  X    - An input set
+#          R    - A relation
+#          FP   - Set-valued function
+# ------------------------------------------------------------------------------
+
+def digraph(X, R, FP):
+    N = {}
+    for x in X:
+        N[x] = 0
+    stack = []
+    F = {}
+    for x in X:
+        if N[x] == 0:
+            traverse(x, N, stack, F, X, R, FP)
+    return F
+
+def traverse(x, N, stack, F, X, R, FP):
+    stack.append(x)
+    d = len(stack)
+    N[x] = d
+    F[x] = FP(x)             # F(X) <- F'(x)
+
+    rel = R(x)               # Get y's related to x
+    for y in rel:
+        if N[y] == 0:
+            traverse(y, N, stack, F, X, R, FP)
+        N[x] = min(N[x], N[y])
+        for a in F.get(y, []):
+            if a not in F[x]:
+                F[x].append(a)
+    if N[x] == d:
+        N[stack[-1]] = MAXINT
+        F[stack[-1]] = F[x]
+        element = stack.pop()
+        while element != x:
+            N[stack[-1]] = MAXINT
+            F[stack[-1]] = F[x]
+            element = stack.pop()
+
+class LALRError(YaccError):
+    pass
+
+
+# -----------------------------------------------------------------------------
+#                             == LRTable ==
+#
+# This class implements the LR table generation algorithm.  There are no
+# public methods.
+# -----------------------------------------------------------------------------
+
+class LRTable:
+    def __init__(self, grammar, log=None):
+        self.grammar = grammar
+
+        # Set up the logger
+        if not log:
+            log = NullLogger()
+        self.log = log
+
+        # Internal attributes
+        self.lr_action     = {}        # Action table
+        self.lr_goto       = {}        # Goto table
+        self.lr_productions  = grammar.Productions    # Copy of grammar Production array
+        self.lr_goto_cache = {}        # Cache of computed gotos
+        self.lr0_cidhash   = {}        # Cache of closures
+
+        self._add_count    = 0         # Internal counter used to detect cycles
+
+        # Diagnostic information filled in by the table generator
+        self.sr_conflict   = 0
+        self.rr_conflict   = 0
+        self.conflicts     = []        # List of conflicts
+
+        self.sr_conflicts  = []
+        self.rr_conflicts  = []
+
+        # Build the tables
+        self.grammar.build_lritems()
+        self.grammar.compute_first()
+        self.grammar.compute_follow()
+        self.lr_parse_table()
+
+    # Bind all production function names to callable objects in pdict
+    def bind_callables(self, pdict):
+        for p in self.lr_productions:
+            p.bind(pdict)
+
+    # Compute the LR(0) closure operation on I, where I is a set of LR(0) items.
+
+    def lr0_closure(self, I):
+        self._add_count += 1
+
+        # Add everything in I to J
+        J = I[:]
+        didadd = True
+        while didadd:
+            didadd = False
+            for j in J:
+                for x in j.lr_after:
+                    if getattr(x, 'lr0_added', 0) == self._add_count:
+                        continue
+                    # Add B --> .G to J
+                    J.append(x.lr_next)
+                    x.lr0_added = self._add_count
+                    didadd = True
+
+        return J
+
+    # Compute the LR(0) goto function goto(I,X) where I is a set
+    # of LR(0) items and X is a grammar symbol.   This function is written
+    # in a way that guarantees uniqueness of the generated goto sets
+    # (i.e. the same goto set will never be returned as two different Python
+    # objects).  With uniqueness, we can later do fast set comparisons using
+    # id(obj) instead of element-wise comparison.
+
+    def lr0_goto(self, I, x):
+        # First we look for a previously cached entry
+        g = self.lr_goto_cache.get((id(I), x))
+        if g:
+            return g
+
+        # Now we generate the goto set in a way that guarantees uniqueness
+        # of the result
+
+        s = self.lr_goto_cache.get(x)
+        if not s:
+            s = {}
+            self.lr_goto_cache[x] = s
+
+        gs = []
+        for p in I:
+            n = p.lr_next
+            if n and n.lr_before == x:
+                s1 = s.get(id(n))
+                if not s1:
+                    s1 = {}
+                    s[id(n)] = s1
+                gs.append(n)
+                s = s1
+        g = s.get('$end')
+        if not g:
+            if gs:
+                g = self.lr0_closure(gs)
+                s['$end'] = g
+            else:
+                s['$end'] = gs
+        self.lr_goto_cache[(id(I), x)] = g
+        return g
+
+    # Compute the LR(0) sets of item function
+    def lr0_items(self):
+        C = [self.lr0_closure([self.grammar.Productions[0].lr_next])]
+        i = 0
+        for I in C:
+            self.lr0_cidhash[id(I)] = i
+            i += 1
+
+        # Loop over the items in C and each grammar symbols
+        i = 0
+        while i < len(C):
+            I = C[i]
+            i += 1
+
+            # Collect all of the symbols that could possibly be in the goto(I,X) sets
+            asyms = {}
+            for ii in I:
+                for s in ii.usyms:
+                    asyms[s] = None
+
+            for x in asyms:
+                g = self.lr0_goto(I, x)
+                if not g or id(g) in self.lr0_cidhash:
+                    continue
+                self.lr0_cidhash[id(g)] = len(C)
+                C.append(g)
+
+        return C
+
+    # -----------------------------------------------------------------------------
+    #                       ==== LALR(1) Parsing ====
+    #
+    # LALR(1) parsing is almost exactly the same as SLR except that instead of
+    # relying upon Follow() sets when performing reductions, a more selective
+    # lookahead set that incorporates the state of the LR(0) machine is utilized.
+    # Thus, we mainly just have to focus on calculating the lookahead sets.
+    #
+    # The method used here is due to DeRemer and Pennelo (1982).
+    #
+    # DeRemer, F. L., and T. J. Pennelo: "Efficient Computation of LALR(1)
+    #     Lookahead Sets", ACM Transactions on Programming Languages and Systems,
+    #     Vol. 4, No. 4, Oct. 1982, pp. 615-649
+    #
+    # Further details can also be found in:
+    #
+    #  J. Tremblay and P. Sorenson, "The Theory and Practice of Compiler Writing",
+    #      McGraw-Hill Book Company, (1985).
+    #
+    # -----------------------------------------------------------------------------
+
+    # -----------------------------------------------------------------------------
+    # compute_nullable_nonterminals()
+    #
+    # Creates a dictionary containing all of the non-terminals that might produce
+    # an empty production.
+    # -----------------------------------------------------------------------------
+
+    def compute_nullable_nonterminals(self):
+        nullable = set()
+        num_nullable = 0
+        while True:
+            for p in self.grammar.Productions[1:]:
+                if p.len == 0:
+                    nullable.add(p.name)
+                    continue
+                for t in p.prod:
+                    if t not in nullable:
+                        break
+                else:
+                    nullable.add(p.name)
+            if len(nullable) == num_nullable:
+                break
+            num_nullable = len(nullable)
+        return nullable
+
+    # -----------------------------------------------------------------------------
+    # find_nonterminal_trans(C)
+    #
+    # Given a set of LR(0) items, this functions finds all of the non-terminal
+    # transitions.    These are transitions in which a dot appears immediately before
+    # a non-terminal.   Returns a list of tuples of the form (state,N) where state
+    # is the state number and N is the nonterminal symbol.
+    #
+    # The input C is the set of LR(0) items.
+    # -----------------------------------------------------------------------------
+
+    def find_nonterminal_transitions(self, C):
+        trans = []
+        for stateno, state in enumerate(C):
+            for p in state:
+                if p.lr_index < p.len - 1:
+                    t = (stateno, p.prod[p.lr_index+1])
+                    if t[1] in self.grammar.Nonterminals:
+                        if t not in trans:
+                            trans.append(t)
+        return trans
+
+    # -----------------------------------------------------------------------------
+    # dr_relation()
+    #
+    # Computes the DR(p,A) relationships for non-terminal transitions.  The input
+    # is a tuple (state,N) where state is a number and N is a nonterminal symbol.
+    #
+    # Returns a list of terminals.
+    # -----------------------------------------------------------------------------
+
+    def dr_relation(self, C, trans, nullable):
+        state, N = trans
+        terms = []
+
+        g = self.lr0_goto(C[state], N)
+        for p in g:
+            if p.lr_index < p.len - 1:
+                a = p.prod[p.lr_index+1]
+                if a in self.grammar.Terminals:
+                    if a not in terms:
+                        terms.append(a)
+
+        # This extra bit is to handle the start state
+        if state == 0 and N == self.grammar.Productions[0].prod[0]:
+            terms.append('$end')
+
+        return terms
+
+    # -----------------------------------------------------------------------------
+    # reads_relation()
+    #
+    # Computes the READS() relation (p,A) READS (t,C).
+    # -----------------------------------------------------------------------------
+
+    def reads_relation(self, C, trans, empty):
+        # Look for empty transitions
+        rel = []
+        state, N = trans
+
+        g = self.lr0_goto(C[state], N)
+        j = self.lr0_cidhash.get(id(g), -1)
+        for p in g:
+            if p.lr_index < p.len - 1:
+                a = p.prod[p.lr_index + 1]
+                if a in empty:
+                    rel.append((j, a))
+
+        return rel
+
+    # -----------------------------------------------------------------------------
+    # compute_lookback_includes()
+    #
+    # Determines the lookback and includes relations
+    #
+    # LOOKBACK:
+    #
+    # This relation is determined by running the LR(0) state machine forward.
+    # For example, starting with a production "N : . A B C", we run it forward
+    # to obtain "N : A B C ."   We then build a relationship between this final
+    # state and the starting state.   These relationships are stored in a dictionary
+    # lookdict.
+    #
+    # INCLUDES:
+    #
+    # Computes the INCLUDE() relation (p,A) INCLUDES (p',B).
+    #
+    # This relation is used to determine non-terminal transitions that occur
+    # inside of other non-terminal transition states.   (p,A) INCLUDES (p', B)
+    # if the following holds:
+    #
+    #       B -> LAT, where T -> epsilon and p' -L-> p
+    #
+    # L is essentially a prefix (which may be empty), T is a suffix that must be
+    # able to derive an empty string.  State p' must lead to state p with the string L.
+    #
+    # -----------------------------------------------------------------------------
+
+    def compute_lookback_includes(self, C, trans, nullable):
+        lookdict = {}          # Dictionary of lookback relations
+        includedict = {}       # Dictionary of include relations
+
+        # Make a dictionary of non-terminal transitions
+        dtrans = {}
+        for t in trans:
+            dtrans[t] = 1
+
+        # Loop over all transitions and compute lookbacks and includes
+        for state, N in trans:
+            lookb = []
+            includes = []
+            for p in C[state]:
+                if p.name != N:
+                    continue
+
+                # Okay, we have a name match.  We now follow the production all the way
+                # through the state machine until we get the . on the right hand side
+
+                lr_index = p.lr_index
+                j = state
+                while lr_index < p.len - 1:
+                    lr_index = lr_index + 1
+                    t = p.prod[lr_index]
+
+                    # Check to see if this symbol and state are a non-terminal transition
+                    if (j, t) in dtrans:
+                        # Yes.  Okay, there is some chance that this is an includes relation
+                        # the only way to know for certain is whether the rest of the
+                        # production derives empty
+
+                        li = lr_index + 1
+                        while li < p.len:
+                            if p.prod[li] in self.grammar.Terminals:
+                                break      # No forget it
+                            if p.prod[li] not in nullable:
+                                break
+                            li = li + 1
+                        else:
+                            # Appears to be a relation between (j,t) and (state,N)
+                            includes.append((j, t))
+
+                    g = self.lr0_goto(C[j], t)               # Go to next set
+                    j = self.lr0_cidhash.get(id(g), -1)      # Go to next state
+
+                # When we get here, j is the final state, now we have to locate the production
+                for r in C[j]:
+                    if r.name != p.name:
+                        continue
+                    if r.len != p.len:
+                        continue
+                    i = 0
+                    # This look is comparing a production ". A B C" with "A B C ."
+                    while i < r.lr_index:
+                        if r.prod[i] != p.prod[i+1]:
+                            break
+                        i = i + 1
+                    else:
+                        lookb.append((j, r))
+            for i in includes:
+                if i not in includedict:
+                    includedict[i] = []
+                includedict[i].append((state, N))
+            lookdict[(state, N)] = lookb
+
+        return lookdict, includedict
+
+    # -----------------------------------------------------------------------------
+    # compute_read_sets()
+    #
+    # Given a set of LR(0) items, this function computes the read sets.
+    #
+    # Inputs:  C        =  Set of LR(0) items
+    #          ntrans   = Set of nonterminal transitions
+    #          nullable = Set of empty transitions
+    #
+    # Returns a set containing the read sets
+    # -----------------------------------------------------------------------------
+
+    def compute_read_sets(self, C, ntrans, nullable):
+        FP = lambda x: self.dr_relation(C, x, nullable)
+        R =  lambda x: self.reads_relation(C, x, nullable)
+        F = digraph(ntrans, R, FP)
+        return F
+
+    # -----------------------------------------------------------------------------
+    # compute_follow_sets()
+    #
+    # Given a set of LR(0) items, a set of non-terminal transitions, a readset,
+    # and an include set, this function computes the follow sets
+    #
+    # Follow(p,A) = Read(p,A) U U {Follow(p',B) | (p,A) INCLUDES (p',B)}
+    #
+    # Inputs:
+    #            ntrans     = Set of nonterminal transitions
+    #            readsets   = Readset (previously computed)
+    #            inclsets   = Include sets (previously computed)
+    #
+    # Returns a set containing the follow sets
+    # -----------------------------------------------------------------------------
+
+    def compute_follow_sets(self, ntrans, readsets, inclsets):
+        FP = lambda x: readsets[x]
+        R  = lambda x: inclsets.get(x, [])
+        F = digraph(ntrans, R, FP)
+        return F
+
+    # -----------------------------------------------------------------------------
+    # add_lookaheads()
+    #
+    # Attaches the lookahead symbols to grammar rules.
+    #
+    # Inputs:    lookbacks         -  Set of lookback relations
+    #            followset         -  Computed follow set
+    #
+    # This function directly attaches the lookaheads to productions contained
+    # in the lookbacks set
+    # -----------------------------------------------------------------------------
+
+    def add_lookaheads(self, lookbacks, followset):
+        for trans, lb in lookbacks.items():
+            # Loop over productions in lookback
+            for state, p in lb:
+                if state not in p.lookaheads:
+                    p.lookaheads[state] = []
+                f = followset.get(trans, [])
+                for a in f:
+                    if a not in p.lookaheads[state]:
+                        p.lookaheads[state].append(a)
+
+    # -----------------------------------------------------------------------------
+    # add_lalr_lookaheads()
+    #
+    # This function does all of the work of adding lookahead information for use
+    # with LALR parsing
+    # -----------------------------------------------------------------------------
+
+    def add_lalr_lookaheads(self, C):
+        # Determine all of the nullable nonterminals
+        nullable = self.compute_nullable_nonterminals()
+
+        # Find all non-terminal transitions
+        trans = self.find_nonterminal_transitions(C)
+
+        # Compute read sets
+        readsets = self.compute_read_sets(C, trans, nullable)
+
+        # Compute lookback/includes relations
+        lookd, included = self.compute_lookback_includes(C, trans, nullable)
+
+        # Compute LALR FOLLOW sets
+        followsets = self.compute_follow_sets(trans, readsets, included)
+
+        # Add all of the lookaheads
+        self.add_lookaheads(lookd, followsets)
+
+    # -----------------------------------------------------------------------------
+    # lr_parse_table()
+    #
+    # This function constructs the parse tables for SLR or LALR
+    # -----------------------------------------------------------------------------
+    def lr_parse_table(self):
+        Productions = self.grammar.Productions
+        Precedence  = self.grammar.Precedence
+        goto   = self.lr_goto         # Goto array
+        action = self.lr_action       # Action array
+        log    = self.log             # Logger for output
+
+        actionp = {}                  # Action production array (temporary)
+
+        # Step 1: Construct C = { I0, I1, ... IN}, collection of LR(0) items
+        # This determines the number of states
+
+        C = self.lr0_items()
+        self.add_lalr_lookaheads(C)
+
+        # Build the parser table, state by state
+        st = 0
+        for I in C:
+            # Loop over each production in I
+            actlist = []              # List of actions
+            st_action  = {}
+            st_actionp = {}
+            st_goto    = {}
+            log.info('')
+            log.info('state %d', st)
+            log.info('')
+            for p in I:
+                log.info('    (%d) %s', p.number, p)
+            log.info('')
+
+            for p in I:
+                    if p.len == p.lr_index + 1:
+                        if p.name == "S'":
+                            # Start symbol. Accept!
+                            st_action['$end'] = 0
+                            st_actionp['$end'] = p
+                        else:
+                            # We are at the end of a production.  Reduce!
+                            laheads = p.lookaheads[st]
+                            for a in laheads:
+                                actlist.append((a, p, 'reduce using rule %d (%s)' % (p.number, p)))
+                                r = st_action.get(a)
+                                if r is not None:
+                                    # Whoa. Have a shift/reduce or reduce/reduce conflict
+                                    if r > 0:
+                                        # Need to decide on shift or reduce here
+                                        # By default we favor shifting. Need to add
+                                        # some precedence rules here.
+
+                                        # Shift precedence comes from the token
+                                        sprec, slevel = Precedence.get(a, ('right', 0))
+
+                                        # Reduce precedence comes from rule being reduced (p)
+                                        rprec, rlevel = Productions[p.number].prec
+
+                                        if (slevel < rlevel) or ((slevel == rlevel) and (rprec == 'left')):
+                                            # We really need to reduce here.
+                                            st_action[a] = -p.number
+                                            st_actionp[a] = p
+                                            if not slevel and not rlevel:
+                                                log.info('  ! shift/reduce conflict for %s resolved as reduce', a)
+                                                self.sr_conflicts.append((st, a, 'reduce'))
+                                            Productions[p.number].reduced += 1
+                                        elif (slevel == rlevel) and (rprec == 'nonassoc'):
+                                            st_action[a] = None
+                                        else:
+                                            # Hmmm. Guess we'll keep the shift
+                                            if not rlevel:
+                                                log.info('  ! shift/reduce conflict for %s resolved as shift', a)
+                                                self.sr_conflicts.append((st, a, 'shift'))
+                                    elif r < 0:
+                                        # Reduce/reduce conflict.   In this case, we favor the rule
+                                        # that was defined first in the grammar file
+                                        oldp = Productions[-r]
+                                        pp = Productions[p.number]
+                                        if oldp.line > pp.line:
+                                            st_action[a] = -p.number
+                                            st_actionp[a] = p
+                                            chosenp, rejectp = pp, oldp
+                                            Productions[p.number].reduced += 1
+                                            Productions[oldp.number].reduced -= 1
+                                        else:
+                                            chosenp, rejectp = oldp, pp
+                                        self.rr_conflicts.append((st, chosenp, rejectp))
+                                        log.info('  ! reduce/reduce conflict for %s resolved using rule %d (%s)',
+                                                 a, st_actionp[a].number, st_actionp[a])
+                                    else:
+                                        raise LALRError('Unknown conflict in state %d' % st)
+                                else:
+                                    st_action[a] = -p.number
+                                    st_actionp[a] = p
+                                    Productions[p.number].reduced += 1
+                    else:
+                        i = p.lr_index
+                        a = p.prod[i+1]       # Get symbol right after the "."
+                        if a in self.grammar.Terminals:
+                            g = self.lr0_goto(I, a)
+                            j = self.lr0_cidhash.get(id(g), -1)
+                            if j >= 0:
+                                # We are in a shift state
+                                actlist.append((a, p, 'shift and go to state %d' % j))
+                                r = st_action.get(a)
+                                if r is not None:
+                                    # Whoa have a shift/reduce or shift/shift conflict
+                                    if r > 0:
+                                        if r != j:
+                                            raise LALRError('Shift/shift conflict in state %d' % st)
+                                    elif r < 0:
+                                        # Do a precedence check.
+                                        #   -  if precedence of reduce rule is higher, we reduce.
+                                        #   -  if precedence of reduce is same and left assoc, we reduce.
+                                        #   -  otherwise we shift
+
+                                        # Shift precedence comes from the token
+                                        sprec, slevel = Precedence.get(a, ('right', 0))
+
+                                        # Reduce precedence comes from the rule that could have been reduced
+                                        rprec, rlevel = Productions[st_actionp[a].number].prec
+
+                                        if (slevel > rlevel) or ((slevel == rlevel) and (rprec == 'right')):
+                                            # We decide to shift here... highest precedence to shift
+                                            Productions[st_actionp[a].number].reduced -= 1
+                                            st_action[a] = j
+                                            st_actionp[a] = p
+                                            if not rlevel:
+                                                log.info('  ! shift/reduce conflict for %s resolved as shift', a)
+                                                self.sr_conflicts.append((st, a, 'shift'))
+                                        elif (slevel == rlevel) and (rprec == 'nonassoc'):
+                                            st_action[a] = None
+                                        else:
+                                            # Hmmm. Guess we'll keep the reduce
+                                            if not slevel and not rlevel:
+                                                log.info('  ! shift/reduce conflict for %s resolved as reduce', a)
+                                                self.sr_conflicts.append((st, a, 'reduce'))
+
+                                    else:
+                                        raise LALRError('Unknown conflict in state %d' % st)
+                                else:
+                                    st_action[a] = j
+                                    st_actionp[a] = p
+
+            # Print the actions associated with each terminal
+            _actprint = {}
+            for a, p, m in actlist:
+                if a in st_action:
+                    if p is st_actionp[a]:
+                        log.info('    %-15s %s', a, m)
+                        _actprint[(a, m)] = 1
+            log.info('')
+            # Print the actions that were not used. (debugging)
+            not_used = 0
+            for a, p, m in actlist:
+                if a in st_action:
+                    if p is not st_actionp[a]:
+                        if not (a, m) in _actprint:
+                            log.debug('  ! %-15s [ %s ]', a, m)
+                            not_used = 1
+                            _actprint[(a, m)] = 1
+            if not_used:
+                log.debug('')
+
+            # Construct the goto table for this state
+
+            nkeys = {}
+            for ii in I:
+                for s in ii.usyms:
+                    if s in self.grammar.Nonterminals:
+                        nkeys[s] = None
+            for n in nkeys:
+                g = self.lr0_goto(I, n)
+                j = self.lr0_cidhash.get(id(g), -1)
+                if j >= 0:
+                    st_goto[n] = j
+                    log.info('    %-30s shift and go to state %d', n, j)
+
+            action[st] = st_action
+            actionp[st] = st_actionp
+            goto[st] = st_goto
+            st += 1
+
+# -----------------------------------------------------------------------------
+#                            === INTROSPECTION ===
+#
+# The following functions and classes are used to implement the PLY
+# introspection features followed by the yacc() function itself.
+# -----------------------------------------------------------------------------
+
+# -----------------------------------------------------------------------------
+# get_caller_module_dict()
+#
+# This function returns a dictionary containing all of the symbols defined within
+# a caller further down the call stack.  This is used to get the environment
+# associated with the yacc() call if none was provided.
+# -----------------------------------------------------------------------------
+
+def get_caller_module_dict(levels):
+    f = sys._getframe(levels)
+    ldict = f.f_globals.copy()
+    if f.f_globals != f.f_locals:
+        ldict.update(f.f_locals)
+    return ldict
+
+# -----------------------------------------------------------------------------
+# parse_grammar()
+#
+# This takes a raw grammar rule string and parses it into production data
+# -----------------------------------------------------------------------------
+def parse_grammar(doc, file, line):
+    grammar = []
+    # Split the doc string into lines
+    pstrings = doc.splitlines()
+    lastp = None
+    dline = line
+    for ps in pstrings:
+        dline += 1
+        p = ps.split()
+        if not p:
+            continue
+        try:
+            if p[0] == '|':
+                # This is a continuation of a previous rule
+                if not lastp:
+                    raise SyntaxError("%s:%d: Misplaced '|'" % (file, dline))
+                prodname = lastp
+                syms = p[1:]
+            else:
+                prodname = p[0]
+                lastp = prodname
+                syms   = p[2:]
+                assign = p[1]
+                if assign != ':' and assign != '::=':
+                    raise SyntaxError("%s:%d: Syntax error. Expected ':'" % (file, dline))
+
+            grammar.append((file, dline, prodname, syms))
+        except SyntaxError:
+            raise
+        except Exception:
+            raise SyntaxError('%s:%d: Syntax error in rule %r' % (file, dline, ps.strip()))
+
+    return grammar
+
+# -----------------------------------------------------------------------------
+# ParserReflect()
+#
+# This class represents information extracted for building a parser including
+# start symbol, error function, tokens, precedence list, action functions,
+# etc.
+# -----------------------------------------------------------------------------
+class ParserReflect(object):
+    def __init__(self, pdict, log=None):
+        self.pdict      = pdict
+        self.start      = None
+        self.error_func = None
+        self.tokens     = None
+        self.modules    = set()
+        self.grammar    = []
+        self.error      = False
+
+        if log is None:
+            self.log = PlyLogger(sys.stderr)
+        else:
+            self.log = log
+
+    # Get all of the basic information
+    def get_all(self):
+        self.get_start()
+        self.get_error_func()
+        self.get_tokens()
+        self.get_precedence()
+        self.get_pfunctions()
+
+    # Validate all of the information
+    def validate_all(self):
+        self.validate_start()
+        self.validate_error_func()
+        self.validate_tokens()
+        self.validate_precedence()
+        self.validate_pfunctions()
+        self.validate_modules()
+        return self.error
+
+    # Compute a signature over the grammar
+    def signature(self):
+        parts = []
+        try:
+            if self.start:
+                parts.append(self.start)
+            if self.prec:
+                parts.append(''.join([''.join(p) for p in self.prec]))
+            if self.tokens:
+                parts.append(' '.join(self.tokens))
+            for f in self.pfuncs:
+                if f[3]:
+                    parts.append(f[3])
+        except (TypeError, ValueError):
+            pass
+        return ''.join(parts)
+
+    # -----------------------------------------------------------------------------
+    # validate_modules()
+    #
+    # This method checks to see if there are duplicated p_rulename() functions
+    # in the parser module file.  Without this function, it is really easy for
+    # users to make mistakes by cutting and pasting code fragments (and it's a real
+    # bugger to try and figure out why the resulting parser doesn't work).  Therefore,
+    # we just do a little regular expression pattern matching of def statements
+    # to try and detect duplicates.
+    # -----------------------------------------------------------------------------
+
+    def validate_modules(self):
+        # Match def p_funcname(
+        fre = re.compile(r'\s*def\s+(p_[a-zA-Z_0-9]*)\(')
+
+        for module in self.modules:
+            try:
+                lines, linen = inspect.getsourcelines(module)
+            except IOError:
+                continue
+
+            counthash = {}
+            for linen, line in enumerate(lines):
+                linen += 1
+                m = fre.match(line)
+                if m:
+                    name = m.group(1)
+                    prev = counthash.get(name)
+                    if not prev:
+                        counthash[name] = linen
+                    else:
+                        filename = inspect.getsourcefile(module)
+                        self.log.warning('%s:%d: Function %s redefined. Previously defined on line %d',
+                                         filename, linen, name, prev)
+
+    # Get the start symbol
+    def get_start(self):
+        self.start = self.pdict.get('start')
+
+    # Validate the start symbol
+    def validate_start(self):
+        if self.start is not None:
+            if not isinstance(self.start, str):
+                self.log.error("'start' must be a string")
+
+    # Look for error handler
+    def get_error_func(self):
+        self.error_func = self.pdict.get('p_error')
+
+    # Validate the error function
+    def validate_error_func(self):
+        if self.error_func:
+            if isinstance(self.error_func, types.FunctionType):
+                ismethod = 0
+            elif isinstance(self.error_func, types.MethodType):
+                ismethod = 1
+            else:
+                self.log.error("'p_error' defined, but is not a function or method")
+                self.error = True
+                return
+
+            eline = self.error_func.__code__.co_firstlineno
+            efile = self.error_func.__code__.co_filename
+            module = inspect.getmodule(self.error_func)
+            self.modules.add(module)
+
+            argcount = self.error_func.__code__.co_argcount - ismethod
+            if argcount != 1:
+                self.log.error('%s:%d: p_error() requires 1 argument', efile, eline)
+                self.error = True
+
+    # Get the tokens map
+    def get_tokens(self):
+        tokens = self.pdict.get('tokens')
+        if not tokens:
+            self.log.error('No token list is defined')
+            self.error = True
+            return
+
+        if not isinstance(tokens, (list, tuple)):
+            self.log.error('tokens must be a list or tuple')
+            self.error = True
+            return
+
+        if not tokens:
+            self.log.error('tokens is empty')
+            self.error = True
+            return
+
+        self.tokens = sorted(tokens)
+
+    # Validate the tokens
+    def validate_tokens(self):
+        # Validate the tokens.
+        if 'error' in self.tokens:
+            self.log.error("Illegal token name 'error'. Is a reserved word")
+            self.error = True
+            return
+
+        terminals = set()
+        for n in self.tokens:
+            if n in terminals:
+                self.log.warning('Token %r multiply defined', n)
+            terminals.add(n)
+
+    # Get the precedence map (if any)
+    def get_precedence(self):
+        self.prec = self.pdict.get('precedence')
+
+    # Validate and parse the precedence map
+    def validate_precedence(self):
+        preclist = []
+        if self.prec:
+            if not isinstance(self.prec, (list, tuple)):
+                self.log.error('precedence must be a list or tuple')
+                self.error = True
+                return
+            for level, p in enumerate(self.prec):
+                if not isinstance(p, (list, tuple)):
+                    self.log.error('Bad precedence table')
+                    self.error = True
+                    return
+
+                if len(p) < 2:
+                    self.log.error('Malformed precedence entry %s. Must be (assoc, term, ..., term)', p)
+                    self.error = True
+                    return
+                assoc = p[0]
+                if not isinstance(assoc, str):
+                    self.log.error('precedence associativity must be a string')
+                    self.error = True
+                    return
+                for term in p[1:]:
+                    if not isinstance(term, str):
+                        self.log.error('precedence items must be strings')
+                        self.error = True
+                        return
+                    preclist.append((term, assoc, level+1))
+        self.preclist = preclist
+
+    # Get all p_functions from the grammar
+    def get_pfunctions(self):
+        p_functions = []
+        for name, item in self.pdict.items():
+            if not name.startswith('p_') or name == 'p_error':
+                continue
+            if isinstance(item, (types.FunctionType, types.MethodType)):
+                line = getattr(item, 'co_firstlineno', item.__code__.co_firstlineno)
+                module = inspect.getmodule(item)
+                p_functions.append((line, module, name, item.__doc__))
+
+        # Sort all of the actions by line number; make sure to stringify
+        # modules to make them sortable, since `line` may not uniquely sort all
+        # p functions
+        p_functions.sort(key=lambda p_function: (
+            p_function[0],
+            str(p_function[1]),
+            p_function[2],
+            p_function[3]))
+        self.pfuncs = p_functions
+
+    # Validate all of the p_functions
+    def validate_pfunctions(self):
+        grammar = []
+        # Check for non-empty symbols
+        if len(self.pfuncs) == 0:
+            self.log.error('no rules of the form p_rulename are defined')
+            self.error = True
+            return
+
+        for line, module, name, doc in self.pfuncs:
+            file = inspect.getsourcefile(module)
+            func = self.pdict[name]
+            if isinstance(func, types.MethodType):
+                reqargs = 2
+            else:
+                reqargs = 1
+            if func.__code__.co_argcount > reqargs:
+                self.log.error('%s:%d: Rule %r has too many arguments', file, line, func.__name__)
+                self.error = True
+            elif func.__code__.co_argcount < reqargs:
+                self.log.error('%s:%d: Rule %r requires an argument', file, line, func.__name__)
+                self.error = True
+            elif not func.__doc__:
+                self.log.warning('%s:%d: No documentation string specified in function %r (ignored)',
+                                 file, line, func.__name__)
+            else:
+                try:
+                    parsed_g = parse_grammar(doc, file, line)
+                    for g in parsed_g:
+                        grammar.append((name, g))
+                except SyntaxError as e:
+                    self.log.error(str(e))
+                    self.error = True
+
+                # Looks like a valid grammar rule
+                # Mark the file in which defined.
+                self.modules.add(module)
+
+        # Secondary validation step that looks for p_ definitions that are not functions
+        # or functions that look like they might be grammar rules.
+
+        for n, v in self.pdict.items():
+            if n.startswith('p_') and isinstance(v, (types.FunctionType, types.MethodType)):
+                continue
+            if n.startswith('t_'):
+                continue
+            if n.startswith('p_') and n != 'p_error':
+                self.log.warning('%r not defined as a function', n)
+            if ((isinstance(v, types.FunctionType) and v.__code__.co_argcount == 1) or
+                   (isinstance(v, types.MethodType) and v.__func__.__code__.co_argcount == 2)):
+                if v.__doc__:
+                    try:
+                        doc = v.__doc__.split(' ')
+                        if doc[1] == ':':
+                            self.log.warning('%s:%d: Possible grammar rule %r defined without p_ prefix',
+                                             v.__code__.co_filename, v.__code__.co_firstlineno, n)
+                    except IndexError:
+                        pass
+
+        self.grammar = grammar
+
+# -----------------------------------------------------------------------------
+# yacc(module)
+#
+# Build a parser
+# -----------------------------------------------------------------------------
+
+# def yacc(*, debug=yaccdebug, module=None, start=None,
+#          check_recursion=True, optimize=False, debugfile=debug_file,
+#          debuglog=None, errorlog=None):
+
+def yacc(method='LALR', debug=yaccdebug, module=None, start=None,
+         check_recursion=True, optimize=False, write_tables=True, debugfile=debug_file,
+         outputdir=None, debuglog=None, errorlog=None, picklefile=None):
+
+    # Reference to the parsing method of the last built parser
+    global parse
+
+    if errorlog is None:
+        errorlog = PlyLogger(sys.stderr)
+
+    # Get the module dictionary used for the parser
+    if module:
+        _items = [(k, getattr(module, k)) for k in dir(module)]
+        pdict = dict(_items)
+        # If no __file__ or __package__ attributes are available, try to obtain them
+        # from the __module__ instead
+        if '__file__' not in pdict:
+            pdict['__file__'] = sys.modules[pdict['__module__']].__file__
+        if '__package__' not in pdict and '__module__' in pdict:
+            if hasattr(sys.modules[pdict['__module__']], '__package__'):
+                pdict['__package__'] = sys.modules[pdict['__module__']].__package__
+    else:
+        pdict = get_caller_module_dict(2)
+
+    # Set start symbol if it's specified directly using an argument
+    if start is not None:
+        pdict['start'] = start
+
+    # Collect parser information from the dictionary
+    pinfo = ParserReflect(pdict, log=errorlog)
+    pinfo.get_all()
+
+    if pinfo.error:
+        raise YaccError('Unable to build parser')
+
+    if debuglog is None:
+        if debug:
+            try:
+                debuglog = PlyLogger(open(debugfile, 'w'))
+            except IOError as e:
+                errorlog.warning("Couldn't open %r. %s" % (debugfile, e))
+                debuglog = NullLogger()
+        else:
+            debuglog = NullLogger()
+
+    debuglog.info('Created by PLY (http://www.dabeaz.com/ply)')
+
+    errors = False
+
+    # Validate the parser information
+    if pinfo.validate_all():
+        raise YaccError('Unable to build parser')
+
+    if not pinfo.error_func:
+        errorlog.warning('no p_error() function is defined')
+
+    # Create a grammar object
+    grammar = Grammar(pinfo.tokens)
+
+    # Set precedence level for terminals
+    for term, assoc, level in pinfo.preclist:
+        try:
+            grammar.set_precedence(term, assoc, level)
+        except GrammarError as e:
+            errorlog.warning('%s', e)
+
+    # Add productions to the grammar
+    for funcname, gram in pinfo.grammar:
+        file, line, prodname, syms = gram
+        try:
+            grammar.add_production(prodname, syms, funcname, file, line)
+        except GrammarError as e:
+            errorlog.error('%s', e)
+            errors = True
+
+    # Set the grammar start symbols
+    try:
+        if start is None:
+            grammar.set_start(pinfo.start)
+        else:
+            grammar.set_start(start)
+    except GrammarError as e:
+        errorlog.error(str(e))
+        errors = True
+
+    if errors:
+        raise YaccError('Unable to build parser')
+
+    # Verify the grammar structure
+    undefined_symbols = grammar.undefined_symbols()
+    for sym, prod in undefined_symbols:
+        errorlog.error('%s:%d: Symbol %r used, but not defined as a token or a rule', prod.file, prod.line, sym)
+        errors = True
+
+    unused_terminals = grammar.unused_terminals()
+    if unused_terminals:
+        debuglog.info('')
+        debuglog.info('Unused terminals:')
+        debuglog.info('')
+        for term in unused_terminals:
+            errorlog.warning('Token %r defined, but not used', term)
+            debuglog.info('    %s', term)
+
+    # Print out all productions to the debug log
+    if debug:
+        debuglog.info('')
+        debuglog.info('Grammar')
+        debuglog.info('')
+        for n, p in enumerate(grammar.Productions):
+            debuglog.info('Rule %-5d %s', n, p)
+
+    # Find unused non-terminals
+    unused_rules = grammar.unused_rules()
+    for prod in unused_rules:
+        errorlog.warning('%s:%d: Rule %r defined, but not used', prod.file, prod.line, prod.name)
+
+    if len(unused_terminals) == 1:
+        errorlog.warning('There is 1 unused token')
+    if len(unused_terminals) > 1:
+        errorlog.warning('There are %d unused tokens', len(unused_terminals))
+
+    if len(unused_rules) == 1:
+        errorlog.warning('There is 1 unused rule')
+    if len(unused_rules) > 1:
+        errorlog.warning('There are %d unused rules', len(unused_rules))
+
+    if debug:
+        debuglog.info('')
+        debuglog.info('Terminals, with rules where they appear')
+        debuglog.info('')
+        terms = list(grammar.Terminals)
+        terms.sort()
+        for term in terms:
+            debuglog.info('%-20s : %s', term, ' '.join([str(s) for s in grammar.Terminals[term]]))
+
+        debuglog.info('')
+        debuglog.info('Nonterminals, with rules where they appear')
+        debuglog.info('')
+        nonterms = list(grammar.Nonterminals)
+        nonterms.sort()
+        for nonterm in nonterms:
+            debuglog.info('%-20s : %s', nonterm, ' '.join([str(s) for s in grammar.Nonterminals[nonterm]]))
+        debuglog.info('')
+
+    if check_recursion:
+        unreachable = grammar.find_unreachable()
+        for u in unreachable:
+            errorlog.warning('Symbol %r is unreachable', u)
+
+        infinite = grammar.infinite_cycles()
+        for inf in infinite:
+            errorlog.error('Infinite recursion detected for symbol %r', inf)
+            errors = True
+
+    unused_prec = grammar.unused_precedence()
+    for term, assoc in unused_prec:
+        errorlog.error('Precedence rule %r defined for unknown symbol %r', assoc, term)
+        errors = True
+
+    if errors:
+        raise YaccError('Unable to build parser')
+
+    # Run the LRTable on the grammar
+    lr = LRTable(grammar, debuglog)
+
+    if debug:
+        num_sr = len(lr.sr_conflicts)
+
+        # Report shift/reduce and reduce/reduce conflicts
+        if num_sr == 1:
+            errorlog.warning('1 shift/reduce conflict')
+        elif num_sr > 1:
+            errorlog.warning('%d shift/reduce conflicts', num_sr)
+
+        num_rr = len(lr.rr_conflicts)
+        if num_rr == 1:
+            errorlog.warning('1 reduce/reduce conflict')
+        elif num_rr > 1:
+            errorlog.warning('%d reduce/reduce conflicts', num_rr)
+
+    # Write out conflicts to the output file
+    if debug and (lr.sr_conflicts or lr.rr_conflicts):
+        debuglog.warning('')
+        debuglog.warning('Conflicts:')
+        debuglog.warning('')
+
+        for state, tok, resolution in lr.sr_conflicts:
+            debuglog.warning('shift/reduce conflict for %s in state %d resolved as %s',  tok, state, resolution)
+
+        already_reported = set()
+        for state, rule, rejected in lr.rr_conflicts:
+            if (state, id(rule), id(rejected)) in already_reported:
+                continue
+            debuglog.warning('reduce/reduce conflict in state %d resolved using rule (%s)', state, rule)
+            debuglog.warning('rejected rule (%s) in state %d', rejected, state)
+            errorlog.warning('reduce/reduce conflict in state %d resolved using rule (%s)', state, rule)
+            errorlog.warning('rejected rule (%s) in state %d', rejected, state)
+            already_reported.add((state, id(rule), id(rejected)))
+
+        warned_never = []
+        for state, rule, rejected in lr.rr_conflicts:
+            if not rejected.reduced and (rejected not in warned_never):
+                debuglog.warning('Rule (%s) is never reduced', rejected)
+                errorlog.warning('Rule (%s) is never reduced', rejected)
+                warned_never.append(rejected)
+
+    # Build the parser
+    lr.bind_callables(pinfo.pdict)
+    parser = LRParser(lr, pinfo.error_func)
+
+    parse = parser.parse
+    return parser

--- a/rpm_lockfile/vendor/bashlex/yacc.py
+++ b/rpm_lockfile/vendor/bashlex/yacc.py
@@ -87,7 +87,7 @@ MAXINT = sys.maxsize
 # information, they can create their own logging object and pass
 # it into PLY.
 
-from bashlex import utils
+from . import utils
 
 class PlyLogger(object):
     def __init__(self, f):

--- a/tests/test_containerfile_packages.py
+++ b/tests/test_containerfile_packages.py
@@ -1,0 +1,329 @@
+"""
+Tests for rpm_lockfile.containerfile_packages.
+"""
+
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from rpm_lockfile.containerfile_packages import (
+    analyze_containerfile_stages,
+    build_copy_map,
+    collect_stage_vars,
+    extract_packages_from_file_installs,
+    extract_packages_from_scripts,
+)
+
+
+def _make_entry(instruction: str, value: str) -> dict:
+    """
+    Build a minimal DockerfileParser structure entry for testing.
+    """
+    return {"instruction": instruction, "value": value, "startline": 0, "endline": 0, "content": ""}
+
+
+class TestCollectStageVars(unittest.TestCase):
+    def test_arg_with_default(self):
+        entries = [_make_entry("ARG", "GCC_VERSION=12")]
+        result = collect_stage_vars(entries)
+        self.assertEqual(result, {"GCC_VERSION": "12"})
+
+    def test_arg_with_quoted_default(self):
+        entries = [_make_entry("ARG", 'GCC_VERSION="12"')]
+        result = collect_stage_vars(entries)
+        self.assertEqual(result, {"GCC_VERSION": "12"})
+
+    def test_arg_without_default(self):
+        entries = [_make_entry("ARG", "KERNEL_VERSION")]
+        result = collect_stage_vars(entries)
+        self.assertEqual(result, {})
+
+    def test_arg_inherits_global(self):
+        entries = [_make_entry("ARG", "KERNEL_VERSION")]
+        result = collect_stage_vars(entries, inherited_vars={"KERNEL_VERSION": "5.14"})
+        self.assertEqual(result, {"KERNEL_VERSION": "5.14"})
+
+    def test_env_with_equals(self):
+        entries = [_make_entry("ENV", "LANG=en_US.UTF-8")]
+        result = collect_stage_vars(entries)
+        self.assertEqual(result, {"LANG": "en_US.UTF-8"})
+
+    def test_env_references_arg(self):
+        entries = [
+            _make_entry("ARG", "GCC_VERSION=12"),
+            _make_entry("ENV", "GCC_VERSION=${GCC_VERSION}"),
+        ]
+        result = collect_stage_vars(entries)
+        self.assertEqual(result, {"GCC_VERSION": "12"})
+
+
+class TestBuildCopyMap(unittest.TestCase):
+    def test_copy_file_to_directory(self):
+        entries = [_make_entry("COPY", "hack/foo.sh /tmp")]
+        result = build_copy_map(entries)
+        self.assertEqual(result["/tmp/foo.sh"], "hack/foo.sh")
+
+    def test_copy_file_to_directory_with_trailing_slash(self):
+        entries = [_make_entry("COPY", "hack/foo.sh /tmp/")]
+        result = build_copy_map(entries)
+        self.assertEqual(result["/tmp/foo.sh"], "hack/foo.sh")
+
+    def test_skips_copy_from(self):
+        entries = [_make_entry("COPY", "--from=builder /app/bin /usr/local/bin")]
+        result = build_copy_map(entries)
+        self.assertEqual(result, {})
+
+    def test_copy_with_chown_flag(self):
+        entries = [_make_entry("COPY", "--chown=root:root hack/foo.sh /tmp/")]
+        result = build_copy_map(entries)
+        self.assertEqual(result["/tmp/foo.sh"], "hack/foo.sh")
+
+
+class TestExtractPackagesFromFileInstalls(unittest.TestCase):
+    def test_xargs_dnf_install_from_file(self):
+        with TemporaryDirectory() as tmpdir:
+            source_dir = Path(tmpdir)
+            pkg_file = source_dir / "main-packages-list.txt"
+            pkg_file.write_text("httpd\npython3-pip\n# comment\nqemu-img\n")
+            copy_map = {"/tmp/main-packages-list.txt": "main-packages-list.txt"}
+
+            run_values = ["xargs -rtd'\\n' dnf install -y < /tmp/main-packages-list.txt"]
+            result, arch_result = extract_packages_from_file_installs(run_values, copy_map, source_dir)
+            self.assertEqual(result, ["httpd", "python3-pip", "qemu-img"])
+            self.assertEqual(arch_result, {})
+
+    def test_pipe_to_xargs_install(self):
+        with TemporaryDirectory() as tmpdir:
+            source_dir = Path(tmpdir)
+            pkg_file = source_dir / "main-packages-list.ocp"
+            pkg_file.write_text("httpd\nqemu-img\n# comment\nsqlite\n")
+            copy_map = {"/tmp/main-packages-list.ocp": "main-packages-list.ocp"}
+
+            run_values = ["grep -vE '^(#|$)' /tmp/main-packages-list.ocp | xargs -rtd'\\n' dnf install -y"]
+            result, arch_result = extract_packages_from_file_installs(run_values, copy_map, source_dir)
+            self.assertEqual(result, ["httpd", "qemu-img", "sqlite"])
+            self.assertEqual(arch_result, {})
+
+    def test_arch_suffix_in_filename(self):
+        with TemporaryDirectory() as tmpdir:
+            source_dir = Path(tmpdir)
+            x86_file = source_dir / "packages-list.ocp-x86_64"
+            x86_file.write_text("biosdevname\n")
+            copy_map = {"/tmp/packages-list.ocp": "packages-list.ocp"}
+
+            run_values = ["grep -vE '^(#|$)' /tmp/${PKGS_LIST}-$(arch) | xargs -rtd'\\n' dnf install -y"]
+            result, arch_result = extract_packages_from_file_installs(
+                run_values,
+                copy_map,
+                source_dir,
+                env_vars={"PKGS_LIST": "packages-list.ocp"},
+            )
+            self.assertEqual(result, [])
+            self.assertEqual(arch_result.get("x86_64"), ["biosdevname"])
+
+
+class TestExtractPackagesFromScripts(unittest.TestCase):
+    def test_script_via_bash_interpreter(self):
+        with TemporaryDirectory() as tmpdir:
+            source_dir = Path(tmpdir)
+            script = source_dir / "hack" / "install.sh"
+            script.parent.mkdir()
+            script.write_text('PKGS="nmap-ncat procps-ng"\ndnf install -y ${PKGS}\n')
+
+            copy_map = {"/tmp/install.sh": "hack/install.sh"}
+            run_values = ["/bin/bash /tmp/install.sh"]
+            result = extract_packages_from_scripts(run_values, source_dir=source_dir, copy_map=copy_map)
+            self.assertIn("nmap-ncat", result.packages)
+            self.assertIn("procps-ng", result.packages)
+
+    def test_direct_script_invocation(self):
+        with TemporaryDirectory() as tmpdir:
+            source_dir = Path(tmpdir)
+            script = source_dir / "install-deps.sh"
+            script.write_text("dnf install -y git\n")
+
+            run_values = ["/src/install-deps.sh"]
+            result = extract_packages_from_scripts(run_values, source_dir=source_dir)
+            self.assertIn("git", result.packages)
+
+    def test_bare_script_name_resolved_via_copy_map(self):
+        with TemporaryDirectory() as tmpdir:
+            source_dir = Path(tmpdir)
+            script = source_dir / "prepare-image.sh"
+            script.write_text("dnf install -y httpd qemu-img\n")
+
+            copy_map = {"/bin/prepare-image.sh": "prepare-image.sh"}
+            run_values = ["set -euxo pipefail && prepare-image.sh && rm -f /bin/prepare-image.sh"]
+            result = extract_packages_from_scripts(run_values, source_dir=source_dir, copy_map=copy_map)
+            self.assertIn("httpd", result.packages)
+            self.assertIn("qemu-img", result.packages)
+
+    def test_arch_specific_packages_from_script(self):
+        with TemporaryDirectory() as tmpdir:
+            source_dir = Path(tmpdir)
+            script = source_dir / "prepare-efi.sh"
+            script.write_text(
+                'dnf install -y grub2 dosfstools\n'
+                'if [[ "$ARCH" == "x86_64" ]]; then\n'
+                '    GRUB_PKG=grub2-efi-x64\n'
+                '    SHIM_PKG=shim-x64\n'
+                'elif [[ "$ARCH" == "aarch64" ]]; then\n'
+                '    GRUB_PKG=grub2-efi-aa64\n'
+                '    SHIM_PKG=shim-aa64\n'
+                'fi\n'
+                'dnf install -y "$GRUB_PKG" "$SHIM_PKG"\n'
+            )
+
+            copy_map = {"/bin/prepare-efi.sh": "prepare-efi.sh"}
+            run_values = ["prepare-efi.sh redhat"]
+            result = extract_packages_from_scripts(run_values, source_dir=source_dir, copy_map=copy_map)
+            self.assertIn("grub2", result.packages)
+            self.assertIn("dosfstools", result.packages)
+            self.assertEqual(result.arch_packages.get("x86_64"), ["grub2-efi-x64", "shim-x64"])
+            self.assertEqual(result.arch_packages.get("aarch64"), ["grub2-efi-aa64", "shim-aa64"])
+
+    def test_bare_update_in_script_sets_has_update(self):
+        with TemporaryDirectory() as tmpdir:
+            source_dir = Path(tmpdir)
+            script = source_dir / "install-python-deps-ocp.sh"
+            script.write_text("yum update -y\npip install some-package\n")
+
+            run_values = [". /cachi2/cachi2.env && /src/install-python-deps-ocp.sh"]
+            result = extract_packages_from_scripts(run_values, source_dir=source_dir)
+            self.assertTrue(result.has_update)
+
+
+class TestAnalyzeContainerfileStages(unittest.TestCase):
+    def _write_containerfile(self, tmpdir: str, content: str) -> Path:
+        path = Path(tmpdir) / "Dockerfile"
+        path.write_text(content)
+        return path
+
+    def test_per_stage_extraction(self):
+        with TemporaryDirectory() as tmpdir:
+            content = (
+                "FROM builder AS build\n"
+                "RUN dnf install -y gcc nmstate-devel git\n"
+                "\n"
+                "FROM base-rhel9\n"
+                "RUN dnf install -y postgresql-server skopeo\n"
+            )
+            path = self._write_containerfile(tmpdir, content)
+            stages = analyze_containerfile_stages(path)
+            self.assertEqual(len(stages), 2)
+            self.assertEqual(stages[0].packages, ["gcc", "git", "nmstate-devel"])
+            self.assertEqual(stages[1].packages, ["postgresql-server", "skopeo"])
+
+    def test_shell_variable_expansion(self):
+        with TemporaryDirectory() as tmpdir:
+            content = (
+                'FROM base\n'
+                'RUN INSTALL_PKGS=" \\\n'
+                '      which tar wget hostname" && \\\n'
+                '    dnf install -y --nodocs ${INSTALL_PKGS} gpgme && \\\n'
+                '    dnf clean all\n'
+            )
+            path = self._write_containerfile(tmpdir, content)
+            stages = analyze_containerfile_stages(path)
+            self.assertEqual(stages[0].packages, ["gpgme", "hostname", "tar", "wget", "which"])
+
+    def test_arg_env_variable_resolution(self):
+        with TemporaryDirectory() as tmpdir:
+            content = (
+                "ARG GCC_VERSION=12\n"
+                "ARG KERNEL_VERSION\n"
+                "FROM base\n"
+                "ARG GCC_VERSION\n"
+                "ARG KERNEL_VERSION\n"
+                "RUN dnf install -y \\\n"
+                "    gcc-${GCC_VERSION} \\\n"
+                "    gcc-c++-${GCC_VERSION} \\\n"
+                "    kernel-devel${KERNEL_VERSION:+-}${KERNEL_VERSION} \\\n"
+                "    make\n"
+            )
+            path = self._write_containerfile(tmpdir, content)
+            stages = analyze_containerfile_stages(path)
+            self.assertEqual(stages[0].packages, ["gcc-12", "gcc-c++-12", "kernel-devel", "make"])
+
+    def test_arch_conditional_packages(self):
+        with TemporaryDirectory() as tmpdir:
+            content = (
+                "FROM base\n"
+                "RUN dnf install -y make && \\\n"
+                "    if [ $(arch) = x86_64 ]; then \\\n"
+                "    dnf -y install kernel-rt-devel; \\\n"
+                "    fi && \\\n"
+                "    if [ $(arch) = aarch64 ]; then \\\n"
+                "    dnf -y install kernel-64k-devel; \\\n"
+                "    fi\n"
+            )
+            path = self._write_containerfile(tmpdir, content)
+            stages = analyze_containerfile_stages(path)
+            self.assertEqual(stages[0].packages, ["make"])
+            self.assertEqual(stages[0].arch_packages, {"aarch64": ["kernel-64k-devel"], "x86_64": ["kernel-rt-devel"]})
+
+    def test_copy_then_bash_script(self):
+        with TemporaryDirectory() as tmpdir:
+            hack_dir = Path(tmpdir) / "hack"
+            hack_dir.mkdir()
+            (hack_dir / "install.sh").write_text('INSTALL_PKGS="nmap-ncat procps-ng"\ndnf install -y ${INSTALL_PKGS}\n')
+            content = "FROM base\nCOPY hack/install.sh /tmp\nRUN /bin/bash /tmp/install.sh\n"
+            path = self._write_containerfile(tmpdir, content)
+            stages = analyze_containerfile_stages(path, source_dir=Path(tmpdir))
+            self.assertIn("nmap-ncat", stages[0].packages)
+            self.assertIn("procps-ng", stages[0].packages)
+
+    def test_script_arch_packages_flow_to_stages(self):
+        with TemporaryDirectory() as tmpdir:
+            source_dir = Path(tmpdir)
+            (source_dir / "prepare-efi.sh").write_text(
+                'dnf install -y grub2 dosfstools\n'
+                'if [[ "$ARCH" == "x86_64" ]]; then\n'
+                '    GRUB_PKG=grub2-efi-x64\n'
+                '    SHIM_PKG=shim-x64\n'
+                'elif [[ "$ARCH" == "aarch64" ]]; then\n'
+                '    GRUB_PKG=grub2-efi-aa64\n'
+                '    SHIM_PKG=shim-aa64\n'
+                'fi\n'
+                'dnf install -y "$GRUB_PKG" "$SHIM_PKG"\n'
+            )
+            content = (
+                "FROM builder AS build\n"
+                "COPY prepare-efi.sh /bin/\n"
+                "RUN prepare-efi.sh redhat\n"
+                "\n"
+                "FROM base-rhel9\n"
+                "RUN dnf install -y httpd\n"
+            )
+            path = self._write_containerfile(tmpdir, content)
+            stages = analyze_containerfile_stages(path, source_dir=source_dir)
+            self.assertIn("grub2", stages[0].packages)
+            self.assertIn("dosfstools", stages[0].packages)
+            self.assertEqual(stages[0].arch_packages.get("x86_64"), ["grub2-efi-x64", "shim-x64"])
+            self.assertEqual(stages[0].arch_packages.get("aarch64"), ["grub2-efi-aa64", "shim-aa64"])
+            self.assertEqual(stages[1].packages, ["httpd"])
+
+    def test_detect_update(self):
+        with TemporaryDirectory() as tmpdir:
+            content = "FROM base\nRUN yum update -y && yum clean all\n"
+            path = self._write_containerfile(tmpdir, content)
+            stages = analyze_containerfile_stages(path)
+            self.assertEqual(stages[0].packages, [])
+            self.assertTrue(stages[0].has_update)
+
+    def test_bare_update_in_script_propagates(self):
+        with TemporaryDirectory() as tmpdir:
+            source_dir = Path(tmpdir)
+            (source_dir / "install-python-deps-ocp.sh").write_text("yum update -y\npip install requests==2.28.0\n")
+            content = (
+                "FROM builder AS build\n"
+                "RUN dnf install -y gcc\n"
+                "\n"
+                "FROM base-rhel9\n"
+                "COPY install-python-deps-ocp.sh /src/\n"
+                "RUN . /cachi2/cachi2.env && /src/install-python-deps-ocp.sh\n"
+            )
+            path = self._write_containerfile(tmpdir, content)
+            stages = analyze_containerfile_stages(path, source_dir=source_dir)
+            self.assertFalse(stages[0].has_update)
+            self.assertTrue(stages[1].has_update)

--- a/tests/test_containerfile_packages.py
+++ b/tests/test_containerfile_packages.py
@@ -7,11 +7,13 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 
 from rpm_lockfile.containerfile_packages import (
+    StagePackages,
     analyze_containerfile_stages,
     build_copy_map,
     collect_stage_vars,
     extract_packages_from_file_installs,
     extract_packages_from_scripts,
+    select_stage,
 )
 
 
@@ -211,7 +213,11 @@ class TestAnalyzeContainerfileStages(unittest.TestCase):
             path = self._write_containerfile(tmpdir, content)
             stages = analyze_containerfile_stages(path)
             self.assertEqual(len(stages), 2)
+            self.assertEqual(stages[0].base_image, "builder")
+            self.assertEqual(stages[0].stage_name, "build")
             self.assertEqual(stages[0].packages, ["gcc", "git", "nmstate-devel"])
+            self.assertEqual(stages[1].base_image, "base-rhel9")
+            self.assertEqual(stages[1].stage_name, "")
             self.assertEqual(stages[1].packages, ["postgresql-server", "skopeo"])
 
     def test_shell_variable_expansion(self):
@@ -327,3 +333,55 @@ class TestAnalyzeContainerfileStages(unittest.TestCase):
             stages = analyze_containerfile_stages(path, source_dir=source_dir)
             self.assertFalse(stages[0].has_update)
             self.assertTrue(stages[1].has_update)
+
+
+class TestSelectStage(unittest.TestCase):
+    def _make_stages(self) -> list[StagePackages]:
+        return [
+            StagePackages(base_image="builder", stage_name="build", packages=["gcc", "make"]),
+            StagePackages(base_image="registry.redhat.io/ubi9/ubi:latest", stage_name="runtime", packages=["httpd"]),
+            StagePackages(base_image="base-rhel9", stage_name="", packages=["skopeo"]),
+        ]
+
+    def test_default_returns_last_stage(self):
+        stages = self._make_stages()
+        result = select_stage(stages)
+        self.assertEqual(result.packages, ["skopeo"])
+
+    def test_stage_num_selects_correct_stage(self):
+        stages = self._make_stages()
+        result = select_stage(stages, stage_num=1)
+        self.assertEqual(result.packages, ["gcc", "make"])
+        result = select_stage(stages, stage_num=2)
+        self.assertEqual(result.packages, ["httpd"])
+
+    def test_stage_num_out_of_range_returns_none(self):
+        stages = self._make_stages()
+        result = select_stage(stages, stage_num=5)
+        self.assertIsNone(result)
+
+    def test_stage_name_selects_correct_stage(self):
+        stages = self._make_stages()
+        result = select_stage(stages, stage_name="build")
+        self.assertEqual(result.packages, ["gcc", "make"])
+        result = select_stage(stages, stage_name="runtime")
+        self.assertEqual(result.packages, ["httpd"])
+
+    def test_stage_name_no_match_returns_none(self):
+        stages = self._make_stages()
+        result = select_stage(stages, stage_name="nonexistent")
+        self.assertIsNone(result)
+
+    def test_image_pattern_selects_correct_stage(self):
+        stages = self._make_stages()
+        result = select_stage(stages, image_pattern=r"ubi9")
+        self.assertEqual(result.packages, ["httpd"])
+
+    def test_image_pattern_no_match_returns_none(self):
+        stages = self._make_stages()
+        result = select_stage(stages, image_pattern=r"centos")
+        self.assertIsNone(result)
+
+    def test_empty_stages_returns_none(self):
+        result = select_stage([])
+        self.assertIsNone(result)

--- a/tests/test_containerfile_packages.py
+++ b/tests/test_containerfile_packages.py
@@ -64,6 +64,7 @@ class TestBuildCopyMap(unittest.TestCase):
         entries = [_make_entry("COPY", "hack/foo.sh /tmp")]
         result = build_copy_map(entries)
         self.assertEqual(result["/tmp/foo.sh"], "hack/foo.sh")
+        self.assertEqual(result["/tmp"], "hack/foo.sh")
 
     def test_copy_file_to_directory_with_trailing_slash(self):
         entries = [_make_entry("COPY", "hack/foo.sh /tmp/")]
@@ -79,6 +80,14 @@ class TestBuildCopyMap(unittest.TestCase):
         entries = [_make_entry("COPY", "--chown=root:root hack/foo.sh /tmp/")]
         result = build_copy_map(entries)
         self.assertEqual(result["/tmp/foo.sh"], "hack/foo.sh")
+
+    def test_copy_file_rename(self):
+        # Both directory-style and rename-style entries are kept since
+        # we can't distinguish without container filesystem context
+        entries = [_make_entry("COPY", "foo.sh /opt/bar.sh")]
+        result = build_copy_map(entries)
+        self.assertEqual(result["/opt/bar.sh"], "foo.sh")
+        self.assertEqual(result["/opt/bar.sh/foo.sh"], "foo.sh")
 
 
 class TestExtractPackagesFromFileInstalls(unittest.TestCase):

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,4 +1,6 @@
-from unittest.mock import patch, mock_open
+import logging
+from pathlib import Path
+from unittest.mock import patch, mock_open, MagicMock
 
 import pytest
 

--- a/tests/test_shell_commands.py
+++ b/tests/test_shell_commands.py
@@ -1,0 +1,252 @@
+"""
+Tests for rpm_lockfile.shell_commands.
+"""
+
+import unittest
+
+import pytest
+from rpm_lockfile.shell_commands import (
+    ARCH_VALUE_RE,
+    analyze_run_commands,
+    resolve_bash_expansion,
+)
+
+
+class TestResolveBashExpansion(unittest.TestCase):
+    def test_simple_braced_var(self):
+        result = resolve_bash_expansion("gcc-${GCC_VERSION}", {"GCC_VERSION": "12"})
+        self.assertEqual(result, "gcc-12")
+
+    def test_simple_unbraced_var(self):
+        result = resolve_bash_expansion("$VAR", {"VAR": "hello"})
+        self.assertEqual(result, "hello")
+
+    def test_default_value_when_unset(self):
+        result = resolve_bash_expansion("${VAR:-fallback}", {})
+        self.assertEqual(result, "fallback")
+
+    def test_default_value_when_set(self):
+        result = resolve_bash_expansion("${VAR:-fallback}", {"VAR": "actual"})
+        self.assertEqual(result, "actual")
+
+    def test_conditional_value_when_set(self):
+        result = resolve_bash_expansion("pkg${VAR:+-}${VAR}", {"VAR": "1.0"})
+        self.assertEqual(result, "pkg-1.0")
+
+    def test_conditional_value_when_unset(self):
+        result = resolve_bash_expansion("pkg${VAR:+-}${VAR}", {})
+        self.assertEqual(result, "pkg")
+
+    def test_unresolved_var_becomes_empty(self):
+        result = resolve_bash_expansion("gcc-${UNKNOWN}", {})
+        self.assertEqual(result, "gcc-")
+
+    def test_kernel_devel_pattern_with_version(self):
+        result = resolve_bash_expansion(
+            "kernel-devel${KERNEL_VERSION:+-}${KERNEL_VERSION}",
+            {"KERNEL_VERSION": "5.14.0-427.el9"},
+        )
+        self.assertEqual(result, "kernel-devel-5.14.0-427.el9")
+
+    def test_kernel_devel_pattern_without_version(self):
+        result = resolve_bash_expansion(
+            "kernel-devel${KERNEL_VERSION:+-}${KERNEL_VERSION}",
+            {},
+        )
+        self.assertEqual(result, "kernel-devel")
+
+    def test_no_variables(self):
+        result = resolve_bash_expansion("plain-package", {})
+        self.assertEqual(result, "plain-package")
+
+    def test_multiple_vars_in_one_string(self):
+        result = resolve_bash_expansion(
+            "${PREFIX}-${NAME}",
+            {"PREFIX": "lib", "NAME": "foo"},
+        )
+        self.assertEqual(result, "lib-foo")
+
+
+class TestAnalyzeRunCommands(unittest.TestCase):
+    def test_resolves_arg_in_packages(self):
+        run_values = ["dnf install -y gcc-${GCC_VERSION} gcc-c++-${GCC_VERSION}"]
+        common, arch, _, _, _, _ = analyze_run_commands(run_values, env_vars={"GCC_VERSION": "12"})
+        self.assertEqual(common, ["gcc-12", "gcc-c++-12"])
+        self.assertEqual(arch, {})
+
+    def test_kernel_devel_conditional_with_version(self):
+        run_values = [
+            "dnf install -y kernel-devel${KERNEL_VERSION:+-}${KERNEL_VERSION}"
+            " kernel-headers${KERNEL_VERSION:+-}${KERNEL_VERSION}"
+        ]
+        common, arch, _, _, _, _ = analyze_run_commands(run_values, env_vars={"KERNEL_VERSION": "5.14.0"})
+        self.assertEqual(common, ["kernel-devel-5.14.0", "kernel-headers-5.14.0"])
+        self.assertEqual(arch, {})
+
+    def test_kernel_devel_conditional_without_version(self):
+        run_values = [
+            "dnf install -y kernel-devel${KERNEL_VERSION:+-}${KERNEL_VERSION}"
+            " kernel-headers${KERNEL_VERSION:+-}${KERNEL_VERSION}"
+        ]
+        common, arch, _, _, _, _ = analyze_run_commands(run_values, env_vars={})
+        self.assertEqual(common, ["kernel-devel", "kernel-headers"])
+        self.assertEqual(arch, {})
+
+    def test_unresolved_var_skipped(self):
+        run_values = ["dnf install -y gcc-${UNKNOWN} make"]
+        common, arch, _, _, _, _ = analyze_run_commands(run_values, env_vars={})
+        self.assertEqual(common, ["make"])
+        self.assertEqual(arch, {})
+
+    def test_no_env_vars_backward_compatible(self):
+        run_values = ['INSTALL_PKGS="wget tar" && dnf install -y ${INSTALL_PKGS} git']
+        common, arch, _, _, _, _ = analyze_run_commands(run_values)
+        self.assertEqual(common, ["git", "tar", "wget"])
+        self.assertEqual(arch, {})
+
+    def test_arch_conditional_x86_64(self):
+        run_values = [
+            "dnf install -y make && if [ $(arch) = x86_64 ]; then dnf -y install kernel-rt-devel kernel-rt-modules; fi"
+        ]
+        common, arch, _, _, _, _ = analyze_run_commands(run_values)
+        self.assertEqual(common, ["make"])
+        self.assertEqual(arch, {"x86_64": ["kernel-rt-devel", "kernel-rt-modules"]})
+
+    def test_fallback_install_after_or(self):
+        run_values = ["dnf -y install gcc-${GCC_VERSION} gcc-c++-${GCC_VERSION} || dnf -y install gcc gcc-c++"]
+        common, arch, _, _, _, _ = analyze_run_commands(run_values)
+        self.assertEqual(common, ["gcc", "gcc-c++"])
+        self.assertEqual(arch, {})
+
+    def test_if_not_yum_install(self):
+        run_values = [
+            "if ! yum install -y prometheus-promu; then curl -s -L https://example.com/promu.tar.gz | tar -xzvf -; fi"
+        ]
+        common, arch, _, _, _, _ = analyze_run_commands(run_values)
+        self.assertEqual(common, ["prometheus-promu"])
+        self.assertEqual(arch, {})
+
+    def test_subshell_arch_conditional_var(self):
+        run_values = [
+            'ARCH_DEP_PKGS=$(if [ "$(uname -m)" != "s390x" ]; then echo -n mstflint ; fi) && '
+            "yum -y install pciutils hwdata kmod $ARCH_DEP_PKGS"
+        ]
+        common, arch, _, _, _, _ = analyze_run_commands(run_values)
+        self.assertIn("mstflint", common)
+        self.assertIn("pciutils", common)
+        self.assertIn("hwdata", common)
+        self.assertIn("kmod", common)
+        self.assertEqual(arch, {})
+
+    def test_arch_conditional_multiple_arches(self):
+        run_values = [
+            "if [ $(arch) = x86_64 ]; then dnf -y install kernel-rt-devel; fi && "
+            "if [ $(arch) = aarch64 ]; then dnf -y install kernel-64k-devel; fi"
+        ]
+        common, arch, _, _, _, _ = analyze_run_commands(run_values)
+        self.assertEqual(common, [])
+        self.assertEqual(arch, {"aarch64": ["kernel-64k-devel"], "x86_64": ["kernel-rt-devel"]})
+
+    def test_hosttype_arch_conditional(self):
+        run_values = [
+            'PACKAGES="git gzip" && '
+            "if [ $HOSTTYPE = x86_64 ]; then PACKAGES=\"$PACKAGES realtime-tests\"; fi && "
+            "yum install -y $PACKAGES"
+        ]
+        common, arch, _, _, _, _ = analyze_run_commands(run_values)
+        self.assertIn("git", common)
+        self.assertIn("gzip", common)
+        self.assertNotIn("realtime-tests", common)
+        self.assertEqual(arch.get("x86_64"), ["realtime-tests"])
+
+    def test_double_bracket_conditional_with_quoted_var_install(self):
+        run_values = [
+            'if [[ "$ARCH" == "x86_64" ]]; then '
+            "GRUB_PKG=grub2-efi-x64; SHIM_PKG=shim-x64; "
+            'elif [[ "$ARCH" == "aarch64" ]]; then '
+            "GRUB_PKG=grub2-efi-aa64; SHIM_PKG=shim-aa64; "
+            "fi && "
+            'dnf install -y "$GRUB_PKG" "$SHIM_PKG"'
+        ]
+        common, arch, _, _, _, _ = analyze_run_commands(run_values)
+        self.assertEqual(common, [])
+        self.assertEqual(arch.get("x86_64"), ["grub2-efi-x64", "shim-x64"])
+        self.assertEqual(arch.get("aarch64"), ["grub2-efi-aa64", "shim-aa64"])
+
+    def test_version_constraints_stripped(self):
+        run_values = ["dnf install -y 'python3.12-setuptools >= 70.3.0' python3.12-pip"]
+        common, arch, _, _, _, _ = analyze_run_commands(run_values)
+        self.assertIn("python3.12-setuptools", common)
+        self.assertIn("python3.12-pip", common)
+        self.assertNotIn(">=", common)
+        self.assertNotIn("70.3.0", common)
+
+    def test_file_path_package_specs_are_included(self):
+        run_values = [
+            "yum install --setopt=tsflags=nodocs -y "
+            "e2fsprogs xfsprogs util-linux nvme-cli "
+            "/usr/lib/udev/scsi_id /usr/bin/xxd"
+        ]
+        common, arch, _, _, _, _ = analyze_run_commands(run_values)
+        self.assertIn("e2fsprogs", common)
+        self.assertIn("/usr/lib/udev/scsi_id", common)
+        self.assertIn("/usr/bin/xxd", common)
+
+
+@pytest.mark.parametrize(
+    "text, expected",
+    [
+        ("[ $(arch) = x86_64 ]", "x86_64"),
+        ("[ $HOSTTYPE = aarch64 ]", "aarch64"),
+        ("[ ${HOSTTYPE} == ppc64le ]", "ppc64le"),
+        ("[ $(uname -m) = s390x ]", "s390x"),
+        ("[ $(uname -p) == x86_64 ]", "x86_64"),
+        ("[ $ARCH = aarch64 ]", "aarch64"),
+        ('[ ${ARCH} == x86_64 ]', "x86_64"),
+        ('[ $(arch) == "x86_64" ]', "x86_64"),
+    ],
+)
+def test_arch_value_regex_matches(text, expected):
+    m = ARCH_VALUE_RE.search(text)
+    assert m is not None, f"No match for: {text}"
+    assert m.group(1) == expected
+
+
+def test_arch_value_regex_no_match():
+    assert ARCH_VALUE_RE.search("echo hello") is None
+
+
+class TestBuilddepParsing(unittest.TestCase):
+    def test_simple_builddep(self):
+        run_values = ["dnf builddep -y pkcs11-helper*"]
+        _, _, _, _, builddep, _ = analyze_run_commands(run_values)
+        self.assertEqual(builddep, ["pkcs11-helper*"])
+
+    def test_builddep_with_flags(self):
+        run_values = ["dnf builddep -y --skip-broken --nobest openvpn*"]
+        _, _, _, _, builddep, _ = analyze_run_commands(run_values)
+        self.assertEqual(builddep, ["openvpn*"])
+
+    def test_builddep_does_not_interfere_with_install(self):
+        run_values = ["dnf install -y gcc make && dnf builddep -y pkcs11-helper*"]
+        common, arch, _, _, builddep, _ = analyze_run_commands(run_values)
+        self.assertEqual(common, ["gcc", "make"])
+        self.assertEqual(arch, {})
+        self.assertEqual(builddep, ["pkcs11-helper*"])
+
+
+class TestModuleParsing(unittest.TestCase):
+    def test_module_install(self):
+        run_values = ["dnf module install -y nodejs:18/development"]
+        _, _, _, _, _, modules = analyze_run_commands(run_values)
+        self.assertEqual(modules, ["nodejs:18/development"])
+
+    def test_module_enable(self):
+        run_values = ["dnf module enable -y nodejs:18"]
+        _, _, _, _, _, modules = analyze_run_commands(run_values)
+        self.assertEqual(modules, ["nodejs:18"])
+
+    def test_module_without_stream_ignored(self):
+        run_values = ["dnf module enable -y nodejs"]
+        _, _, _, _, _, modules = analyze_run_commands(run_values)
+        self.assertEqual(modules, [])

--- a/tests/test_shell_commands.py
+++ b/tests/test_shell_commands.py
@@ -159,6 +159,25 @@ class TestAnalyzeRunCommands(unittest.TestCase):
         self.assertNotIn("realtime-tests", common)
         self.assertEqual(arch.get("x86_64"), ["realtime-tests"])
 
+    def test_glob_package_pattern_with_resolved_var(self):
+        """
+        Glob patterns like golang-*$VERSION* should be included after
+        variable resolution (e.g. golang-*1.26*). DNF supports globs.
+        """
+        run_values = ['dnf install -y "golang-*$VERSION*"']
+        common, arch, _, _, _, _ = analyze_run_commands(run_values, env_vars={"VERSION": "1.26"})
+        self.assertIn("golang-*1.26*", common)
+        self.assertEqual(arch, {})
+
+    def test_glob_package_pattern_without_var(self):
+        """
+        Bare glob patterns like python3* should also be included.
+        """
+        run_values = ["dnf install -y python3*"]
+        common, arch, _, _, _, _ = analyze_run_commands(run_values)
+        self.assertIn("python3*", common)
+        self.assertEqual(arch, {})
+
     def test_double_bracket_conditional_with_quoted_var_install(self):
         run_values = [
             'if [[ "$ARCH" == "x86_64" ]]; then '

--- a/tests/test_shell_commands.py
+++ b/tests/test_shell_commands.py
@@ -70,82 +70,82 @@ class TestResolveBashExpansion(unittest.TestCase):
 class TestAnalyzeRunCommands(unittest.TestCase):
     def test_resolves_arg_in_packages(self):
         run_values = ["dnf install -y gcc-${GCC_VERSION} gcc-c++-${GCC_VERSION}"]
-        common, arch, _, _, _, _ = analyze_run_commands(run_values, env_vars={"GCC_VERSION": "12"})
-        self.assertEqual(common, ["gcc-12", "gcc-c++-12"])
-        self.assertEqual(arch, {})
+        result = analyze_run_commands(run_values, env_vars={"GCC_VERSION": "12"})
+        self.assertEqual(result.packages, ["gcc-12", "gcc-c++-12"])
+        self.assertEqual(result.arch_packages, {})
 
     def test_kernel_devel_conditional_with_version(self):
         run_values = [
             "dnf install -y kernel-devel${KERNEL_VERSION:+-}${KERNEL_VERSION}"
             " kernel-headers${KERNEL_VERSION:+-}${KERNEL_VERSION}"
         ]
-        common, arch, _, _, _, _ = analyze_run_commands(run_values, env_vars={"KERNEL_VERSION": "5.14.0"})
-        self.assertEqual(common, ["kernel-devel-5.14.0", "kernel-headers-5.14.0"])
-        self.assertEqual(arch, {})
+        result = analyze_run_commands(run_values, env_vars={"KERNEL_VERSION": "5.14.0"})
+        self.assertEqual(result.packages, ["kernel-devel-5.14.0", "kernel-headers-5.14.0"])
+        self.assertEqual(result.arch_packages, {})
 
     def test_kernel_devel_conditional_without_version(self):
         run_values = [
             "dnf install -y kernel-devel${KERNEL_VERSION:+-}${KERNEL_VERSION}"
             " kernel-headers${KERNEL_VERSION:+-}${KERNEL_VERSION}"
         ]
-        common, arch, _, _, _, _ = analyze_run_commands(run_values, env_vars={})
-        self.assertEqual(common, ["kernel-devel", "kernel-headers"])
-        self.assertEqual(arch, {})
+        result = analyze_run_commands(run_values, env_vars={})
+        self.assertEqual(result.packages, ["kernel-devel", "kernel-headers"])
+        self.assertEqual(result.arch_packages, {})
 
     def test_unresolved_var_skipped(self):
         run_values = ["dnf install -y gcc-${UNKNOWN} make"]
-        common, arch, _, _, _, _ = analyze_run_commands(run_values, env_vars={})
-        self.assertEqual(common, ["make"])
-        self.assertEqual(arch, {})
+        result = analyze_run_commands(run_values, env_vars={})
+        self.assertEqual(result.packages, ["make"])
+        self.assertEqual(result.arch_packages, {})
 
     def test_no_env_vars_backward_compatible(self):
         run_values = ['INSTALL_PKGS="wget tar" && dnf install -y ${INSTALL_PKGS} git']
-        common, arch, _, _, _, _ = analyze_run_commands(run_values)
-        self.assertEqual(common, ["git", "tar", "wget"])
-        self.assertEqual(arch, {})
+        result = analyze_run_commands(run_values)
+        self.assertEqual(result.packages, ["git", "tar", "wget"])
+        self.assertEqual(result.arch_packages, {})
 
     def test_arch_conditional_x86_64(self):
         run_values = [
             "dnf install -y make && if [ $(arch) = x86_64 ]; then dnf -y install kernel-rt-devel kernel-rt-modules; fi"
         ]
-        common, arch, _, _, _, _ = analyze_run_commands(run_values)
-        self.assertEqual(common, ["make"])
-        self.assertEqual(arch, {"x86_64": ["kernel-rt-devel", "kernel-rt-modules"]})
+        result = analyze_run_commands(run_values)
+        self.assertEqual(result.packages, ["make"])
+        self.assertEqual(result.arch_packages, {"x86_64": ["kernel-rt-devel", "kernel-rt-modules"]})
 
     def test_fallback_install_after_or(self):
         run_values = ["dnf -y install gcc-${GCC_VERSION} gcc-c++-${GCC_VERSION} || dnf -y install gcc gcc-c++"]
-        common, arch, _, _, _, _ = analyze_run_commands(run_values)
-        self.assertEqual(common, ["gcc", "gcc-c++"])
-        self.assertEqual(arch, {})
+        result = analyze_run_commands(run_values)
+        self.assertEqual(result.packages, ["gcc", "gcc-c++"])
+        self.assertEqual(result.arch_packages, {})
 
     def test_if_not_yum_install(self):
         run_values = [
             "if ! yum install -y prometheus-promu; then curl -s -L https://example.com/promu.tar.gz | tar -xzvf -; fi"
         ]
-        common, arch, _, _, _, _ = analyze_run_commands(run_values)
-        self.assertEqual(common, ["prometheus-promu"])
-        self.assertEqual(arch, {})
+        result = analyze_run_commands(run_values)
+        self.assertEqual(result.packages, ["prometheus-promu"])
+        self.assertEqual(result.arch_packages, {})
 
     def test_subshell_arch_conditional_var(self):
         run_values = [
             'ARCH_DEP_PKGS=$(if [ "$(uname -m)" != "s390x" ]; then echo -n mstflint ; fi) && '
             "yum -y install pciutils hwdata kmod $ARCH_DEP_PKGS"
         ]
-        common, arch, _, _, _, _ = analyze_run_commands(run_values)
-        self.assertIn("mstflint", common)
-        self.assertIn("pciutils", common)
-        self.assertIn("hwdata", common)
-        self.assertIn("kmod", common)
-        self.assertEqual(arch, {})
+        result = analyze_run_commands(run_values)
+        self.assertIn("mstflint", result.packages)
+        self.assertIn("pciutils", result.packages)
+        self.assertIn("hwdata", result.packages)
+        self.assertIn("kmod", result.packages)
+        self.assertEqual(result.arch_packages, {})
 
     def test_arch_conditional_multiple_arches(self):
         run_values = [
             "if [ $(arch) = x86_64 ]; then dnf -y install kernel-rt-devel; fi && "
             "if [ $(arch) = aarch64 ]; then dnf -y install kernel-64k-devel; fi"
         ]
-        common, arch, _, _, _, _ = analyze_run_commands(run_values)
-        self.assertEqual(common, [])
-        self.assertEqual(arch, {"aarch64": ["kernel-64k-devel"], "x86_64": ["kernel-rt-devel"]})
+        result = analyze_run_commands(run_values)
+        self.assertEqual(result.packages, [])
+        self.assertEqual(result.arch_packages, {"aarch64": ["kernel-64k-devel"], "x86_64": ["kernel-rt-devel"]})
 
     def test_hosttype_arch_conditional(self):
         run_values = [
@@ -153,11 +153,11 @@ class TestAnalyzeRunCommands(unittest.TestCase):
             "if [ $HOSTTYPE = x86_64 ]; then PACKAGES=\"$PACKAGES realtime-tests\"; fi && "
             "yum install -y $PACKAGES"
         ]
-        common, arch, _, _, _, _ = analyze_run_commands(run_values)
-        self.assertIn("git", common)
-        self.assertIn("gzip", common)
-        self.assertNotIn("realtime-tests", common)
-        self.assertEqual(arch.get("x86_64"), ["realtime-tests"])
+        result = analyze_run_commands(run_values)
+        self.assertIn("git", result.packages)
+        self.assertIn("gzip", result.packages)
+        self.assertNotIn("realtime-tests", result.packages)
+        self.assertEqual(result.arch_packages.get("x86_64"), ["realtime-tests"])
 
     def test_glob_package_pattern_with_resolved_var(self):
         """
@@ -165,18 +165,18 @@ class TestAnalyzeRunCommands(unittest.TestCase):
         variable resolution (e.g. golang-*1.26*). DNF supports globs.
         """
         run_values = ['dnf install -y "golang-*$VERSION*"']
-        common, arch, _, _, _, _ = analyze_run_commands(run_values, env_vars={"VERSION": "1.26"})
-        self.assertIn("golang-*1.26*", common)
-        self.assertEqual(arch, {})
+        result = analyze_run_commands(run_values, env_vars={"VERSION": "1.26"})
+        self.assertIn("golang-*1.26*", result.packages)
+        self.assertEqual(result.arch_packages, {})
 
     def test_glob_package_pattern_without_var(self):
         """
         Bare glob patterns like python3* should also be included.
         """
         run_values = ["dnf install -y python3*"]
-        common, arch, _, _, _, _ = analyze_run_commands(run_values)
-        self.assertIn("python3*", common)
-        self.assertEqual(arch, {})
+        result = analyze_run_commands(run_values)
+        self.assertIn("python3*", result.packages)
+        self.assertEqual(result.arch_packages, {})
 
     def test_double_bracket_conditional_with_quoted_var_install(self):
         run_values = [
@@ -187,18 +187,18 @@ class TestAnalyzeRunCommands(unittest.TestCase):
             "fi && "
             'dnf install -y "$GRUB_PKG" "$SHIM_PKG"'
         ]
-        common, arch, _, _, _, _ = analyze_run_commands(run_values)
-        self.assertEqual(common, [])
-        self.assertEqual(arch.get("x86_64"), ["grub2-efi-x64", "shim-x64"])
-        self.assertEqual(arch.get("aarch64"), ["grub2-efi-aa64", "shim-aa64"])
+        result = analyze_run_commands(run_values)
+        self.assertEqual(result.packages, [])
+        self.assertEqual(result.arch_packages.get("x86_64"), ["grub2-efi-x64", "shim-x64"])
+        self.assertEqual(result.arch_packages.get("aarch64"), ["grub2-efi-aa64", "shim-aa64"])
 
     def test_version_constraints_stripped(self):
         run_values = ["dnf install -y 'python3.12-setuptools >= 70.3.0' python3.12-pip"]
-        common, arch, _, _, _, _ = analyze_run_commands(run_values)
-        self.assertIn("python3.12-setuptools", common)
-        self.assertIn("python3.12-pip", common)
-        self.assertNotIn(">=", common)
-        self.assertNotIn("70.3.0", common)
+        result = analyze_run_commands(run_values)
+        self.assertIn("python3.12-setuptools", result.packages)
+        self.assertIn("python3.12-pip", result.packages)
+        self.assertNotIn(">=", result.packages)
+        self.assertNotIn("70.3.0", result.packages)
 
     def test_file_path_package_specs_are_included(self):
         run_values = [
@@ -206,10 +206,10 @@ class TestAnalyzeRunCommands(unittest.TestCase):
             "e2fsprogs xfsprogs util-linux nvme-cli "
             "/usr/lib/udev/scsi_id /usr/bin/xxd"
         ]
-        common, arch, _, _, _, _ = analyze_run_commands(run_values)
-        self.assertIn("e2fsprogs", common)
-        self.assertIn("/usr/lib/udev/scsi_id", common)
-        self.assertIn("/usr/bin/xxd", common)
+        result = analyze_run_commands(run_values)
+        self.assertIn("e2fsprogs", result.packages)
+        self.assertIn("/usr/lib/udev/scsi_id", result.packages)
+        self.assertIn("/usr/bin/xxd", result.packages)
 
 
 @pytest.mark.parametrize(
@@ -238,34 +238,34 @@ def test_arch_value_regex_no_match():
 class TestBuilddepParsing(unittest.TestCase):
     def test_simple_builddep(self):
         run_values = ["dnf builddep -y pkcs11-helper*"]
-        _, _, _, _, builddep, _ = analyze_run_commands(run_values)
-        self.assertEqual(builddep, ["pkcs11-helper*"])
+        result = analyze_run_commands(run_values)
+        self.assertEqual(result.builddep_packages, ["pkcs11-helper*"])
 
     def test_builddep_with_flags(self):
         run_values = ["dnf builddep -y --skip-broken --nobest openvpn*"]
-        _, _, _, _, builddep, _ = analyze_run_commands(run_values)
-        self.assertEqual(builddep, ["openvpn*"])
+        result = analyze_run_commands(run_values)
+        self.assertEqual(result.builddep_packages, ["openvpn*"])
 
     def test_builddep_does_not_interfere_with_install(self):
         run_values = ["dnf install -y gcc make && dnf builddep -y pkcs11-helper*"]
-        common, arch, _, _, builddep, _ = analyze_run_commands(run_values)
-        self.assertEqual(common, ["gcc", "make"])
-        self.assertEqual(arch, {})
-        self.assertEqual(builddep, ["pkcs11-helper*"])
+        result = analyze_run_commands(run_values)
+        self.assertEqual(result.packages, ["gcc", "make"])
+        self.assertEqual(result.arch_packages, {})
+        self.assertEqual(result.builddep_packages, ["pkcs11-helper*"])
 
 
 class TestModuleParsing(unittest.TestCase):
     def test_module_install(self):
         run_values = ["dnf module install -y nodejs:18/development"]
-        _, _, _, _, _, modules = analyze_run_commands(run_values)
-        self.assertEqual(modules, ["nodejs:18/development"])
+        result = analyze_run_commands(run_values)
+        self.assertEqual(result.module_specs, ["nodejs:18/development"])
 
     def test_module_enable(self):
         run_values = ["dnf module enable -y nodejs:18"]
-        _, _, _, _, _, modules = analyze_run_commands(run_values)
-        self.assertEqual(modules, ["nodejs:18"])
+        result = analyze_run_commands(run_values)
+        self.assertEqual(result.module_specs, ["nodejs:18"])
 
     def test_module_without_stream_ignored(self):
         run_values = ["dnf module enable -y nodejs"]
-        _, _, _, _, _, modules = analyze_run_commands(run_values)
-        self.assertEqual(modules, [])
+        result = analyze_run_commands(run_values)
+        self.assertEqual(result.module_specs, [])


### PR DESCRIPTION
## Summary
  
This is a proposal to upstream the Containerfile/bash parsing logic into rpm-lockfile-prototype.

We implemented this logic on our side in [openshift-eng/art-tools#2852](https://github.com/openshift-eng/art-tools/pull/2852) to extract package names from Containerfile `RUN` commands before feeding them to `rpm-lockfile-prototype` for resolution. 

However, we noticed the [existing TODO](https://github.com/konflux-ci/rpm-lockfile-prototype/blob/11cc01c/rpm_lockfile/__init__.py#L540) (`# TODO maybe try extracting packages from Containerfile?`) — the intention to support this was already there, so we'd like to move this logic upstream where it benefits all consumers.

Again, this is just a proposal — happy to discuss the approach, adjust the implementation, or split things differently if needed.

### What this does

When `-f`/`--containerfile` is used, the tool now also parses `RUN` commands to extract `dnf`/`yum`/`microdnf` install invocations and includes those packages in dependency resolution, no extra flags needed.
   
### New modules
  
- **`shell_commands.py`** — bashlex-based AST walking for shell variable expansion, arch-conditional detection, and package extraction from install commands
- **`containerfile_packages.py`** — Dockerfile stage analysis, COPY map building, script discovery, and file-install pattern detection

### Capabilities
  
- Shell variable expansion (`${VAR}`, `${VAR:-default}`, `${VAR:+alt}`)
- Architecture-conditional packages (`$(arch)`, `$HOSTTYPE`, `$ARCH` in if/elif)
- Script extraction (COPY'd `.sh` files invoked in RUN)
- File-based installs (`xargs dnf install < file`)
- `dnf builddep` and `module enable/install`
- Version constraint stripping
  
### New dependencies

- `bashlex` — bash lexer/parser for AST walking
- `dockerfile-parse` — Dockerfile structure parsing


