### PR TITLE
fix: add usr/share/rpm to rpmdb extraction paths

### DIFF
--- a/rpm_lockfile/containers.py
+++ b/rpm_lockfile/containers.py
@@ -12,7 +12,7 @@ from . import utils
 
 # Known locations for rpmdb inside the image; files/lib is for
 # Flatpak runtime images.
-RPMDB_PATHS = ["usr/lib/sysimage/rpm", "var/lib/rpm", "files/lib/sysimage/rpm"]
+RPMDB_PATHS = ["usr/lib/sysimage/rpm", "var/lib/rpm", "files/lib/sysimage/rpm", "usr/share/rpm"]
 
 # Storage usage limit. If the filesystem with the cache fills up over this
 # limit, nothing new will be added into the cache.


### PR DESCRIPTION
## Summary

rhel-bootc images (such as `registry.redhat.io/rhel9/rhel-bootc:9.8`) store the rpmdb at `/usr/share/rpm` with a symlink from `/usr/lib/sysimage/rpm` → `../../share/rpm`. The extraction filter only matched the symlink path, not the actual database location, so the rpmdb files were never extracted from the image layers.

Adding `usr/share/rpm` to `RPMDB_PATHS` ensures the actual database files are extracted alongside the symlink.