### PR TITLE
fix: support Python 3.9 by deferring annotation evaluation

### DIFF
--- a/rpm_lockfile/containerfile_packages.py
+++ b/rpm_lockfile/containerfile_packages.py
@@ -7,6 +7,8 @@ referenced in RUN commands, and analyze per-stage install and update
 commands.
 """
 
+from __future__ import annotations
+
 import logging
 import re
 import shlex

--- a/rpm_lockfile/shell_commands.py
+++ b/rpm_lockfile/shell_commands.py
@@ -7,6 +7,8 @@ Handles variable assignments, arch-conditional blocks, subshell
 expansions, and bash-to-POSIX preprocessing.
 """
 
+from __future__ import annotations
+
 import logging
 import re
 from dataclasses import dataclass, field


### PR DESCRIPTION
Add 'from __future__ import annotations' to shell_commands.py and containerfile_packages.py to defer evaluation of type annotations. The X | Y union syntax introduced in these modules requires Python 3.10+ at runtime without this import, causing a TypeError on Python 3.9.

Fixes #132