### PR TITLE
Wire up builddep from Containerfile and support [ test ] || cmd arch-conditionals

### DIFF
--- a/rpm_lockfile/__init__.py
+++ b/rpm_lockfile/__init__.py
@@ -26,7 +26,7 @@ except ImportError:
 import yaml
 
 from . import containers, content_origin, schema, utils
-from .containerfile_packages import analyze_containerfile_stages, select_stage
+from .containerfile_packages import analyze_containerfile_stages, resolve_builddep_packages, select_stage
 
 CONTAINERFILE_HELP = """
 Load installed packages from base image specified in Containerfile and make
@@ -463,7 +463,7 @@ def logging_setup(debug=False):
 def _extract_containerfile_packages(
     containerfile: str,
     context: dict,
-) -> tuple[set[str], dict[str, set[str]], set[str], set[str]]:
+) -> tuple[set[str], dict[str, set[str]], set[str], set[str], list[str]]:
     """
     Extract RPM package names from Containerfile RUN commands.
 
@@ -475,12 +475,13 @@ def _extract_containerfile_packages(
         context (dict): Configuration context with optional stage filters.
     Return Value(s):
         tuple: (common_packages, arch_packages, upgrade_packages,
-                module_enable) — all empty on failure.
+                module_enable, builddep_packages) — all empty on failure.
     """
     common_packages: set[str] = set()
     arch_packages: dict[str, set[str]] = {}
     upgrade_packages: set[str] = set()
     module_enable: set[str] = set()
+    builddep_packages: list[str] = []
 
     cf_path = Path(containerfile)
     source_dir = cf_path.parent
@@ -492,6 +493,7 @@ def _extract_containerfile_packages(
             arch_packages.setdefault(arch, set()).update(pkgs)
         upgrade_packages.update(selected.update_targets)
         module_enable.update(selected.module_specs)
+        builddep_packages = list(selected.builddep_packages)
     if common_packages or arch_packages:
         logging.info(
             "Extracted %d common and %d arch-specific packages from Containerfile",
@@ -508,12 +510,15 @@ def _extract_containerfile_packages(
             )
         if module_enable:
             logging.debug("Containerfile module enable: %s", sorted(module_enable))
+        if builddep_packages:
+            logging.debug("Containerfile builddep patterns: %s", sorted(builddep_packages))
 
     return (
         common_packages,
         arch_packages,
         upgrade_packages,
         module_enable,
+        builddep_packages,
     )
 
 
@@ -569,6 +574,7 @@ def main():
     containerfile_arch_packages: dict[str, set[str]] = {}
     containerfile_upgrade_packages: set[str] = set()
     containerfile_module_enable: set[str] = set()
+    containerfile_builddep_packages: list[str] = []
 
     if args.local_system or context.get("localSystem"):
         rpmdb = local_rpmdb()
@@ -609,6 +615,7 @@ def main():
                     containerfile_arch_packages,
                     containerfile_upgrade_packages,
                     containerfile_module_enable,
+                    containerfile_builddep_packages,
                 ) = _extract_containerfile_packages(containerfile, context)
             except Exception:
                 logging.warning(
@@ -617,6 +624,11 @@ def main():
                     containerfile,
                     exc_info=True,
                 )
+
+            if containerfile_builddep_packages:
+                source_dir = Path(containerfile).parent
+                builddep_resolved = resolve_builddep_packages(containerfile_builddep_packages, source_dir)
+                containerfile_common_packages |= builddep_resolved
 
     for arch in sorted(arches):
         packages = set()

--- a/rpm_lockfile/containerfile_packages.py
+++ b/rpm_lockfile/containerfile_packages.py
@@ -631,9 +631,10 @@ def resolve_builddep_packages(
                     continue
                 for line in result.stdout.strip().splitlines():
                     req = line.strip().split()[0] if line.strip() else ""
-                    # Skip file-path provides (/usr/bin/...) and virtual
-                    # provides like rpmlib(...) — only keep package names
-                    if req and not req.startswith("/") and "(" not in req:
+                    # Skip rpmlib(...) — those are RPM-internal and not
+                    # installable. Everything else (package names, file
+                    # paths, virtual provides) is valid for resolution.
+                    if req and not req.startswith("rpmlib("):
                         resolved.add(req)
             except Exception as exc:
                 logging.warning(

--- a/rpm_lockfile/containerfile_packages.py
+++ b/rpm_lockfile/containerfile_packages.py
@@ -9,9 +9,11 @@ commands.
 
 from __future__ import annotations
 
+import fnmatch
 import logging
 import re
 import shlex
+import subprocess
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
 
@@ -571,6 +573,84 @@ def analyze_containerfile_stages(
         stages.append(stage)
 
     return stages
+
+
+def resolve_builddep_packages(
+    builddep_patterns: list[str],
+    source_dir: Path,
+) -> set[str]:
+    """
+    Resolve dnf builddep glob patterns to concrete BuildRequires by
+    finding matching SRPMs/spec files in source_dir and extracting
+    their dependencies via rpm -qpR (SRPMs) or rpmspec (spec files).
+
+    Arg(s):
+        builddep_patterns (list[str]): Glob patterns from dnf builddep
+            commands (e.g., ["pkcs11-helper*", "openvpn*"]).
+        source_dir (Path): Directory containing SRPMs or spec files.
+    Return Value(s):
+        set[str]: Deduplicated package names from BuildRequires.
+    """
+    resolved: set[str] = set()
+
+    for pattern in builddep_patterns:
+        srpm_pattern = pattern if pattern.endswith(".src.rpm") else f"{pattern}.src.rpm"
+        matching = [
+            f
+            for f in source_dir.iterdir()
+            if f.is_file()
+            and f.name.endswith(".src.rpm")
+            and fnmatch.fnmatch(f.name, srpm_pattern)
+        ]
+
+        if not matching:
+            matching = [
+                f
+                for f in source_dir.iterdir()
+                if f.is_file()
+                and f.name.endswith(".spec")
+                and fnmatch.fnmatch(f.name, pattern)
+            ]
+
+        if not matching:
+            logging.warning(
+                "No SRPM or spec file matching '%s' found in %s, "
+                "builddep packages will not be included in lockfile",
+                pattern,
+                source_dir,
+            )
+            continue
+
+        for path in matching:
+            logging.info("Extracting BuildRequires from %s", path.name)
+            if path.name.endswith(".spec"):
+                cmd = ["rpmspec", "-q", "--buildrequires", str(path)]
+            else:
+                cmd = ["rpm", "-qpR", str(path)]
+            try:
+                result = subprocess.run(
+                    cmd,
+                    capture_output=True,
+                    text=True,
+                    check=False,
+                )
+                if result.returncode != 0:
+                    logging.warning("%s failed: %s", " ".join(cmd), result.stderr)
+                    continue
+                for line in result.stdout.strip().splitlines():
+                    req = line.strip().split()[0] if line.strip() else ""
+                    if req and not req.startswith("/") and "(" not in req:
+                        resolved.add(req)
+            except Exception as exc:
+                logging.warning(
+                    "Failed to extract BuildRequires from %s: %s", path.name, exc
+                )
+
+    if resolved:
+        logging.info(
+            "Resolved %d builddep packages: %s", len(resolved), sorted(resolved)
+        )
+    return resolved
 
 
 def select_stage(

--- a/rpm_lockfile/containerfile_packages.py
+++ b/rpm_lockfile/containerfile_packages.py
@@ -581,13 +581,17 @@ def resolve_builddep_packages(
 ) -> set[str]:
     """
     Resolve dnf builddep glob patterns to concrete BuildRequires by
-    finding matching SRPMs/spec files in source_dir and extracting
-    their dependencies via rpm -qpR (SRPMs) or rpmspec (spec files).
+    finding matching SRPMs in source_dir and extracting their
+    dependencies via rpm -qpR.
+
+    Spec files are intentionally not supported: rpmspec resolves macros
+    using host system definitions, which may not match the build
+    environment and would produce incorrect results.
 
     Arg(s):
         builddep_patterns (list[str]): Glob patterns from dnf builddep
             commands (e.g., ["pkcs11-helper*", "openvpn*"]).
-        source_dir (Path): Directory containing SRPMs or spec files.
+        source_dir (Path): Directory containing SRPMs.
     Return Value(s):
         set[str]: Deduplicated package names from BuildRequires.
     """
@@ -604,17 +608,8 @@ def resolve_builddep_packages(
         ]
 
         if not matching:
-            matching = [
-                f
-                for f in source_dir.iterdir()
-                if f.is_file()
-                and f.name.endswith(".spec")
-                and fnmatch.fnmatch(f.name, pattern)
-            ]
-
-        if not matching:
             logging.warning(
-                "No SRPM or spec file matching '%s' found in %s, "
+                "No SRPM matching '%s' found in %s, "
                 "builddep packages will not be included in lockfile",
                 pattern,
                 source_dir,
@@ -623,11 +618,8 @@ def resolve_builddep_packages(
 
         for path in matching:
             logging.info("Extracting BuildRequires from %s", path.name)
-            if path.name.endswith(".spec"):
-                cmd = ["rpmspec", "-q", "--buildrequires", str(path)]
-            else:
-                cmd = ["rpm", "-qpR", str(path)]
             try:
+                cmd = ["rpm", "-qpR", str(path)]
                 result = subprocess.run(
                     cmd,
                     capture_output=True,
@@ -639,6 +631,8 @@ def resolve_builddep_packages(
                     continue
                 for line in result.stdout.strip().splitlines():
                     req = line.strip().split()[0] if line.strip() else ""
+                    # Skip file-path provides (/usr/bin/...) and virtual
+                    # provides like rpmlib(...) — only keep package names
                     if req and not req.startswith("/") and "(" not in req:
                         resolved.add(req)
             except Exception as exc:

--- a/rpm_lockfile/shell_commands.py
+++ b/rpm_lockfile/shell_commands.py
@@ -15,12 +15,11 @@ from dataclasses import dataclass, field
 
 from rpm_lockfile.vendor import bashlex
 
-
 # Shell subshell expressions that evaluate to the current architecture
-ARCH_SUBSHELL_KEYWORDS = ("$(arch)", "$(uname -m)", "$(uname -p)")
+ARCH_SUBSHELL_KEYWORDS = ("$(arch)", "$(uname -m)", "$(uname -p)", "$(go env GOARCH)")
 
 # Shell variable names that hold the current architecture
-ARCH_VAR_NAMES = ("HOSTTYPE", "ARCH")
+ARCH_VAR_NAMES = ("HOSTTYPE", "ARCH", "GOARCH")
 
 # All arch keywords: subshells + variables in both $VAR and ${VAR} forms
 ARCH_KEYWORDS = ARCH_SUBSHELL_KEYWORDS + tuple(
@@ -33,6 +32,17 @@ ARCH_VALUE_RE = re.compile(
     rf"(?:{_ARCH_PATTERN})"
     r"[\"']?\s*==?\s*[\"']?(\w+)[\"']?"
 )
+
+
+ARCH_NEQ_VALUE_RE = re.compile(
+    rf"(?:{_ARCH_PATTERN})"
+    r"""[\"']?\s*!=\s*[\"']?(\w+)[\"']?"""
+)
+
+_GO_TO_RPM_ARCH = {
+    "amd64": "x86_64",
+    "arm64": "aarch64",
+}
 
 
 _MAX_EXPANSION_DEPTH = 10
@@ -143,6 +153,14 @@ def _is_valid_package_token(token: str) -> bool:
     return True
 
 
+def _normalize_arch_names(arches: list[str]) -> list[str]:
+    """
+    Normalize Go-style arch names (amd64, arm64) to RPM names
+    (x86_64, aarch64). Names already in RPM form pass through unchanged.
+    """
+    return [_GO_TO_RPM_ARCH.get(a, a) for a in arches]
+
+
 def _extract_condition_arch(node) -> list[str]:
     """
     Extract architecture names from an if/elif condition node.
@@ -159,8 +177,79 @@ def _extract_condition_arch(node) -> list[str]:
             words = [p.word for p in part.parts if hasattr(p, "word")]
             text = " ".join(words)
             if _has_arch_test(text):
-                arches.extend(_extract_arch_values(text))
+                arches.extend(_normalize_arch_names(_extract_arch_values(text)))
     return arches
+
+
+def _extract_list_arch_context(test_node, operator: str) -> list[str] | None:
+    """
+    Compute effective arch context from a ``[ test ] || cmd`` or
+    ``[ test ] && cmd`` pattern.
+
+    Handles:
+        ``[ $(arch) != X ] || cmd`` -> [X] (double negation = only on X)
+        ``[ $(arch) = X ] && cmd``  -> [X] (direct match = only on X)
+        Other combos need full arch set -> returns None (unconditional).
+    """
+    if not hasattr(test_node, "parts"):
+        return None
+    words = [p.word for p in test_node.parts if hasattr(p, "word")]
+    if not words or words[0] != "[":
+        return None
+    text = " ".join(words)
+    if not _has_arch_test(text):
+        return None
+
+    neq_arches = ARCH_NEQ_VALUE_RE.findall(text)
+    eq_arches = ARCH_VALUE_RE.findall(text)
+
+    if neq_arches and operator == "||":
+        return _normalize_arch_names(neq_arches)
+    if eq_arches and operator == "&&":
+        return _normalize_arch_names(eq_arches)
+
+    logger = logging.getLogger(__name__)
+    logger.debug(
+        f"Unsupported arch-conditional pattern (needs full arch set): {text} {operator} cmd"
+    )
+    return None
+
+
+def _walk_list_node(
+    node,
+    ctx: _WalkContext,
+    arch_context: list[str] | None = None,
+    in_conditional: bool = False,
+):
+    """
+    Walk a list node, detecting ``[ test ] || cmd`` and
+    ``[ test ] && cmd`` arch-conditional patterns.
+    """
+    parts = node.parts
+    consumed: set[int] = set()
+
+    for i, part in enumerate(parts):
+        if part.kind != "command" or i in consumed:
+            continue
+        words = [p.word for p in part.parts if hasattr(p, "word")]
+        if not words or words[0] != "[":
+            continue
+        if i + 2 >= len(parts):
+            continue
+        op_node = parts[i + 1]
+        if not hasattr(op_node, "op") or op_node.op not in ("||", "&&"):
+            continue
+        arch_ctx = _extract_list_arch_context(part, op_node.op)
+        if arch_ctx is None:
+            continue
+        consumed.add(i)
+        consumed.add(i + 1)
+        consumed.add(i + 2)
+        _walk_nodes([parts[i + 2]], ctx, arch_ctx, in_conditional=False)
+
+    remaining = [p for idx, p in enumerate(parts) if idx not in consumed]
+    if remaining:
+        _walk_nodes(remaining, ctx, arch_context, in_conditional)
 
 
 def _walk_nodes(
@@ -177,7 +266,7 @@ def _walk_nodes(
         kind = node.kind
 
         if kind == "list":
-            _walk_nodes(node.parts, ctx, arch_context, in_conditional)
+            _walk_list_node(node, ctx, arch_context, in_conditional)
 
         elif kind == "compound":
             for child in node.list:

--- a/tests/test_containerfile_packages.py
+++ b/tests/test_containerfile_packages.py
@@ -464,12 +464,18 @@ class TestResolveBuilddepPackages(unittest.TestCase):
             with patch("subprocess.run") as mock_run:
                 mock_run.return_value = MagicMock(
                     returncode=0,
-                    stdout="gcc\nopenssl-devel\nrpmlib(CompressedFileNames)\n/usr/bin/perl\nmake\n",
+                    stdout="gcc\nopenssl-devel\nrpmlib(CompressedFileNames)\n/usr/bin/perl\npython3dist(setuptools)\npkgconfig(libcrypto)\nmake\n",
                     stderr="",
                 )
                 result = resolve_builddep_packages(["pkcs11-helper*"], tmp_path)
 
-            self.assertEqual(result, {"gcc", "openssl-devel", "make"})
+            self.assertEqual(
+                result,
+                {
+                    "gcc", "openssl-devel", "/usr/bin/perl",
+                    "python3dist(setuptools)", "pkgconfig(libcrypto)", "make",
+                },
+            )
             mock_run.assert_called_once()
 
     def test_spec_files_not_supported(self):

--- a/tests/test_containerfile_packages.py
+++ b/tests/test_containerfile_packages.py
@@ -5,6 +5,7 @@ Tests for rpm_lockfile.containerfile_packages.
 import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from unittest.mock import MagicMock, patch
 
 from rpm_lockfile.containerfile_packages import (
     StagePackages,
@@ -13,6 +14,7 @@ from rpm_lockfile.containerfile_packages import (
     collect_stage_vars,
     extract_packages_from_file_installs,
     extract_packages_from_scripts,
+    resolve_builddep_packages,
     select_stage,
 )
 
@@ -445,3 +447,61 @@ class TestSelectStage(unittest.TestCase):
     def test_empty_stages_returns_none(self):
         result = select_stage([])
         self.assertIsNone(result)
+
+
+class TestResolveBuilddepPackages(unittest.TestCase):
+
+    def test_from_srpm(self):
+        """
+        resolve_builddep_packages should extract BuildRequires from
+        matching SRPMs via rpm -qpR.
+        """
+        with TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            srpm = tmp_path / "pkcs11-helper-1.26.0-3.el8.src.rpm"
+            srpm.touch()
+
+            with patch("subprocess.run") as mock_run:
+                mock_run.return_value = MagicMock(
+                    returncode=0,
+                    stdout="gcc\nopenssl-devel\nrpmlib(CompressedFileNames)\n/usr/bin/perl\nmake\n",
+                    stderr="",
+                )
+                result = resolve_builddep_packages(["pkcs11-helper*"], tmp_path)
+
+            self.assertEqual(result, {"gcc", "openssl-devel", "make"})
+            mock_run.assert_called_once()
+
+    def test_from_spec(self):
+        """
+        resolve_builddep_packages should fall back to .spec files and use
+        rpmspec instead of rpm -qpR.
+        """
+        with TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            spec = tmp_path / "pkcs11-helper.spec"
+            spec.touch()
+
+            with patch("subprocess.run") as mock_run:
+                mock_run.return_value = MagicMock(
+                    returncode=0,
+                    stdout="gcc\nopenssl-devel\nautomake\n",
+                    stderr="",
+                )
+                result = resolve_builddep_packages(["pkcs11-helper*"], tmp_path)
+
+            self.assertEqual(result, {"gcc", "openssl-devel", "automake"})
+            mock_run.assert_called_once()
+            cmd = mock_run.call_args[0][0]
+            self.assertEqual(cmd[0], "rpmspec")
+            self.assertIn("--buildrequires", cmd)
+
+    def test_no_match(self):
+        """
+        When no SRPM matches, resolve_builddep_packages should return
+        empty set.
+        """
+        with TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            result = resolve_builddep_packages(["nonexistent*"], tmp_path)
+            self.assertEqual(result, set())

--- a/tests/test_containerfile_packages.py
+++ b/tests/test_containerfile_packages.py
@@ -472,10 +472,10 @@ class TestResolveBuilddepPackages(unittest.TestCase):
             self.assertEqual(result, {"gcc", "openssl-devel", "make"})
             mock_run.assert_called_once()
 
-    def test_from_spec(self):
+    def test_spec_files_not_supported(self):
         """
-        resolve_builddep_packages should fall back to .spec files and use
-        rpmspec instead of rpm -qpR.
+        Spec files are not supported because rpmspec resolves macros
+        using host definitions. Only SRPMs should be processed.
         """
         with TemporaryDirectory() as tmp:
             tmp_path = Path(tmp)
@@ -483,18 +483,10 @@ class TestResolveBuilddepPackages(unittest.TestCase):
             spec.touch()
 
             with patch("subprocess.run") as mock_run:
-                mock_run.return_value = MagicMock(
-                    returncode=0,
-                    stdout="gcc\nopenssl-devel\nautomake\n",
-                    stderr="",
-                )
                 result = resolve_builddep_packages(["pkcs11-helper*"], tmp_path)
 
-            self.assertEqual(result, {"gcc", "openssl-devel", "automake"})
-            mock_run.assert_called_once()
-            cmd = mock_run.call_args[0][0]
-            self.assertEqual(cmd[0], "rpmspec")
-            self.assertIn("--buildrequires", cmd)
+            self.assertEqual(result, set())
+            mock_run.assert_not_called()
 
     def test_no_match(self):
         """

--- a/tests/test_shell_commands.py
+++ b/tests/test_shell_commands.py
@@ -7,6 +7,7 @@ import unittest
 import pytest
 from rpm_lockfile.shell_commands import (
     ARCH_VALUE_RE,
+    ARCH_NEQ_VALUE_RE,
     analyze_run_commands,
     resolve_bash_expansion,
 )
@@ -236,6 +237,9 @@ class TestAnalyzeRunCommands(unittest.TestCase):
         ("[ $ARCH = aarch64 ]", "aarch64"),
         ("[ ${ARCH} == x86_64 ]", "x86_64"),
         ('[ $(arch) == "x86_64" ]', "x86_64"),
+        ("[ $(go env GOARCH) = amd64 ]", "amd64"),
+        ("[ $GOARCH = amd64 ]", "amd64"),
+        ('[ ${GOARCH} == arm64 ]', "arm64"),
     ],
 )
 def test_arch_value_regex_matches(text, expected):
@@ -246,6 +250,130 @@ def test_arch_value_regex_matches(text, expected):
 
 def test_arch_value_regex_no_match():
     assert ARCH_VALUE_RE.search("echo hello") is None
+
+
+class TestListArchConditional(unittest.TestCase):
+    """
+    Tests for ``[ test ] || cmd`` and ``[ test ] && cmd`` arch-conditional
+    patterns in list nodes.
+    """
+
+    def test_neq_or_extracts_arch_packages(self):
+        """
+        ``[ $(arch) != x86_64 ] || dnf install -y pkg`` installs only on x86_64.
+        """
+        result = analyze_run_commands(
+            ["[ $(arch) != x86_64 ] || dnf install -y special-pkg"]
+        )
+        self.assertEqual(result.packages, [])
+        self.assertEqual(result.arch_packages, {"x86_64": ["special-pkg"]})
+
+    def test_eq_and_extracts_arch_packages(self):
+        """
+        ``[ $(arch) = x86_64 ] && dnf install -y pkg`` installs only on x86_64.
+        """
+        result = analyze_run_commands(
+            ["[ $(arch) = x86_64 ] && dnf install -y special-pkg"]
+        )
+        self.assertEqual(result.packages, [])
+        self.assertEqual(result.arch_packages, {"x86_64": ["special-pkg"]})
+
+    def test_double_bracket_neq_or(self):
+        """
+        ``[[ $(arch) != aarch64 ]] || yum install -y arm-pkg`` with [[ ]] preprocessing.
+        """
+        result = analyze_run_commands(
+            ["[[ $(arch) != aarch64 ]] || yum install -y arm-pkg"]
+        )
+        self.assertEqual(result.packages, [])
+        self.assertEqual(result.arch_packages, {"aarch64": ["arm-pkg"]})
+
+    def test_eq_or_treated_as_unconditional(self):
+        """
+        ``[ $(arch) = x86_64 ] || dnf install -y pkg`` means "all except x86_64"
+        which needs the full arch set — treated as unconditional.
+        """
+        result = analyze_run_commands(
+            ["[ $(arch) = x86_64 ] || dnf install -y pkg"]
+        )
+        self.assertIn("pkg", result.packages)
+        self.assertEqual(result.arch_packages, {})
+
+    def test_neq_and_treated_as_unconditional(self):
+        """
+        ``[ $(arch) != x86_64 ] && dnf install -y pkg`` means "all except x86_64"
+        — treated as unconditional.
+        """
+        result = analyze_run_commands(
+            ["[ $(arch) != x86_64 ] && dnf install -y pkg"]
+        )
+        self.assertIn("pkg", result.packages)
+        self.assertEqual(result.arch_packages, {})
+
+    def test_arch_context_only_applies_to_next_command(self):
+        """
+        In ``[ test ] || cmd1 && cmd2``, only cmd1 gets the arch context.
+        """
+        result = analyze_run_commands(
+            ["[ $(arch) != x86_64 ] || dnf install -y special-pkg && dnf install -y common-pkg"]
+        )
+        self.assertIn("common-pkg", result.packages)
+        self.assertEqual(result.arch_packages, {"x86_64": ["special-pkg"]})
+
+    def test_regular_or_fallback_unchanged(self):
+        """
+        Regular ``cmd1 || cmd2`` without [ test ] stays unconditional.
+        """
+        result = analyze_run_commands(
+            ["dnf install -y preferred-pkg || dnf install -y fallback-pkg"]
+        )
+        self.assertIn("preferred-pkg", result.packages)
+        self.assertIn("fallback-pkg", result.packages)
+        self.assertEqual(result.arch_packages, {})
+
+    def test_uname_m_neq_or(self):
+        """
+        ``[ $(uname -m) != s390x ] || dnf install -y s390x-pkg``
+        """
+        result = analyze_run_commands(
+            ["[ $(uname -m) != s390x ] || dnf install -y s390x-pkg"]
+        )
+        self.assertEqual(result.packages, [])
+        self.assertEqual(result.arch_packages, {"s390x": ["s390x-pkg"]})
+
+    def test_go_env_goarch_neq_or(self):
+        """
+        ``[ $(go env GOARCH) != "amd64" ] || yum install -y pkg``
+        Go arch name ``amd64`` is normalized to RPM name ``x86_64``.
+        """
+        result = analyze_run_commands(
+            ['[ $(go env GOARCH) != "amd64" ] || yum install -y special-pkg']
+        )
+        self.assertEqual(result.packages, [])
+        self.assertEqual(result.arch_packages, {"x86_64": ["special-pkg"]})
+
+    def test_go_env_goarch_neq_or_subshell(self):
+        """
+        ``[ $(go env GOARCH) != "amd64" ] || (yum install -y pkg1 pkg2 && other)``
+        — subshell grouping after ``||`` should still extract arch packages.
+        Go arch name ``amd64`` is normalized to RPM name ``x86_64``.
+        """
+        result = analyze_run_commands(
+            ['[ $(go env GOARCH) != "amd64" ] || (yum install -y llvm-toolset cmake3 gcc-c++ && tar zfx cross.tar.gz)']
+        )
+        self.assertEqual(result.packages, [])
+        self.assertEqual(result.arch_packages, {"x86_64": ["cmake3", "gcc-c++", "llvm-toolset"]})
+
+    def test_goarch_var_neq_or(self):
+        """
+        ``[ $GOARCH != "arm64" ] || dnf install -y pkg``
+        Go arch name ``arm64`` is normalized to RPM name ``aarch64``.
+        """
+        result = analyze_run_commands(
+            ['[ $GOARCH != "arm64" ] || dnf install -y arm-only-pkg']
+        )
+        self.assertEqual(result.packages, [])
+        self.assertEqual(result.arch_packages, {"aarch64": ["arm-only-pkg"]})
 
 
 class TestBuilddepParsing(unittest.TestCase):

--- a/tests/test_shell_commands.py
+++ b/tests/test_shell_commands.py
@@ -252,6 +252,26 @@ def test_arch_value_regex_no_match():
     assert ARCH_VALUE_RE.search("echo hello") is None
 
 
+@pytest.mark.parametrize(
+    "text, expected",
+    [
+        ('[ "$(uname -m)" != x86_64 ]', "x86_64"),
+        ("[ $(uname -m) != aarch64 ]", "aarch64"),
+        ('[ "$(go env GOARCH)" != amd64 ]', "amd64"),
+        ("[ $GOARCH != arm64 ]", "arm64"),
+        ('[ ${GOARCH} != ppc64le ]', "ppc64le"),
+    ],
+)
+def test_arch_neq_value_regex_matches(text, expected):
+    m = ARCH_NEQ_VALUE_RE.search(text)
+    assert m is not None, f"No match for: {text}"
+    assert m.group(1) == expected
+
+
+def test_arch_neq_value_regex_no_match():
+    assert ARCH_NEQ_VALUE_RE.search("echo hello") is None
+
+
 class TestListArchConditional(unittest.TestCase):
     """
     Tests for ``[ test ] || cmd`` and ``[ test ] && cmd`` arch-conditional


### PR DESCRIPTION
  ### Summary

Wire up `builddep_packages` from Containerfile extraction into the resolution pipeline, and add support for `[ test ] || cmd` / `[ test ] && cmd` arch-conditional install patterns in the shell parser.

  #### Commit 1: Wire up builddep_packages from Containerfile extraction into resolution

  PR #130 added Containerfile package extraction including `builddep_packages` parsing in `shell_commands.py`, but the parsed builddep patterns were never wired into the resolution 
  pipeline. This commit completes that work:

  - Wire `builddep_packages` through `_extract_containerfile_packages` and into lockfile resolution
  - Add `resolve_builddep_packages()` in `containerfile_packages.py` to resolve `dnf builddep` glob patterns against local SRPMs/spec files and extract their `BuildRequires`
  - Resolved dependencies are merged into `containerfile_common_packages` so they flow through normal lockfile resolution

  **How it works:**

  1. `_extract_containerfile_packages` now returns `builddep_packages` (glob patterns like `pkcs11-helper*`) from the selected Containerfile stage
  2. `resolve_builddep_packages()` matches those patterns against `.src.rpm` files in the source directory 
  3. For SRPMs: extracts dependencies via `rpm -qpR`
  4. Filters out rpmlib(...) provides (RPM-internal, not installable) — all other dependency types (package names, file paths like /usr/bin/foo, virtual provides like python3dist(...) and pkgconfig(...)) are kept for resolution
  5. Resolved package names are merged into common packages for lockfile generation

  #### Commit 2: Support `[ arch != X ] || dnf install` pattern in shell parser

  Ported from [openshift-eng/art-tools#2969](https://github.com/openshift-eng/art-tools/pull/2969).

  - Recognize arch-conditional installs using `[ test ] || cmd` and `[ test ] && cmd` shorthand patterns commonly found in Dockerfiles
  - Supported patterns:
    - `[ $(arch) != X ] || dnf install pkg` (install only on X)
    - `[ $(arch) = X ] && dnf install pkg` (install only on X)
    - Works with `[[ ]]`, `$(uname -m)`, `$(uname -p)`, `$(go env GOARCH)`, `$HOSTTYPE`
  - Unsupported "all except X" combos (`= ||`, `!= &&`) treated as unconditional since they need the full arch set to enumerate
  - Added `$(go env GOARCH)` to `ARCH_SUBSHELL_KEYWORDS`
