### PR TITLE
perf: skip repo tag listing during skopeo inspect

### DIFF
--- a/rpm_lockfile/utils.py
+++ b/rpm_lockfile/utils.py
@@ -206,7 +206,7 @@ def inspect_image(image_spec, arch=None):
     cmd = ["skopeo"]
     if arch:
         cmd.append(f"--override-arch={translate_arch(arch)}")
-    cmd.extend(["inspect", f"docker://{strip_tag(image_spec)}"])
+    cmd.extend(["inspect", "--no-tags", f"docker://{strip_tag(image_spec)}"])
     cp = logged_run(cmd, stdout=subprocess.PIPE, check=True)
     return json.loads(cp.stdout)
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -355,7 +355,7 @@ def test_get_labels_from_image(image_spec, image_url):
 
     assert labels == INSPECT_OUTPUT["Labels"]
     mock_run.assert_called_once_with(
-        ["skopeo", "inspect", f"docker://{image_url}"],
+        ["skopeo", "inspect", "--no-tags", f"docker://{image_url}"],
         check=True,
         stdout=subprocess.PIPE,
     )
@@ -381,7 +381,7 @@ def test_get_labels_from_containerfile(tmpdir):
 
     assert labels == INSPECT_OUTPUT["Labels"]
     mock_run.assert_called_once_with(
-        ["skopeo", "inspect", f"docker://{image}"], check=True, stdout=subprocess.PIPE
+        ["skopeo", "inspect", "--no-tags", f"docker://{image}"], check=True, stdout=subprocess.PIPE
     )
 
 
@@ -419,7 +419,7 @@ def test_get_labels_from_containerfile_stage(tmpdir, filter):
 
     assert labels == INSPECT_OUTPUT["Labels"]
     mock_run.assert_called_once_with(
-        ["skopeo", "inspect", f"docker://{image}"], check=True, stdout=subprocess.PIPE
+        ["skopeo", "inspect", "--no-tags", f"docker://{image}"], check=True, stdout=subprocess.PIPE
     )
 
 


### PR DESCRIPTION
## Summary
- Pass `--no-tags` to `skopeo inspect` in `inspect_image()` to avoid listing every tag in a repository.
- Repositories with thousands of tags (e.g. UBI) spend most of inspect time on tag enumeration; this is unnecessary for lockfile generation.

## Motivation
`inspect_image()` is used only to read `Digest` (rpmdb cache pinning) and `Labels` (`varsFromImage` / `varsFromContainerfile`). The tool never consumes `RepoTags` from inspect output.

By default, `skopeo inspect` lists all tags for the repository. On `registry.access.redhat.com/ubi9/ubi:latest` (~2,455 tags), inspect drops from ~7.7s to ~1.5s with `--no-tags`, with identical `Digest` and `Labels`. Other internal repos with thousands of tags dropped from more than an hour inspecting to mere seconds.

## Test plan
- [x] `pytest tests/test_utils.py -k get_labels` — 8 passed
- [x] Run lockfile generation against a high-tag-count base image and confirm output is unchanged
