### PR TITLE
skip Containerfile package scan when packages are explicitly declared

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,20 @@ containerfile:
 If multiple filters for selecting stage are set, the first one to match is
 used.
 
+## Containerfile package scanning and `packages` precedence
+
+When `context.containerfile` is set, the tool automatically extracts package
+names from `RUN dnf/yum/microdnf install` commands in the Containerfile.
+
+If the `packages` key is also present in the input file, the user-defined list
+takes precedence and the Containerfile package scan is skipped. This allows
+users to manually specify packages with `arches: only/not` filtering for cases
+the scanner cannot replicate (e.g. complex shell conditionals, dynamic package
+lists).
+
+The Containerfile is still used for base image resolution and rpmdb extraction
+regardless.
+
 # Environment variables
 
 It is possible to configure persistent cache location for downloaded repodata

--- a/rpm_lockfile/__init__.py
+++ b/rpm_lockfile/__init__.py
@@ -596,8 +596,11 @@ def main():
             or utils.extract_image(containerfile, **_get_containerfile_filters(context))
         )
 
-        # Extract packages from Containerfile RUN commands
-        if containerfile:
+        # Extract packages from Containerfile RUN commands only if the user
+        # has not explicitly declared a packages list. When packages are
+        # specified, the user's list should take precedence over the
+        # Containerfile scan
+        if containerfile and not config.get("packages"):
             try:
                 (
                     containerfile_common_packages,


### PR DESCRIPTION
## Summary
- When `packages` is explicitly declared in `rpms.in.yaml`, skip the Containerfile RUN-command package extraction.
- The user's package list should be the source of truth if they specify it. The Containerfile scanner should not override it.
## Motivation
The Containerfile package scanner (added in #130) provides useful auto-discovery for simple Dockerfiles. However, some complex Containerfiles with different behaviors between architectures can use shell patterns that are really hard to resolve them all via static analysis:
- Short-circuit conditionals:
`[[ $(uname -m) == "x86_64" ]] && PKGS="$PKGS virtio-vga" || true`
- Variable reassignment with subshell/sed:
`[[ $(uname -m) == "s390x" ]] && PKGS="$(echo $PKGS | sed 's/pkg-a//g')" || true`
- Dynamic package lists from external scripts or piped commands
- Nested conditionals, loops over arch arrays, etc.

There are too many possible shell idioms for a static scanner to reliably cover. When it gets a case wrong, arch-specific packages leak into all architectures, causing dnf resolution failures that are confusing to debug.
When a user explicitly specifies a `packages` list, they should have the final word on what gets resolved — not the scanner. The explicit list supports proper `arches: only/not` filtering and is guaranteed to be correct.
## Behavior
| `context.containerfile` | `packages` key present | Containerfile scan |
|---|---|---|
| set | no | runs (auto-discovery) |
| set | yes | skipped (user's list takes precedence) |
| not set | either | n/a |

The Containerfile is still used for base image resolution and rpmdb extraction regardless — only the RUN-command package scanning is affected.