### PR TITLE
fix: detect arch conditions in subshell package assignments

### DIFF
--- a/rpm_lockfile/__init__.py
+++ b/rpm_lockfile/__init__.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+from __future__ import annotations
+
 import argparse
 import contextlib
 import logging
@@ -463,6 +465,7 @@ def logging_setup(debug=False):
 def _extract_containerfile_packages(
     containerfile: str,
     context: dict,
+    arches: list[str] | None = None,
 ) -> tuple[set[str], dict[str, set[str]], set[str], set[str], list[str]]:
     """
     Extract RPM package names from Containerfile RUN commands.
@@ -473,6 +476,8 @@ def _extract_containerfile_packages(
     Arg(s):
         containerfile (str): Path to the Containerfile.
         context (dict): Configuration context with optional stage filters.
+        arches (list[str] | None): Architectures being resolved, passed
+            through to shell command analysis for arch-conditional detection.
     Return Value(s):
         tuple: (common_packages, arch_packages, upgrade_packages,
                 module_enable, builddep_packages) — all empty on failure.
@@ -485,7 +490,7 @@ def _extract_containerfile_packages(
 
     cf_path = Path(containerfile)
     source_dir = cf_path.parent
-    stages = analyze_containerfile_stages(cf_path, source_dir=source_dir)
+    stages = analyze_containerfile_stages(cf_path, source_dir=source_dir, arches=arches)
     selected = select_stage(stages, **_get_containerfile_filters(context))
     if selected:
         common_packages.update(selected.packages)
@@ -616,7 +621,7 @@ def main():
                     containerfile_upgrade_packages,
                     containerfile_module_enable,
                     containerfile_builddep_packages,
-                ) = _extract_containerfile_packages(containerfile, context)
+                ) = _extract_containerfile_packages(containerfile, context, arches)
             except Exception:
                 logging.warning(
                     "Failed to extract packages from Containerfile %s; "

--- a/rpm_lockfile/containerfile_packages.py
+++ b/rpm_lockfile/containerfile_packages.py
@@ -25,8 +25,6 @@ from .shell_commands import (
     resolve_bash_expansion,
 )
 
-# Common Linux architectures for multi-arch resolution
-DEFAULT_ARCHES = ["x86_64", "s390x", "ppc64le", "aarch64"]
 
 
 @dataclass
@@ -247,7 +245,7 @@ def extract_packages_from_file_installs(
         source_dir (Path): Source tree root.
         env_vars (dict[str, str] | None): Variables for path resolution.
         arches (list[str] | None): Architectures to resolve for arch-specific
-            file paths. Defaults to DEFAULT_ARCHES.
+            file paths.
     Return Value(s):
         tuple[list[str], dict[str, list[str]]]:
             - Sorted unique package names (common to all arches).
@@ -255,7 +253,7 @@ def extract_packages_from_file_installs(
     """
     logger = logging.getLogger(__name__)
     variables = dict(env_vars or {})
-    arch_list = arches or DEFAULT_ARCHES
+    arch_list = arches or []
     redirect_re = re.compile(
         r"""
         (?:xargs\s+(?:\S+\s+)*)?    # optional xargs with optional flags
@@ -341,6 +339,7 @@ def extract_packages_from_scripts(
     source_dir: Path | None = None,
     copy_map: dict[str, str] | None = None,
     env_vars: dict[str, str] | None = None,
+    arches: list[str] | None = None,
 ) -> StagePackages:
     """
     Find shell scripts invoked in RUN commands and extract yum/dnf
@@ -362,6 +361,8 @@ def extract_packages_from_scripts(
         copy_map (dict[str, str] | None): Container path to source path
             mapping from COPY/ADD instructions.
         env_vars (dict[str, str] | None): Variables for path resolution.
+        arches (list[str] | None): Architectures being resolved, passed
+            through for arch-conditional subshell detection.
     Return Value(s):
         StagePackages: Extracted packages, update targets, arch-specific
             packages, and update flag from scripts.
@@ -448,7 +449,7 @@ def extract_packages_from_scripts(
                     joined_lines.append(stripped)
             script_body = "\n".join(line for line in joined_lines if line.strip())
 
-            result = analyze_run_commands([script_body])
+            result = analyze_run_commands([script_body], arches=arches)
             all_packages.update(result.packages)
             for arch, arch_pkgs in result.arch_packages.items():
                 all_arch_packages.setdefault(arch, set()).update(arch_pkgs)
@@ -459,7 +460,8 @@ def extract_packages_from_scripts(
                 scripts_have_bare_update = True
 
             file_pkgs, file_arch_pkgs = extract_packages_from_file_installs(
-                [script_body], copy_map, source_dir, env_vars=env_vars
+                [script_body], copy_map, source_dir, env_vars=env_vars,
+                arches=arches,
             )
             all_packages.update(file_pkgs)
             for arch, arch_pkgs in file_arch_pkgs.items():
@@ -480,6 +482,7 @@ def extract_packages_from_scripts(
 def analyze_containerfile_stages(
     containerfile_path: Path,
     source_dir: Path | None = None,
+    arches: list[str] | None = None,
 ) -> list[StagePackages]:
     """
     Parse a Containerfile and return per-stage package analysis.
@@ -500,6 +503,8 @@ def analyze_containerfile_stages(
         containerfile_path (Path): Path to the Containerfile/Dockerfile.
         source_dir (Path | None): Source tree root to locate script files
             referenced in RUN commands.
+        arches (list[str] | None): Architectures being resolved, passed
+            through for arch-conditional subshell detection.
     Return Value(s):
         list[StagePackages]: Per-stage package analysis.
     """
@@ -545,7 +550,9 @@ def analyze_containerfile_stages(
                 base_image = resolve_bash_expansion(m.group("img"), stage_vars)
                 stage_name = m.group("name") or ""
 
-        result = analyze_run_commands(run_values, env_vars=stage_vars)
+        result = analyze_run_commands(
+            run_values, env_vars=stage_vars, arches=arches
+        )
         stage = StagePackages(
             base_image=base_image,
             stage_name=stage_name,
@@ -559,12 +566,14 @@ def analyze_containerfile_stages(
                 source_dir=source_dir,
                 copy_map=copy_map,
                 env_vars=stage_vars,
+                arches=arches,
             )
         )
 
         if source_dir:
             file_pkgs, file_arch_pkgs = extract_packages_from_file_installs(
-                run_values, copy_map, source_dir, env_vars=stage_vars
+                run_values, copy_map, source_dir, env_vars=stage_vars,
+                arches=arches,
             )
             stage = stage.merge(
                 StagePackages(packages=file_pkgs, arch_packages=file_arch_pkgs)

--- a/rpm_lockfile/shell_commands.py
+++ b/rpm_lockfile/shell_commands.py
@@ -74,6 +74,7 @@ class _WalkContext:
     """
 
     variables: dict[str, str] = field(default_factory=dict)
+    known_arches: frozenset[str] = field(default_factory=frozenset)
     shell_vars: dict[str, str] = field(default_factory=dict)
     arch_shell_vars: dict[str, dict[str, str]] = field(default_factory=dict)
     packages: set[str] = field(default_factory=set)
@@ -374,7 +375,18 @@ def _process_assignments(
         if has_cmdsub:
             extracted = _extract_subshell_packages(var_value)
             if extracted:
-                ctx.shell_vars[var_name] = extracted
+                target_arches = _extract_subshell_arch_condition(
+                    var_value, ctx.known_arches
+                )
+                if target_arches:
+                    per_arch = ctx.arch_shell_vars.setdefault(var_name, {})
+                    for arch in target_arches:
+                        if arch in per_arch:
+                            per_arch[arch] = f"{per_arch[arch]} {extracted}"
+                        else:
+                            per_arch[arch] = extracted
+                else:
+                    ctx.shell_vars[var_name] = extracted
         elif arch_context:
             per_arch = ctx.arch_shell_vars.setdefault(var_name, {})
             for arch in arch_context:
@@ -578,6 +590,47 @@ def _process_command_node(
     )
 
 
+def _extract_subshell_arch_condition(
+    subshell_body: str, known_arches: frozenset[str]
+) -> list[str] | None:
+    """
+    Detect architecture conditions inside a subshell body and return
+    the list of arches where the subshell produces output.
+
+    Arg(s):
+        subshell_body (str): Text inside a $(...) subshell, e.g.
+            'if [ "$(uname -m)" != "s390x" ]; then echo -n mstflint; fi'
+        known_arches (frozenset[str]): Full set of architectures being
+            resolved, used for complement computation on != patterns.
+    Return Value(s):
+        list[str] | None: Target arches (RPM names), or None if no
+            arch condition detected or pattern is ambiguous.
+    """
+    if not _has_arch_test(subshell_body):
+        return None
+
+    if not known_arches:
+        return None
+
+    neq_arches = ARCH_NEQ_VALUE_RE.findall(subshell_body)
+    eq_arches = ARCH_VALUE_RE.findall(subshell_body)
+
+    if neq_arches and eq_arches:
+        return None
+
+    if neq_arches:
+        excluded = set(_normalize_arch_names(neq_arches))
+        target = sorted(known_arches - excluded)
+        return target if target else None
+
+    if eq_arches:
+        if len(eq_arches) > 1:
+            return None
+        return _normalize_arch_names(eq_arches)
+
+    return None
+
+
 def _extract_subshell_packages(subshell_body: str) -> str:
     """
     Extract package names from echo commands inside a $(...) subshell.
@@ -601,6 +654,7 @@ def _extract_subshell_packages(subshell_body: str) -> str:
 def _parse_and_walk(
     run_values: list[str],
     env_vars: dict[str, str] | None = None,
+    arches: list[str] | None = None,
 ) -> _WalkContext:
     """
     Single pass: preprocess, parse with bashlex, and walk all RUN bodies.
@@ -608,11 +662,16 @@ def _parse_and_walk(
     Arg(s):
         run_values (list[str]): RUN command bodies.
         env_vars (dict[str, str] | None): Variables from ARG/ENV directives.
+        arches (list[str] | None): Architectures being resolved, used for
+            complement computation in subshell arch conditions.
     Return Value(s):
         _WalkContext: Walk context with accumulated packages and state.
     """
     logger = logging.getLogger(__name__)
-    ctx = _WalkContext(variables=dict(env_vars or {}))
+    ctx = _WalkContext(
+        variables=dict(env_vars or {}),
+        known_arches=frozenset(arches) if arches else frozenset(),
+    )
 
     for run_body in run_values:
         preprocessed = _preprocess_for_bashlex(run_body)
@@ -632,6 +691,7 @@ def _parse_and_walk(
 def analyze_run_commands(
     run_values: list[str],
     env_vars: dict[str, str] | None = None,
+    arches: list[str] | None = None,
 ) -> RunCommandResult:
     """
     Single-pass analysis of RUN command bodies.
@@ -639,11 +699,13 @@ def analyze_run_commands(
     Arg(s):
         run_values (list[str]): RUN command bodies.
         env_vars (dict[str, str] | None): Variables from ARG/ENV directives.
+        arches (list[str] | None): Architectures being resolved, used for
+            complement computation in subshell arch conditions.
     Return Value(s):
         RunCommandResult: Sorted packages, arch-specific packages,
             update targets, builddep patterns, and module specs.
     """
-    ctx = _parse_and_walk(run_values, env_vars)
+    ctx = _parse_and_walk(run_values, env_vars, arches)
     return RunCommandResult(
         packages=sorted(ctx.packages),
         arch_packages={

--- a/rpm_lockfile/shell_commands.py
+++ b/rpm_lockfile/shell_commands.py
@@ -423,7 +423,7 @@ def _detect_pkg_action(
         if wl in ("update", "upgrade"):
             ctx.has_update = True
             return "update", idx
-        if wl == "builddep":
+        if wl in ("builddep", "build-dep"):
             return "builddep", idx
         if wl == "module":
             for sub_idx, sub_w in enumerate(word_values[idx + 1 :], idx + 1):

--- a/rpm_lockfile/shell_commands.py
+++ b/rpm_lockfile/shell_commands.py
@@ -555,12 +555,14 @@ def _process_command_node(
         return
 
     word_values = [w.word for w in words]
-    action, action_idx = _detect_pkg_action(word_values, ctx)
+    all_vars = {**ctx.variables, **ctx.shell_vars}
+    resolved_first = resolve_bash_expansion(word_values[0], all_vars) if word_values else ""
+    resolved_word_values = [resolved_first] + word_values[1:] if word_values else word_values
+    action, action_idx = _detect_pkg_action(resolved_word_values, ctx)
     if not action:
         return
 
     pkg_words = word_values[action_idx + 1 :]
-    all_vars = {**ctx.variables, **ctx.shell_vars}
     combined_arch_vals = {
         k: " ".join(per_arch.values()) for k, per_arch in ctx.arch_shell_vars.items()
     }

--- a/tests/test_containerfile_packages.py
+++ b/tests/test_containerfile_packages.py
@@ -146,6 +146,7 @@ class TestExtractPackagesFromFileInstalls(unittest.TestCase):
                 copy_map,
                 source_dir,
                 env_vars={"PKGS_LIST": "packages-list.ocp"},
+                arches=["x86_64", "s390x", "ppc64le", "aarch64"],
             )
             self.assertEqual(result, [])
             self.assertEqual(arch_result.get("x86_64"), ["biosdevname"])

--- a/tests/test_shell_commands.py
+++ b/tests/test_shell_commands.py
@@ -450,6 +450,21 @@ class TestBuilddepParsing(unittest.TestCase):
         self.assertEqual(result.builddep_packages, ["pkcs11-helper*"])
 
 
+    def test_build_dep_hyphenated(self):
+        run_values = ["dnf build-dep tuned.spec -y"]
+        result = analyze_run_commands(run_values)
+        self.assertIn("tuned.spec", result.builddep_packages)
+
+    def test_build_dep_hyphenated_with_install(self):
+        run_values = [
+            "dnf install -y gcc rpm-build && cd assets/tuned/daemon "
+            "&& dnf build-dep tuned.spec -y"
+        ]
+        result = analyze_run_commands(run_values)
+        self.assertIn("gcc", result.packages)
+        self.assertIn("tuned.spec", result.builddep_packages)
+
+
 class TestModuleParsing(unittest.TestCase):
     def test_module_install(self):
         run_values = ["dnf module install -y nodejs:18/development"]

--- a/tests/test_shell_commands.py
+++ b/tests/test_shell_commands.py
@@ -138,12 +138,47 @@ class TestAnalyzeRunCommands(unittest.TestCase):
             'ARCH_DEP_PKGS=$(if [ "$(uname -m)" != "s390x" ]; then echo -n mstflint ; fi) && '
             "yum -y install pciutils hwdata kmod $ARCH_DEP_PKGS"
         ]
-        result = analyze_run_commands(run_values)
-        self.assertIn("mstflint", result.packages)
+        result = analyze_run_commands(
+            run_values, arches=["x86_64", "s390x", "ppc64le", "aarch64"]
+        )
+        self.assertNotIn("mstflint", result.packages)
         self.assertIn("pciutils", result.packages)
         self.assertIn("hwdata", result.packages)
         self.assertIn("kmod", result.packages)
+        for a in ("x86_64", "aarch64", "ppc64le"):
+            self.assertIn("mstflint", result.arch_packages.get(a, []))
+        self.assertNotIn("s390x", result.arch_packages)
+
+    def test_subshell_arch_conditional_var_eq(self):
+        run_values = [
+            'SPECIAL=$(if [ "$(uname -m)" == "x86_64" ]; then echo -n intel-pkg ; fi) && '
+            "yum -y install base-pkg $SPECIAL"
+        ]
+        result = analyze_run_commands(
+            run_values, arches=["x86_64", "s390x", "ppc64le", "aarch64"]
+        )
+        self.assertNotIn("intel-pkg", result.packages)
+        self.assertIn("base-pkg", result.packages)
+        self.assertEqual(result.arch_packages, {"x86_64": ["intel-pkg"]})
+
+    def test_subshell_no_arch_condition(self):
+        run_values = ['EXTRA=$(echo extra-pkg) && yum -y install base-pkg $EXTRA']
+        result = analyze_run_commands(run_values)
+        self.assertIn("extra-pkg", result.packages)
+        self.assertIn("base-pkg", result.packages)
         self.assertEqual(result.arch_packages, {})
+
+    def test_subshell_arch_conditional_var_go_arch(self):
+        run_values = [
+            'SPECIAL=$(if [ "$(go env GOARCH)" == "amd64" ]; then echo -n x86-only ; fi) && '
+            "yum -y install common-pkg $SPECIAL"
+        ]
+        result = analyze_run_commands(
+            run_values, arches=["x86_64", "s390x", "ppc64le", "aarch64"]
+        )
+        self.assertNotIn("x86-only", result.packages)
+        self.assertIn("common-pkg", result.packages)
+        self.assertEqual(result.arch_packages, {"x86_64": ["x86-only"]})
 
     def test_arch_conditional_multiple_arches(self):
         run_values = [

--- a/tests/test_shell_commands.py
+++ b/tests/test_shell_commands.py
@@ -465,3 +465,37 @@ class TestModuleParsing(unittest.TestCase):
         run_values = ["dnf module enable -y nodejs"]
         result = analyze_run_commands(run_values)
         self.assertEqual(result.module_specs, [])
+
+
+class TestVariablePackageManager(unittest.TestCase):
+    def test_variable_resolves_to_microdnf(self):
+        run_values = ["${DNF} install -y openssh-clients"]
+        result = analyze_run_commands(run_values, env_vars={"DNF": "microdnf"})
+        self.assertIn("openssh-clients", result.packages)
+
+    def test_variable_resolves_to_dnf(self):
+        run_values = ["${DNF} install -y gcc"]
+        result = analyze_run_commands(run_values, env_vars={"DNF": "dnf"})
+        self.assertIn("gcc", result.packages)
+
+    def test_variable_in_conditional(self):
+        run_values = [
+            "if ! rpm -q openssh-clients; then ${DNF} install -y openssh-clients "
+            "&& ${DNF} clean all && rm -rf /var/cache/dnf/*; fi"
+        ]
+        result = analyze_run_commands(run_values, env_vars={"DNF": "microdnf"})
+        self.assertIn("openssh-clients", result.packages)
+
+    def test_variable_multiple_commands(self):
+        run_values = [
+            "if ! rpm -q openssh-clients; then ${DNF} install -y openssh-clients && ${DNF} clean all; fi",
+            "if ! rpm -q libvirt-libs; then ${DNF} install -y libvirt-libs && ${DNF} clean all; fi",
+            "if ! command -v tar; then ${DNF} install -y tar && ${DNF} clean all; fi",
+        ]
+        result = analyze_run_commands(run_values, env_vars={"DNF": "microdnf"})
+        self.assertEqual(result.packages, ["libvirt-libs", "openssh-clients", "tar"])
+
+    def test_variable_with_default(self):
+        run_values = ["${DNF:-microdnf} install -y tar"]
+        result = analyze_run_commands(run_values)
+        self.assertIn("tar", result.packages)


### PR DESCRIPTION
## Summary

   Three shell-command parser fixes that improve Dockerfile package detection:

   - **Detect arch conditions in subshell assignments** — subshell-assigned packages (e.g. `mstflint` only on non-s390x) were treated as common to all architectures, causing
   resolution failures
   - **Resolve variable package manager commands** — `${DNF}` and similar variable references were not expanded before matching against known package managers (`dnf`, `yum`,
   `microdnf`), causing missed packages
   - **Recognize `build-dep` as alias for `builddep`** — the hyphenated form `dnf build-dep` was not detected as a valid action


  ## Problem
  
  ### Subshell arch conditions

  Dockerfiles use subshell assignments for arch-conditional packages:

  ```bash
  ARCH_DEP_PKGS=$(if [ "$(uname -m)" != "s390x" ]; then echo -n mstflint ; fi)
  yum -y install pciutils hwdata kmod $ARCH_DEP_PKGS
```
  `_extract_subshell_packages()` extracts `mstflint` but loses the `!= s390x` condition — it stores in `shell_vars` (common to all arches) instead of `arch_shell_vars`. 
  
  When resolution runs for `s390x` where `mstflint` is unavailable, it fails and the retry logic strips the package from `ALL arches`, including x86_64/aarch64/ppc64le where it exists.

### Variable package manager commands

   When a Dockerfile uses a variable for the package manager:

   ```dockerfile
   ARG DNF=${DNF:-microdnf}
   RUN ${DNF} install -y openssh-clients
   ```

   The parser checked the literal `${DNF}` against known package manager names and failed to match, so the entire install line was silently skipped.

   ### `build-dep` alias

   Some packages use `dnf build-dep` (hyphenated) instead of `dnf builddep`. The regex only matched the non-hyphenated form.

## Fix
   ### Subshell arch conditions

  When a subshell body contains an arch test (reusing `existing _has_arch_test()`, `ARCH_VALUE_RE`, `ARCH_NEQ_VALUE_RE`):

  - `!= s390x` → store package for {`x86_64`, `aarch64`, `ppc64le`} (complement)
  - `== x86_64` → store package for {`x86_64`} only
  - Ambiguous patterns (mixed ==/!=, multiple ==) → fall back to common (safe over-inclusion)

  The downstream `_resolve_arch_specific_tokens()` already handles `arch_shell_vars` correctly, this fix just routes the data there.

### Variable package manager commands

   Resolve the first word of each command through shell variable expansion before matching against package manager names. This uses the existing `_expand_variables()` infrastructure.

   ### `build-dep` alias

   Updated the action regex to accept both `builddep` and `build-dep`.
