### PR TITLE
Always retry with filelists on DepsolveError

### DIFF
--- a/rpm_lockfile/__init__.py
+++ b/rpm_lockfile/__init__.py
@@ -215,10 +215,10 @@ def resolver(
             # And resolve the transaction
             try:
                 base.resolve(allow_erasing=allow_erasing)
-            except dnf.exceptions.DepsolveError as exc:
-                if not download_filelists and "nothing provides /" in exc.value:
-                    # If we did not download filelists and the error indicates
-                    # they may be needed, signal that with a custom exception.
+            except dnf.exceptions.DepsolveError:
+                if not download_filelists:
+                    # Retry with filelists — they may provide file-level
+                    # dependencies needed to validate the transaction.
                     raise MissingFilelists()
                 raise
 


### PR DESCRIPTION
## Summary

- Always retry with filelists on any `DepsolveError`, not just when the error contains `"nothing provides /"`
- Fixes package replacement failures when base image has a security-patched version that differs from compose repos

## Problem

The current filelists retry heuristic (`"nothing provides /" in exc.value`) misses DepsolveErrors caused by package version conflicts during replacement. When `allow_erasing=True` tries to replace a security-patched base image package (e.g. `platform-python-3.6.8-51.el8_8.2`) with the compose repo version (`3.6.8-51.el8`), DNF emits:

```
cannot install both platform-python-3.6.8-51.el8.aarch64 from rhel8.8-buildroot
  and platform-python-3.6.8-51.el8_8.2.aarch64 from @System
```

This doesn't match the heuristic, so filelists are never downloaded. But filelists are the fix: they let DNF verify that the repo version provides the same file-level dependencies (e.g. `/usr/libexec/platform-python`) as the installed version.

## Fix

Remove the string check and always retry with filelists on any `DepsolveError`. The first attempt without filelists is still made for performance, and the retry reuses the repodata cache — only filelists metadata is additionally downloaded.

The cost is that genuinely broken configurations will see one extra retry before the real error, but this is preferable to silently failing on valid configurations.

Fixes #144

Made with [Cursor](https://cursor.com)