### PR TITLE
Add assumeProvides config to declare pre-satisfied dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+
+- New `assumeProvides` configuration key to declare packages or capabilities
+  that should be treated as already installed during dependency resolution.
+  This is useful when RPMs are built in earlier Containerfile stages and
+  installed in a later stage. ([#147](https://github.com/konflux-ci/rpm-lockfile-prototype/issues/147))
+
 ## [0.24.0] - 2026-07-02
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -207,6 +207,13 @@ reinstallPackages: []
 upgradePackages: []
   # List of rpms to update. Same specification as `packages` above.
 
+assumeProvides:
+  # List of package names or RPM capabilities that should be treated as
+  # already satisfied during dependency resolution. Use this when packages
+  # are built in an earlier Containerfile stage and installed later.
+  - nvidia-kmod
+  - cuda-libs
+
 moduleEnable: []
   # List of module streams that should be enabled during the dependency
   # resolution. The specification uses the same format as `packages` above.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,6 @@ authors = [
 ]
 readme = "README.md"
 dependencies = [
-    "createrepo-c",
     "dockerfile-parse",
     "jsonschema",
     "productmd",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ authors = [
 ]
 readme = "README.md"
 dependencies = [
+    "createrepo-c",
     "dockerfile-parse",
     "jsonschema",
     "productmd",

--- a/rpm_lockfile/__init__.py
+++ b/rpm_lockfile/__init__.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import argparse
 import contextlib
-import hashlib
 import logging
 import os
 import platform
@@ -26,10 +25,9 @@ except ImportError:
         file=sys.stderr,
     )
     sys.exit(127)
-import createrepo_c as cr
 import yaml
 
-from . import containers, content_origin, schema, utils
+from . import assumed_provides, containers, content_origin, schema, utils
 from .containerfile_packages import analyze_containerfile_stages, resolve_builddep_packages, select_stage
 
 CONTAINERFILE_HELP = """
@@ -181,11 +179,9 @@ def resolver(
                     "Adding assumed provides repo: %s",
                     ", ".join(assume_provides),
                 )
-                repo_path = create_assumed_provides_repo(
-                    cache_dir, assume_provides
-                )
+                repo_path = assumed_provides.create_repo(cache_dir, assume_provides)
                 base.repos.add_new_repo(
-                    ASSUMED_PROVIDES_REPO_ID,
+                    assumed_provides.REPO_ID,
                     conf,
                     baseurl=[f"file://{repo_path}"],
                 )
@@ -247,7 +243,7 @@ def resolver(
 
             # These packages would be installed
             for pkg in base.transaction.install_set:
-                if pkg.name.startswith(ASSUMED_PROVIDES_PREFIX):
+                if pkg.name.startswith(assumed_provides.PACKAGE_PREFIX):
                     continue
                 if f"{pkg.name}-{pkg.e}:{pkg.v}-{pkg.r}.{pkg.a}" in modular_packages:
                     modular_repos.add(pkg.repoid)
@@ -283,60 +279,6 @@ def resolver(
                 )
 
     return packages, sources, module_metadata
-
-
-ASSUMED_PROVIDES_REPO_ID = "_assumed-provides"
-ASSUMED_PROVIDES_PREFIX = "_assumed-provides-"
-
-
-def create_assumed_provides_repo(tmpdir, assume_provides):
-    repo_dir = os.path.join(tmpdir, ASSUMED_PROVIDES_REPO_ID)
-    repodata_dir = os.path.join(repo_dir, "repodata")
-    os.makedirs(repodata_dir, exist_ok=True)
-
-    primary_path = os.path.join(repodata_dir, "primary.xml.gz")
-    filelists_path = os.path.join(repodata_dir, "filelists.xml.gz")
-    other_path = os.path.join(repodata_dir, "other.xml.gz")
-
-    primary = cr.PrimaryXmlFile(primary_path)
-    filelists = cr.FilelistsXmlFile(filelists_path)
-    other = cr.OtherXmlFile(other_path)
-
-    for entry in assume_provides:
-        pkg = cr.Package()
-        pkg.name = f"{ASSUMED_PROVIDES_PREFIX}{entry}"
-        pkg.version = "0"
-        pkg.release = "0"
-        pkg.epoch = "0"
-        pkg.arch = "noarch"
-        pkg.summary = "Assumed provides placeholder"
-        pkg.description = "Placeholder"
-        pkg.pkgId = hashlib.sha256(entry.encode()).hexdigest()
-        pkg.checksum_type = "sha256"
-        pkg.provides = [(entry, None, None, None, None, None)]
-        primary.add_pkg(pkg)
-        filelists.add_pkg(pkg)
-        other.add_pkg(pkg)
-
-    primary.close()
-    filelists.close()
-    other.close()
-
-    repomd = cr.Repomd()
-    for md_type, path in [
-        ("primary", primary_path),
-        ("filelists", filelists_path),
-        ("other", other_path),
-    ]:
-        rec = cr.RepomdRecord(md_type, path)
-        rec.fill(cr.SHA256)
-        rec.rename_file()
-        repomd.set_record(rec)
-
-    with open(os.path.join(repodata_dir, "repomd.xml"), "w") as f:
-        f.write(repomd.xml_dump())
-
-    return repo_dir
 
 
 def rpmdb_preparer(func=None):

--- a/rpm_lockfile/__init__.py
+++ b/rpm_lockfile/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import contextlib
+import hashlib
 import logging
 import os
 import platform
@@ -25,6 +26,7 @@ except ImportError:
         file=sys.stderr,
     )
     sys.exit(127)
+import createrepo_c as cr
 import yaml
 
 from . import containers, content_origin, schema, utils
@@ -128,6 +130,7 @@ def resolver(
     upgrade_packages: set[str],
     download_filelists: bool = False,
     zchunk: bool = None,
+    assume_provides: list[str] = None,
 ):
     packages = set()
     sources = set()
@@ -172,6 +175,19 @@ def resolver(
                     ),
                     conf,
                     **repo.kwargs,
+                )
+            if assume_provides:
+                logging.info(
+                    "Adding assumed provides repo: %s",
+                    ", ".join(assume_provides),
+                )
+                repo_path = create_assumed_provides_repo(
+                    cache_dir, assume_provides
+                )
+                base.repos.add_new_repo(
+                    ASSUMED_PROVIDES_REPO_ID,
+                    conf,
+                    baseurl=[f"file://{repo_path}"],
                 )
             base.fill_sack(load_system_repo=True)
 
@@ -231,6 +247,8 @@ def resolver(
 
             # These packages would be installed
             for pkg in base.transaction.install_set:
+                if pkg.name.startswith(ASSUMED_PROVIDES_PREFIX):
+                    continue
                 if f"{pkg.name}-{pkg.e}:{pkg.v}-{pkg.r}.{pkg.a}" in modular_packages:
                     modular_repos.add(pkg.repoid)
                 packages.add(PackageItem.from_dnf(pkg))
@@ -265,6 +283,60 @@ def resolver(
                 )
 
     return packages, sources, module_metadata
+
+
+ASSUMED_PROVIDES_REPO_ID = "_assumed-provides"
+ASSUMED_PROVIDES_PREFIX = "_assumed-provides-"
+
+
+def create_assumed_provides_repo(tmpdir, assume_provides):
+    repo_dir = os.path.join(tmpdir, ASSUMED_PROVIDES_REPO_ID)
+    repodata_dir = os.path.join(repo_dir, "repodata")
+    os.makedirs(repodata_dir, exist_ok=True)
+
+    primary_path = os.path.join(repodata_dir, "primary.xml.gz")
+    filelists_path = os.path.join(repodata_dir, "filelists.xml.gz")
+    other_path = os.path.join(repodata_dir, "other.xml.gz")
+
+    primary = cr.PrimaryXmlFile(primary_path)
+    filelists = cr.FilelistsXmlFile(filelists_path)
+    other = cr.OtherXmlFile(other_path)
+
+    for entry in assume_provides:
+        pkg = cr.Package()
+        pkg.name = f"{ASSUMED_PROVIDES_PREFIX}{entry}"
+        pkg.version = "0"
+        pkg.release = "0"
+        pkg.epoch = "0"
+        pkg.arch = "noarch"
+        pkg.summary = "Assumed provides placeholder"
+        pkg.description = "Placeholder"
+        pkg.pkgId = hashlib.sha256(entry.encode()).hexdigest()
+        pkg.checksum_type = "sha256"
+        pkg.provides = [(entry, None, None, None, None, None)]
+        primary.add_pkg(pkg)
+        filelists.add_pkg(pkg)
+        other.add_pkg(pkg)
+
+    primary.close()
+    filelists.close()
+    other.close()
+
+    repomd = cr.Repomd()
+    for md_type, path in [
+        ("primary", primary_path),
+        ("filelists", filelists_path),
+        ("other", other_path),
+    ]:
+        rec = cr.RepomdRecord(md_type, path)
+        rec.fill(cr.SHA256)
+        rec.rename_file()
+        repomd.set_record(rec)
+
+    with open(os.path.join(repodata_dir, "repomd.xml"), "w") as f:
+        f.write(repomd.xml_dump())
+
+    return repo_dir
 
 
 def rpmdb_preparer(func=None):
@@ -305,6 +377,7 @@ def process_arch(
     install_weak_deps: bool,
     upgrade_packages: set[str],
     zchunk: bool = None,
+    assume_provides: list[str] = None,
 ):
     logging.info("Running solver for %s", arch)
 
@@ -325,6 +398,7 @@ def process_arch(
                     upgrade_packages,
                     download_filelists=download_filelists,
                     zchunk=zchunk,
+                    assume_provides=assume_provides,
                 )
                 break
             except MissingFilelists:
@@ -566,6 +640,7 @@ def main():
     context = config.get("context", {})
     allowerasing = args.allowerasing or config.get("allowerasing", False)
     no_sources = config.get("noSources", False)
+    assume_provides = config.get("assumeProvides", [])
 
     local = args.local_system or context.get("localSystem")
     if local and arches != [platform.machine()]:
@@ -672,6 +747,7 @@ def main():
                 )
                 | containerfile_upgrade_packages,
                 zchunk=config.get("zchunk"),
+                assume_provides=assume_provides,
             )
         )
 

--- a/rpm_lockfile/assumed_provides.py
+++ b/rpm_lockfile/assumed_provides.py
@@ -1,0 +1,154 @@
+"""Generate a minimal DNF repository whose packages provide assumed capabilities.
+
+The repodata (primary.xml.gz, filelists.xml.gz, other.xml.gz and repomd.xml)
+is written using only the Python standard library so that no external
+dependency on createrepo_c is needed.
+"""
+
+import gzip
+import hashlib
+import os
+from xml.sax.saxutils import escape
+
+
+REPO_ID = "_assumed-provides"
+PACKAGE_PREFIX = "_assumed-provides-"
+
+
+def _primary_xml(entries):
+    """Return primary.xml content for the given provide entries."""
+    parts = [
+        '<?xml version="1.0" encoding="UTF-8"?>\n'
+        '<metadata xmlns="http://linux.duke.edu/metadata/common"'
+        ' xmlns:rpm="http://linux.duke.edu/metadata/rpm"'
+        f' packages="{len(entries)}">\n'
+    ]
+    for entry in entries:
+        name = f"{PACKAGE_PREFIX}{entry}"
+        pkg_id = hashlib.sha256(entry.encode()).hexdigest()
+        escaped_entry = escape(entry)
+        escaped_name = escape(name)
+        parts.append(
+            f'<package type="rpm">\n'
+            f"  <name>{escaped_name}</name>\n"
+            f"  <arch>noarch</arch>\n"
+            f'  <version epoch="0" ver="0" rel="0"/>\n'
+            f'  <checksum type="sha256" pkgid="YES">{pkg_id}</checksum>\n'
+            f"  <summary>Assumed provides placeholder</summary>\n"
+            f"  <description>Placeholder</description>\n"
+            f"  <packager/>\n"
+            f"  <url/>\n"
+            f'  <time file="0" build="0"/>\n'
+            f'  <size package="0" installed="0" archive="0"/>\n'
+            f'  <location href="{escaped_name}-0-0.noarch.rpm"/>\n'
+            f"  <format>\n"
+            f"    <rpm:license>MIT</rpm:license>\n"
+            f"    <rpm:group>Unspecified</rpm:group>\n"
+            f"    <rpm:buildhost>localhost</rpm:buildhost>\n"
+            f"    <rpm:sourcerpm/>\n"
+            f"    <rpm:provides>\n"
+            f'      <rpm:entry name="{escaped_entry}"/>\n'
+            f"    </rpm:provides>\n"
+            f"  </format>\n"
+            f"</package>\n"
+        )
+    parts.append("</metadata>\n")
+    return "".join(parts)
+
+
+def _filelists_xml(entries):
+    """Return filelists.xml content."""
+    parts = [
+        '<?xml version="1.0" encoding="UTF-8"?>\n'
+        '<filelists xmlns="http://linux.duke.edu/metadata/filelists"'
+        f' packages="{len(entries)}">\n'
+    ]
+    for entry in entries:
+        pkg_id = hashlib.sha256(entry.encode()).hexdigest()
+        escaped_name = escape(f"{PACKAGE_PREFIX}{entry}")
+        parts.append(
+            f'<package pkgid="{pkg_id}" name="{escaped_name}"'
+            f' arch="noarch">\n'
+            f'  <version epoch="0" ver="0" rel="0"/>\n'
+            f"</package>\n"
+        )
+    parts.append("</filelists>\n")
+    return "".join(parts)
+
+
+def _other_xml(entries):
+    """Return other.xml content."""
+    parts = [
+        '<?xml version="1.0" encoding="UTF-8"?>\n'
+        '<otherdata xmlns="http://linux.duke.edu/metadata/other"'
+        f' packages="{len(entries)}">\n'
+    ]
+    for entry in entries:
+        pkg_id = hashlib.sha256(entry.encode()).hexdigest()
+        escaped_name = escape(f"{PACKAGE_PREFIX}{entry}")
+        parts.append(
+            f'<package pkgid="{pkg_id}" name="{escaped_name}"'
+            f' arch="noarch">\n'
+            f'  <version epoch="0" ver="0" rel="0"/>\n'
+            f"</package>\n"
+        )
+    parts.append("</otherdata>\n")
+    return "".join(parts)
+
+
+def _write_gz(path, content):
+    """Write *content* as a gzip-compressed file and return (sha256, size)."""
+    data = content.encode("utf-8")
+    with gzip.open(path, "wb") as f:
+        f.write(data)
+    with open(path, "rb") as f:
+        compressed = f.read()
+    return hashlib.sha256(compressed).hexdigest(), len(compressed)
+
+
+def _repomd_xml(records):
+    """Return repomd.xml content.
+
+    *records* is a list of (md_type, sha256, size, filename) tuples.
+    """
+    parts = [
+        '<?xml version="1.0" encoding="UTF-8"?>\n'
+        '<repomd xmlns="http://linux.duke.edu/metadata/repo">\n'
+    ]
+    for md_type, checksum, size, filename in records:
+        parts.append(
+            f'  <data type="{md_type}">\n'
+            f'    <checksum type="sha256">{checksum}</checksum>\n'
+            f'    <location href="repodata/{filename}"/>\n'
+            f"    <size>{size}</size>\n"
+            f"  </data>\n"
+        )
+    parts.append("</repomd>\n")
+    return "".join(parts)
+
+
+def create_repo(tmpdir, assume_provides):
+    """Create a temporary repo with dummy packages providing *assume_provides*.
+
+    Returns the path to the repository directory.
+    """
+    repo_dir = os.path.join(tmpdir, REPO_ID)
+    repodata_dir = os.path.join(repo_dir, "repodata")
+    os.makedirs(repodata_dir, exist_ok=True)
+
+    records = []
+    for md_type, generator in [
+        ("primary", _primary_xml),
+        ("filelists", _filelists_xml),
+        ("other", _other_xml),
+    ]:
+        filename = f"{md_type}.xml.gz"
+        path = os.path.join(repodata_dir, filename)
+        content = generator(assume_provides)
+        checksum, size = _write_gz(path, content)
+        records.append((md_type, checksum, size, filename))
+
+    with open(os.path.join(repodata_dir, "repomd.xml"), "w") as f:
+        f.write(_repomd_xml(records))
+
+    return repo_dir

--- a/rpm_lockfile/schema.py
+++ b/rpm_lockfile/schema.py
@@ -131,6 +131,10 @@ def get_schema():
             "noSources": {"type": "boolean"},
             "installWeakDeps": {"type": "boolean"},
             "zchunk": {"type": "boolean"},
+            "assumeProvides": {
+                "type": "array",
+                "items": {"type": "string", "minLength": 1},
+            },
         },
         "required": ["contentOrigin"],
         "additionalProperties": False,

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,12 +1,12 @@
 import os
 import tempfile
 from unittest.mock import patch, mock_open
+from xml.etree import ElementTree
 
-import createrepo_c as cr
 import pytest
 
 import rpm_lockfile
-from rpm_lockfile import schema
+from rpm_lockfile import assumed_provides, schema
 
 
 @pytest.mark.parametrize(
@@ -71,19 +71,23 @@ class TestAssumeProvides:
 
     def test_create_assumed_provides_repo(self):
         with tempfile.TemporaryDirectory() as tmpdir:
-            repo_dir = rpm_lockfile.create_assumed_provides_repo(
+            repo_dir = assumed_provides.create_repo(
                 tmpdir, ["nvidia-kmod", "cuda-libs"]
             )
             repomd_path = os.path.join(repo_dir, "repodata", "repomd.xml")
             assert os.path.exists(repomd_path)
 
-            repomd = cr.Repomd(repomd_path)
-            assert repomd.repo_tags == []
-            records = {r.type: r for r in repomd.records}
-            assert "primary" in records
+            ns = {"repo": "http://linux.duke.edu/metadata/repo"}
+            tree = ElementTree.parse(repomd_path)
+            data_types = {
+                el.get("type") for el in tree.findall("repo:data", ns)
+            }
+            assert "primary" in data_types
+            assert "filelists" in data_types
+            assert "other" in data_types
 
     def test_create_assumed_provides_repo_empty(self):
         with tempfile.TemporaryDirectory() as tmpdir:
-            repo_dir = rpm_lockfile.create_assumed_provides_repo(tmpdir, [])
+            repo_dir = assumed_provides.create_repo(tmpdir, [])
             repomd_path = os.path.join(repo_dir, "repodata", "repomd.xml")
             assert os.path.exists(repomd_path)

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,8 +1,12 @@
+import os
+import tempfile
 from unittest.mock import patch, mock_open
 
+import createrepo_c as cr
 import pytest
 
 import rpm_lockfile
+from rpm_lockfile import schema
 
 
 @pytest.mark.parametrize(
@@ -47,3 +51,39 @@ def test_read_container_yaml(arch, expected):
 )
 def test_filter_for_arch(input, expected):
     assert sorted(rpm_lockfile.filter_for_arch("ppc64le", input)) == sorted(expected)
+
+
+class TestAssumeProvides:
+    def test_schema_accepts_assume_provides(self):
+        config = {
+            "contentOrigin": {"repos": []},
+            "assumeProvides": ["nvidia-kmod", "cuda-libs"],
+        }
+        schema.validate(config)
+
+    def test_schema_rejects_invalid_assume_provides(self):
+        config = {
+            "contentOrigin": {"repos": []},
+            "assumeProvides": "not-a-list",
+        }
+        with pytest.raises(SystemExit):
+            schema.validate(config)
+
+    def test_create_assumed_provides_repo(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo_dir = rpm_lockfile.create_assumed_provides_repo(
+                tmpdir, ["nvidia-kmod", "cuda-libs"]
+            )
+            repomd_path = os.path.join(repo_dir, "repodata", "repomd.xml")
+            assert os.path.exists(repomd_path)
+
+            repomd = cr.Repomd(repomd_path)
+            assert repomd.repo_tags == []
+            records = {r.type: r for r in repomd.records}
+            assert "primary" in records
+
+    def test_create_assumed_provides_repo_empty(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo_dir = rpm_lockfile.create_assumed_provides_repo(tmpdir, [])
+            repomd_path = os.path.join(repo_dir, "repodata", "repomd.xml")
+            assert os.path.exists(repomd_path)


### PR DESCRIPTION
## Summary

- Adds `assumeProvides` configuration key that lets users declare packages or RPM capabilities that should be treated as already installed during dependency resolution
- Injects dummy RPMs into the rpmdb before the solver runs so DNF treats the declared capabilities as satisfied
- Useful when RPMs are built in an earlier Containerfile stage (e.g. `nvidia-kmod`) and installed later — avoids fragile manual lockfile entries that break MintMaker automation

Example config:
```yaml
assumeProvides:
  - nvidia-kmod
  - cuda-libs
```

Closes #147