### PR TITLE
fix: strip quotes from pipe regex file path capture

### DIFF
--- a/rpm_lockfile/containerfile_packages.py
+++ b/rpm_lockfile/containerfile_packages.py
@@ -287,7 +287,7 @@ def extract_packages_from_file_installs(
                 match = pipe_re.search(cmd_clean)
             if not match:
                 continue
-            raw_path = match.group(1)
+            raw_path = _strip_quotes(match.group(1))
             resolved_path = resolve_bash_expansion(raw_path, variables)
             if not resolved_path:
                 continue

--- a/tests/test_containerfile_packages.py
+++ b/tests/test_containerfile_packages.py
@@ -131,6 +131,24 @@ class TestExtractPackagesFromFileInstalls(unittest.TestCase):
             self.assertEqual(result, ["httpd", "qemu-img", "sqlite"])
             self.assertEqual(arch_result, {})
 
+    def test_pipe_with_quoted_env_var_in_path(self):
+        with TemporaryDirectory() as tmpdir:
+            source_dir = Path(tmpdir)
+            pkg_file = source_dir / "main-packages-list.ocp"
+            pkg_file.write_text("coreos-installer\ndosfstools\n")
+            copy_map = {"/tmp/main-packages-list.ocp": "main-packages-list.ocp"}
+
+            run_values = [
+                "grep -v '^#' \"/tmp/${PKGS_LIST}\" | xargs -rtd'\\n' dnf install -y"
+            ]
+            result, _ = extract_packages_from_file_installs(
+                run_values,
+                copy_map,
+                source_dir,
+                env_vars={"PKGS_LIST": "main-packages-list.ocp"},
+            )
+            self.assertEqual(result, ["coreos-installer", "dosfstools"])
+
     def test_arch_suffix_in_filename(self):
         with TemporaryDirectory() as tmpdir:
             source_dir = Path(tmpdir)


### PR DESCRIPTION
The pipe_re pattern in `extract_packages_from_file_installs` captures the file path including surrounding quotes (e.g. "/tmp/${PKGS_LIST}"), which breaks copy_map lookup after variable expansion. 
This caused packages like coreos-installer to be silently missing from lockfiles for images that switched from stdin redirect to grep pipe pattern
