### PR TITLE
Add {var} interpolation for packages, modules, and context.image

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,7 +248,22 @@ installWeakDeps: false
 # standard downloads instead. This can improve performance when using a caching
 # proxy. The default is to use whatever is configured for the system DNF.
 zchunk: false
+
+variables:
+  # Ordered list of variable sources for {var} substitution in package names,
+  # module streams, assumeProvides, context.image, and contentOrigin URLs.
+  # Sources are processed in order; later values override earlier ones.
+  - file: versions.conf           # KEY=VALUE file (same format as --build-arg-file)
+  - image: registry.example.com/base:latest   # use image labels as variables
+  - containerfile: Containerfile   # use labels from the base image in a Containerfile
+  - inline:                        # define variables directly
+      DRIVER_VERSION: "580.126.20"
 ```
+
+The `{var}` placeholders are replaced everywhere: `packages`, `reinstallPackages`,
+`upgradePackages`, `moduleEnable`, `moduleDisable`, `assumeProvides`, `context.image`,
+and in `contentOrigin` URLs (where they merge with any per-source `varsFromImage` or
+`varsFromContainerfile` labels; the per-source values take precedence over globals).
 
 The configuration file can specify a containerfile to extract a base image from
 either in the `context` section or in `varsFromContainerfile` inside

--- a/rpm_lockfile/__init__.py
+++ b/rpm_lockfile/__init__.py
@@ -357,12 +357,12 @@ def process_arch(
     }
 
 
-def collect_content_origins(config_dir, origins):
+def collect_content_origins(config_dir, origins, variables=None):
     loaders = content_origin.load()
     repos = []
     for source_type, source_data in origins.items():
         try:
-            collector = loaders[source_type](config_dir)
+            collector = loaders[source_type](config_dir, variables=variables)
         except KeyError:
             raise RuntimeError(f"Unknown content origin '{source_type}'")
         repos.extend(collector.collect(source_data))
@@ -576,6 +576,24 @@ def main():
 
     schema.validate(config)
 
+    variables = utils.load_variables(config.pop("variables", []), config_dir)
+
+    if variables:
+        logging.info("Substitution variables: %s", ", ".join(sorted(variables)))
+        for key in (
+            "packages",
+            "reinstallPackages",
+            "upgradePackages",
+            "moduleEnable",
+            "moduleDisable",
+            "assumeProvides",
+        ):
+            if key in config:
+                config[key] = utils.subst_vars_in_list(config[key], variables)
+        ctx = config.get("context", {})
+        if isinstance(ctx.get("image"), str):
+            ctx["image"] = utils.subst_vars(ctx["image"], variables)
+
     data = {"lockfileVersion": 1, "lockfileVendor": "redhat", "arches": []}
     arches = args.arch or config.get("arches") or [platform.machine()]
 
@@ -590,7 +608,7 @@ def main():
             f"Only current architecture ({platform.machine()}) can be resolved against local system.",
         )
 
-    repos = collect_content_origins(config_dir, config["contentOrigin"])
+    repos = collect_content_origins(config_dir, config["contentOrigin"], variables)
 
     containerfile_common_packages: set[str] = set()
     containerfile_arch_packages: dict[str, set[str]] = {}

--- a/rpm_lockfile/content_origin/composes.py
+++ b/rpm_lockfile/content_origin/composes.py
@@ -44,7 +44,7 @@ class ComposeOrigin:
         ]
     }
 
-    def __init__(self):
+    def __init__(self, config_dir=None, variables=None):
         self.session = requests.Session()
         try:
             self.cts_url = os.environ["CTS_URL"].rstrip("/")

--- a/rpm_lockfile/content_origin/repofiles.py
+++ b/rpm_lockfile/content_origin/repofiles.py
@@ -45,9 +45,10 @@ class RepofileOrigin:
         ],
     }
 
-    def __init__(self, config_dir):
+    def __init__(self, config_dir, variables=None):
         self.session = requests.Session()
         self.config_dir = config_dir
+        self.variables = variables or {}
 
     def collect(self, sources):
         for source in sources:
@@ -57,7 +58,7 @@ class RepofileOrigin:
     def _get_repofile_path(self, source):
         if isinstance(source, str):
             return source
-        vars = utils.get_labels(source, self.config_dir)
+        vars = utils.get_labels(source, self.config_dir, base_vars=self.variables)
         if "location" in source:
             return utils.subst_vars(source["location"], vars)
         return utils.get_file_from_git(

--- a/rpm_lockfile/content_origin/repos.py
+++ b/rpm_lockfile/content_origin/repos.py
@@ -19,12 +19,13 @@ class RepoOrigin:
         ],
     }
 
-    def __init__(self, config_dir):
+    def __init__(self, config_dir, variables=None):
         self.config_dir = config_dir
+        self.variables = variables or {}
 
     def collect(self, sources):
         for source in sources:
-            vars = utils.get_labels(source, self.config_dir)
+            vars = utils.get_labels(source, self.config_dir, base_vars=self.variables)
             if "baseurl" in source:
                 source["baseurl"] = utils.subst_vars(source["baseurl"], vars)
             yield Repo.from_dict(source)

--- a/rpm_lockfile/schema.py
+++ b/rpm_lockfile/schema.py
@@ -135,6 +135,44 @@ def get_schema():
                 "type": "array",
                 "items": {"type": "string", "minLength": 1},
             },
+            "variables": {
+                "type": "array",
+                "items": {
+                    "oneOf": [
+                        {
+                            "type": "object",
+                            "properties": {"file": {"type": "string"}},
+                            "required": ["file"],
+                            "additionalProperties": False,
+                        },
+                        {
+                            "type": "object",
+                            "properties": {
+                                "containerfile": utils.CONTAINERFILE_SCHEMA,
+                            },
+                            "required": ["containerfile"],
+                            "additionalProperties": False,
+                        },
+                        {
+                            "type": "object",
+                            "properties": {"image": {"type": "string"}},
+                            "required": ["image"],
+                            "additionalProperties": False,
+                        },
+                        {
+                            "type": "object",
+                            "properties": {
+                                "inline": {
+                                    "type": "object",
+                                    "additionalProperties": {"type": "string"},
+                                },
+                            },
+                            "required": ["inline"],
+                            "additionalProperties": False,
+                        },
+                    ],
+                },
+            },
         },
         "required": ["contentOrigin"],
         "additionalProperties": False,

--- a/rpm_lockfile/utils.py
+++ b/rpm_lockfile/utils.py
@@ -9,6 +9,8 @@ import subprocess
 import tempfile
 from pathlib import Path
 
+from .containerfile_packages import _strip_quotes
+
 
 # Path to where local dnf expects to find rpmdb. This is relative to /.
 RPMDB_PATH = subprocess.run(
@@ -195,6 +197,74 @@ def subst_vars(template, vars):
     return template
 
 
+def load_variables_file(filepath, config_dir):
+    """Parse a KEY=VALUE file into a dict.
+
+    Same format as Containerfile --build-arg-file: one KEY=VALUE per line,
+    blank lines and lines starting with # are skipped, optional quotes on
+    values are stripped.
+    """
+    resolved = os.path.join(config_dir, filepath)
+    variables = {}
+    with open(resolved) as f:
+        for line in f:
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            if "=" not in line:
+                continue
+            key, value = line.split("=", 1)
+            key = key.strip()
+            if not key:
+                continue
+            variables[key] = _strip_quotes(value.strip())
+    return variables
+
+
+def subst_vars_in_list(items, variables):
+    """Apply {var} substitution to each entry in a package-like list.
+
+    Items can be plain strings or dicts with a "name" key (arch-filtered
+    packages).  Returns a new list with substitutions applied.
+    """
+    result = []
+    for item in items:
+        if isinstance(item, str):
+            result.append(subst_vars(item, variables))
+        elif isinstance(item, dict) and "name" in item:
+            result.append({**item, "name": subst_vars(item["name"], variables)})
+        else:
+            result.append(item)
+    return result
+
+
+def load_variables(sources, config_dir):
+    """Process an ordered list of variable sources.
+
+    Each source is a dict with exactly one key: file, containerfile, image,
+    or inline.  Sources are processed in order; later values override earlier
+    ones for the same key.
+    """
+    variables = {}
+    for source in sources:
+        if "file" in source:
+            variables.update(load_variables_file(source["file"], config_dir))
+        elif "containerfile" in source:
+            variables.update(
+                _get_containerfile_labels(source["containerfile"], config_dir)
+            )
+        elif "image" in source:
+            variables.update(_get_image_labels(source["image"]))
+        elif "inline" in source:
+            variables.update(source["inline"])
+        else:
+            raise RuntimeError(
+                f"Unknown variable source: {source}. "
+                "Expected one of: file, containerfile, image, inline."
+            )
+    return variables
+
+
 def translate_arch(arch):
     # This is a horrible hack. Skopeo will reject x86_64, but is happy with
     # amd64. The same goes for aarch64 -> arm64.
@@ -281,12 +351,15 @@ def check_image_spec(image_spec):
     return bool(m)
 
 
-def get_labels(obj, config_dir):
+def get_labels(obj, config_dir, base_vars=None):
     """Find labels from an image or the base image used in the containerfile
     from given configuration object. The given configuration dict is modified
     in place to remove any keys relevant for this lookup.
+
+    If base_vars is provided, start with those values; per-source labels
+    override them.
     """
-    vars = {}
+    vars = dict(base_vars) if base_vars else {}
     image = obj.pop("varsFromImage", None)
     if image:
         vars |= _get_image_labels(image)

--- a/tests/content_origin/test_repofiles.py
+++ b/tests/content_origin/test_repofiles.py
@@ -52,7 +52,7 @@ def test_collect_http_complex():
     origin.session.get.assert_called_once_with(repourl, timeout=ANY)
 
 
-def fake_get_labels(obj, config_dir):
+def fake_get_labels(obj, config_dir, base_vars=None):
     obj.pop("varsFromContainerfile", None)
     obj.pop("varsFromImage", None)
     return {
@@ -131,3 +131,15 @@ def test_collect_git_with_vars_from_image(tmpdir):
 
     assert repos == [REPO]
     mock_get_file.assert_called_once_with(giturl, "abcdef", "test.repo")
+
+
+def test_collect_http_with_global_variables():
+    origin = repofiles.RepofileOrigin("/test", variables={"vcs-ref": "abcdef"})
+    origin.session = Mock()
+    origin.session.get.return_value = Mock(text=REPOFILE)
+    repourl = "http://example.com/test.repo"
+
+    repos = list(origin.collect([{"location": f"{repourl}?x={{vcs-ref}}"}]))
+
+    assert repos == [REPO]
+    origin.session.get.assert_called_once_with(f"{repourl}?x=abcdef", timeout=ANY)

--- a/tests/content_origin/test_repos.py
+++ b/tests/content_origin/test_repos.py
@@ -31,7 +31,7 @@ def test_collect_simple_mirrorlist(tmpdir):
     assert repos == [Repo(repoid="a", kwargs={"mirrorlist": url})]
 
 
-def fake_get_labels(obj, config_dir):
+def fake_get_labels(obj, config_dir, base_vars=None):
     obj.pop("varsFromContainerfile", None)
     obj.pop("varsFromImage", None)
     return {
@@ -69,4 +69,22 @@ def test_collect_with_vars_from_containerfile(tmpdir):
             )
         )
 
+    assert repos == [EXPANDED_REPO]
+
+
+def test_collect_with_global_variables(tmpdir):
+    origin = RepoOrigin(tmpdir, variables={"architecture": "x86_64"})
+    config = [{"repoid": "a", "baseurl": "https://example.com/{architecture}/repo"}]
+    repos = list(origin.collect(config))
+    assert repos == [EXPANDED_REPO]
+
+
+def test_collect_global_vars_overridden_by_source(tmpdir):
+    origin = RepoOrigin(tmpdir, variables={"architecture": "ppc64le"})
+    with patch("rpm_lockfile.utils.get_labels", new=fake_get_labels):
+        repos = list(
+            origin.collect(
+                [TEMPLATE_CONFIG | {"varsFromImage": "registry.example.com/image:latest"}]
+            )
+        )
     assert repos == [EXPANDED_REPO]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -524,3 +524,126 @@ def test_hash_file(content, hash, tmp_path):
     fn = tmp_path / "something"
     fn.write_text(content, encoding="utf-8")
     assert utils.hash_file(fn) == hash
+
+
+@pytest.mark.parametrize(
+    "content,expected",
+    [
+        ("FOO=bar\nBAZ=qux\n", {"FOO": "bar", "BAZ": "qux"}),
+        ("FOO=bar\n\n# comment\nBAZ=qux\n", {"FOO": "bar", "BAZ": "qux"}),
+        ('FOO="bar baz"\nQUX=\'hello\'\n', {"FOO": "bar baz", "QUX": "hello"}),
+        ("FOO=bar=baz\n", {"FOO": "bar=baz"}),
+        ("  FOO = bar  \n", {"FOO": "bar"}),
+        ("NO_EQUALS_LINE\nFOO=bar\n", {"FOO": "bar"}),
+        ("=valuewithnokey\nFOO=bar\n", {"FOO": "bar"}),
+    ],
+)
+def test_load_variables_file(content, expected, tmp_path):
+    fn = tmp_path / "vars.conf"
+    fn.write_text(content, encoding="utf-8")
+    assert utils.load_variables_file("vars.conf", str(tmp_path)) == expected
+
+
+def test_load_variables_file_missing(tmp_path):
+    with pytest.raises(FileNotFoundError):
+        utils.load_variables_file("nonexistent.conf", str(tmp_path))
+
+
+@pytest.mark.parametrize(
+    "items,variables,expected",
+    [
+        (
+            ["nvidia-driver-{VER}", "other-pkg"],
+            {"VER": "580.0"},
+            ["nvidia-driver-580.0", "other-pkg"],
+        ),
+        (
+            [{"name": "nvidia-driver-{VER}", "arches": {"only": "x86_64"}}],
+            {"VER": "580.0"},
+            [{"name": "nvidia-driver-580.0", "arches": {"only": "x86_64"}}],
+        ),
+        (
+            ["pkg-{A}-{B}"],
+            {"A": "1", "B": "2"},
+            ["pkg-1-2"],
+        ),
+        (
+            ["no-placeholders"],
+            {"VER": "580.0"},
+            ["no-placeholders"],
+        ),
+        (
+            ["pkg-{VER}"],
+            {},
+            ["pkg-{VER}"],
+        ),
+    ],
+)
+def test_subst_vars_in_list(items, variables, expected):
+    assert utils.subst_vars_in_list(items, variables) == expected
+
+
+def test_load_variables_inline(tmp_path):
+    sources = [{"inline": {"FOO": "bar", "BAZ": "qux"}}]
+    assert utils.load_variables(sources, str(tmp_path)) == {"FOO": "bar", "BAZ": "qux"}
+
+
+def test_load_variables_file_source(tmp_path):
+    fn = tmp_path / "vars.conf"
+    fn.write_text("FOO=bar\nBAZ=qux\n", encoding="utf-8")
+    sources = [{"file": "vars.conf"}]
+    assert utils.load_variables(sources, str(tmp_path)) == {"FOO": "bar", "BAZ": "qux"}
+
+
+def test_load_variables_ordering(tmp_path):
+    fn = tmp_path / "vars.conf"
+    fn.write_text("FOO=from-file\nBAZ=only-file\n", encoding="utf-8")
+    sources = [
+        {"file": "vars.conf"},
+        {"inline": {"FOO": "from-inline", "QUX": "only-inline"}},
+    ]
+    result = utils.load_variables(sources, str(tmp_path))
+    assert result == {"FOO": "from-inline", "BAZ": "only-file", "QUX": "only-inline"}
+
+
+def test_load_variables_image(tmp_path):
+    with patch("rpm_lockfile.utils._get_image_labels") as mock:
+        mock.return_value = {"vcs-ref": "abc123", "architecture": "x86_64"}
+        sources = [{"image": "registry.example.com/image:latest"}]
+        result = utils.load_variables(sources, str(tmp_path))
+    assert result == {"vcs-ref": "abc123", "architecture": "x86_64"}
+    mock.assert_called_once_with("registry.example.com/image:latest")
+
+
+def test_load_variables_containerfile(tmp_path):
+    with patch("rpm_lockfile.utils._get_containerfile_labels") as mock:
+        mock.return_value = {"vcs-ref": "abc123"}
+        sources = [{"containerfile": "Containerfile"}]
+        result = utils.load_variables(sources, str(tmp_path))
+    assert result == {"vcs-ref": "abc123"}
+    mock.assert_called_once_with("Containerfile", str(tmp_path))
+
+
+def test_load_variables_empty(tmp_path):
+    assert utils.load_variables([], str(tmp_path)) == {}
+
+
+def test_load_variables_unknown_source(tmp_path):
+    with pytest.raises(RuntimeError, match="Unknown variable source"):
+        utils.load_variables([{"bogus": "value"}], str(tmp_path))
+
+
+def test_get_labels_with_base_vars():
+    obj = {"repoid": "a", "baseurl": "https://example.com/repo"}
+    result = utils.get_labels(obj, "/top", base_vars={"FOO": "bar", "BAZ": "qux"})
+    assert result == {"FOO": "bar", "BAZ": "qux"}
+
+
+def test_get_labels_base_vars_overridden_by_source():
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = Mock(stdout=json.dumps(INSPECT_OUTPUT))
+        obj = {"varsFromImage": "registry.example.com/image:latest", "architecture": "override-me"}
+        result = utils.get_labels(obj, "/top", base_vars={"architecture": "ppc64le", "custom": "kept"})
+    assert result["architecture"] == "x86_64"
+    assert result["custom"] == "kept"
+    assert result["vcs-ref"] == "abcdef"


### PR DESCRIPTION
## Summary

Extends the existing `subst_vars()` mechanism (used for repo URLs) to package names, `moduleEnable`/`moduleDisable`, `assumeProvides`, and `context.image`.

Variables can be defined inline (`variables:`) or loaded from an external KEY=VALUE file (`variablesFile:`), letting `rpms.in.yaml` share a single source of truth with Containerfile `--build-arg-file` configs.

### Example

```yaml
variablesFile: ../../argfile-cuda.conf
# or inline:
# variables:
#   DRIVER_VERSION: "580.126.20"

context:
  image: "{BASE_IMAGE}"

packages:
  - nvidia-driver-{DRIVER_VERSION}
  - nvidia-driver-cuda-{DRIVER_VERSION}
  - nvidia-fabricmanager-{DRIVER_VERSION}
```

### Changes

- `schema.py`: add `variables` (object) and `variablesFile` (string) to the JSON schema
- `utils.py`: add `load_variables_file()` for KEY=VALUE parsing and `subst_vars_in_list()` for list-level substitution
- `__init__.py`: wire up variable loading and substitution in `main()` after schema validation
- `tests/test_utils.py`: tests for new functions

Closes #150