### PR TITLE
Parse reinstall packages from Dockerfile RUN commands

### DIFF
--- a/rpm_lockfile/__init__.py
+++ b/rpm_lockfile/__init__.py
@@ -496,11 +496,13 @@ def _extract_containerfile_packages(
             through to shell command analysis for arch-conditional detection.
     Return Value(s):
         tuple: (common_packages, arch_packages, upgrade_packages,
-                module_enable, builddep_packages) — all empty on failure.
+                reinstall_packages, module_enable, builddep_packages)
+                — all empty on failure.
     """
     common_packages: set[str] = set()
     arch_packages: dict[str, set[str]] = {}
     upgrade_packages: set[str] = set()
+    reinstall_packages: set[str] = set()
     module_enable: set[str] = set()
     builddep_packages: list[str] = []
 
@@ -513,6 +515,7 @@ def _extract_containerfile_packages(
         for arch, pkgs in selected.arch_packages.items():
             arch_packages.setdefault(arch, set()).update(pkgs)
         upgrade_packages.update(selected.update_targets)
+        reinstall_packages.update(selected.reinstall_targets)
         module_enable.update(selected.module_specs)
         builddep_packages = list(selected.builddep_packages)
     if common_packages or arch_packages:
@@ -529,6 +532,10 @@ def _extract_containerfile_packages(
             logging.debug(
                 "Containerfile upgrade packages: %s", sorted(upgrade_packages)
             )
+        if reinstall_packages:
+            logging.debug(
+                "Containerfile reinstall packages: %s", sorted(reinstall_packages)
+            )
         if module_enable:
             logging.debug("Containerfile module enable: %s", sorted(module_enable))
         if builddep_packages:
@@ -538,6 +545,7 @@ def _extract_containerfile_packages(
         common_packages,
         arch_packages,
         upgrade_packages,
+        reinstall_packages,
         module_enable,
         builddep_packages,
     )
@@ -595,6 +603,7 @@ def main():
     containerfile_common_packages: set[str] = set()
     containerfile_arch_packages: dict[str, set[str]] = {}
     containerfile_upgrade_packages: set[str] = set()
+    containerfile_reinstall_packages: set[str] = set()
     containerfile_module_enable: set[str] = set()
     containerfile_builddep_packages: list[str] = []
 
@@ -636,6 +645,7 @@ def main():
                     containerfile_common_packages,
                     containerfile_arch_packages,
                     containerfile_upgrade_packages,
+                    containerfile_reinstall_packages,
                     containerfile_module_enable,
                     containerfile_builddep_packages,
                 ) = _extract_containerfile_packages(containerfile, context, arches)
@@ -676,7 +686,8 @@ def main():
                 allow_erasing=allowerasing,
                 reinstall_packages=set(
                     filter_for_arch(arch, config.get("reinstallPackages", []))
-                ),
+                )
+                | containerfile_reinstall_packages,
                 module_enable=set(filter_for_arch(arch, config.get("moduleEnable", [])))
                 | containerfile_module_enable,
                 module_disable=set(

--- a/rpm_lockfile/containerfile_packages.py
+++ b/rpm_lockfile/containerfile_packages.py
@@ -39,6 +39,7 @@ class StagePackages:
     has_update: bool = False
     arch_packages: dict[str, list[str]] = field(default_factory=dict)
     update_targets: list[str] = field(default_factory=list)
+    reinstall_targets: list[str] = field(default_factory=list)
     builddep_packages: list[str] = field(default_factory=list)
     module_specs: list[str] = field(default_factory=list)
 
@@ -59,6 +60,9 @@ class StagePackages:
             has_update=self.has_update or other.has_update,
             arch_packages=merged_arch,
             update_targets=sorted(set(self.update_targets + other.update_targets)),
+            reinstall_targets=sorted(
+                set(self.reinstall_targets + other.reinstall_targets)
+            ),
             builddep_packages=sorted(
                 set(self.builddep_packages + other.builddep_packages)
             ),
@@ -379,6 +383,7 @@ def extract_packages_from_scripts(
     copy_map = copy_map or {}
     all_packages: set[str] = set()
     all_updates: set[str] = set()
+    all_reinstalls: set[str] = set()
     all_arch_packages: dict[str, set[str]] = {}
     all_builddep: set[str] = set()
     all_modules: set[str] = set()
@@ -454,6 +459,7 @@ def extract_packages_from_scripts(
             for arch, arch_pkgs in result.arch_packages.items():
                 all_arch_packages.setdefault(arch, set()).update(arch_pkgs)
             all_updates.update(result.update_targets)
+            all_reinstalls.update(result.reinstall_targets)
             all_builddep.update(result.builddep_packages)
             all_modules.update(result.module_specs)
             if result.has_update:
@@ -474,6 +480,7 @@ def extract_packages_from_scripts(
             arch: sorted(pkgs) for arch, pkgs in sorted(all_arch_packages.items())
         },
         update_targets=sorted(all_updates),
+        reinstall_targets=sorted(all_reinstalls),
         builddep_packages=sorted(all_builddep),
         module_specs=sorted(all_modules),
     )

--- a/rpm_lockfile/shell_commands.py
+++ b/rpm_lockfile/shell_commands.py
@@ -2,7 +2,8 @@
 Shell command parsing for RPM package extraction.
 
 Provides bashlex-based AST walking to extract package names from
-yum/dnf install and update commands in RUN bodies and shell scripts.
+yum/dnf install, update, and reinstall commands in RUN bodies and
+shell scripts.
 Handles variable assignments, arch-conditional blocks, subshell
 expansions, and bash-to-POSIX preprocessing.
 """
@@ -407,7 +408,7 @@ def _detect_pkg_action(
     word_values: list[str], ctx: _WalkContext
 ) -> tuple[str | None, int]:
     """
-    Detect install/update/upgrade action in a dnf/yum command.
+    Detect install/update/upgrade/reinstall action in a dnf/yum command.
 
     Return Value(s):
         tuple[str | None, int]: (action, action_index) or (None, -1).
@@ -423,6 +424,8 @@ def _detect_pkg_action(
         if wl in ("update", "upgrade"):
             ctx.has_update = True
             return "update", idx
+        if wl == "reinstall":
+            return "reinstall", idx
         if wl in ("builddep", "build-dep"):
             return "builddep", idx
         if wl == "module":

--- a/rpm_lockfile/shell_commands.py
+++ b/rpm_lockfile/shell_commands.py
@@ -64,6 +64,7 @@ class RunCommandResult:
     arch_packages: dict[str, list[str]] = field(default_factory=dict)
     update_targets: list[str] = field(default_factory=list)
     has_update: bool = False
+    reinstall_targets: list[str] = field(default_factory=list)
     builddep_packages: list[str] = field(default_factory=list)
     module_specs: list[str] = field(default_factory=list)
 
@@ -82,6 +83,7 @@ class _WalkContext:
     arch_packages: dict[str, set[str]] = field(default_factory=dict)
     update_targets: set[str] = field(default_factory=set)
     has_update: bool = False
+    reinstall_targets: set[str] = field(default_factory=set)
     builddep_packages: set[str] = field(default_factory=set)
     module_specs: set[str] = field(default_factory=set)
 
@@ -527,6 +529,8 @@ def _classify_package_tokens(
 
         if action == "update":
             ctx.update_targets.add(token)
+        elif action == "reinstall":
+            ctx.reinstall_targets.add(token)
         elif arch_context:
             for arch in arch_context:
                 ctx.arch_packages.setdefault(arch, set()).add(token)
@@ -718,6 +722,7 @@ def analyze_run_commands(
         },
         update_targets=sorted(ctx.update_targets),
         has_update=ctx.has_update,
+        reinstall_targets=sorted(ctx.reinstall_targets),
         builddep_packages=sorted(ctx.builddep_packages),
         module_specs=sorted(ctx.module_specs),
     )

--- a/tests/test_shell_commands.py
+++ b/tests/test_shell_commands.py
@@ -120,15 +120,14 @@ class TestAnalyzeRunCommands(unittest.TestCase):
     def test_reinstall_packages_parsed(self):
         run_values = ["dnf -y reinstall tzdata && dnf clean all"]
         result = analyze_run_commands(run_values)
-        self.assertIn("tzdata", result.packages)
-        self.assertEqual(result.arch_packages, {})
+        self.assertEqual(result.reinstall_targets, ["tzdata"])
+        self.assertEqual(result.packages, [])
 
     def test_reinstall_multiple_packages_parsed(self):
         run_values = ["microdnf -y reinstall tzdata glibc && microdnf clean all"]
         result = analyze_run_commands(run_values)
-        self.assertIn("tzdata", result.packages)
-        self.assertIn("glibc", result.packages)
-        self.assertEqual(result.arch_packages, {})
+        self.assertEqual(sorted(result.reinstall_targets), ["glibc", "tzdata"])
+        self.assertEqual(result.packages, [])
 
     def test_reinstall_mixed_with_install(self):
         run_values = [
@@ -136,8 +135,8 @@ class TestAnalyzeRunCommands(unittest.TestCase):
         ]
         result = analyze_run_commands(run_values)
         self.assertIn("openssl", result.packages)
-        self.assertIn("tzdata", result.packages)
-        self.assertEqual(result.arch_packages, {})
+        self.assertNotIn("tzdata", result.packages)
+        self.assertEqual(result.reinstall_targets, ["tzdata"])
 
     def test_fallback_install_after_or(self):
         run_values = [

--- a/tests/test_shell_commands.py
+++ b/tests/test_shell_commands.py
@@ -117,6 +117,28 @@ class TestAnalyzeRunCommands(unittest.TestCase):
             result.arch_packages, {"x86_64": ["kernel-rt-devel", "kernel-rt-modules"]}
         )
 
+    def test_reinstall_packages_parsed(self):
+        run_values = ["dnf -y reinstall tzdata && dnf clean all"]
+        result = analyze_run_commands(run_values)
+        self.assertIn("tzdata", result.packages)
+        self.assertEqual(result.arch_packages, {})
+
+    def test_reinstall_multiple_packages_parsed(self):
+        run_values = ["microdnf -y reinstall tzdata glibc && microdnf clean all"]
+        result = analyze_run_commands(run_values)
+        self.assertIn("tzdata", result.packages)
+        self.assertIn("glibc", result.packages)
+        self.assertEqual(result.arch_packages, {})
+
+    def test_reinstall_mixed_with_install(self):
+        run_values = [
+            "microdnf -y install openssl && microdnf -y reinstall tzdata && microdnf clean all"
+        ]
+        result = analyze_run_commands(run_values)
+        self.assertIn("openssl", result.packages)
+        self.assertIn("tzdata", result.packages)
+        self.assertEqual(result.arch_packages, {})
+
     def test_fallback_install_after_or(self):
         run_values = [
             "dnf -y install gcc-${GCC_VERSION} gcc-c++-${GCC_VERSION} || dnf -y install gcc gcc-c++"


### PR DESCRIPTION
The shell command parser did not recognize `reinstall` as a dnf/yum action, so packages from `RUN dnf reinstall tzdata` were invisible to lockfile generation. This caused downstream consumers (e.g. ART doozer) to miss these packages when building the lockfile, leading to missing package files in hermetic Konflux builds.

Add `reinstall` recognition to `_detect_pkg_action()`. Reinstall packages flow into the install list via the existing default path in `_classify_package_tokens()`, ensuring they appear in the resolved lockfile.