### PR TITLE
Fix rpmdb extraction from ostree-based images

### DIFF
--- a/rpm_lockfile/containers.py
+++ b/rpm_lockfile/containers.py
@@ -73,8 +73,11 @@ def setup_rpmdb(dest_dir, baseimage, arch):
     else:
         logging.info("Using already downloaded rpmdb")
 
-    # Copy the cache to the correct destination directory.
-    shutil.copytree(cache, dest_dir, dirs_exist_ok=True)
+    # Copy the cache to the correct destination directory. Use
+    # symlinks=True to preserve symlinks as-is. The cache may contain
+    # symlinks from the image (e.g. usr/lib/sysimage/rpm pointing to
+    # ../../share/rpm in ostree-based images).
+    shutil.copytree(cache, dest_dir, symlinks=True, dirs_exist_ok=True)
 
     _maybe_cleanup(cache)
 
@@ -96,15 +99,31 @@ def _online_setup_rpmdb(dest_dir, baseimage, arch):
         with open(tmpdir / "manifest.json") as f:
             manifest = json.load(f)
 
-        # This are all possible locations for rpmdb that are populated by the
-        # image.
-        dbpaths = set()
+        # In ostree-based images (e.g. bootc), rpmdb entries can be
+        # hardlinks to content-addressed objects stored elsewhere in
+        # the tar (under sysroot/ostree/repo/objects/). When extractall
+        # can not create a hardlink because the target was filtered
+        # out, it falls back to calling the filter on the target
+        # member. Pre-scan all layers to collect these targets so the
+        # filter can accept them.
+        _hardlink_targets = set()
+        for layer in manifest["layers"]:
+            digest = layer["digest"].split(":", 1)[1]
+            archive = tarfile.open(tmpdir / digest)
+            for member in archive:
+                if not member.islnk():
+                    continue
+                for candidate_path in RPMDB_PATHS:
+                    if Path(member.name).is_relative_to(candidate_path):
+                        _hardlink_targets.add(member.linkname)
+                        break
 
         def filter_rpmdb(member, path):
             for candidate_path in RPMDB_PATHS:
                 if Path(member.name).is_relative_to(candidate_path):
-                    dbpaths.add(candidate_path)
                     return tarfile.data_filter(member, path)
+            if member.name in _hardlink_targets:
+                return tarfile.data_filter(member, path)
 
         # One layer at a time...
         for layer in manifest["layers"]:
@@ -114,6 +133,16 @@ def _online_setup_rpmdb(dest_dir, baseimage, arch):
             # the destination cache.
             archive = tarfile.open(tmpdir / digest)
             archive.extractall(path=dest_dir, filter=filter_rpmdb)
+
+        # Determine which rpmdb paths actually have content on disk.
+        # Tracking accepted members in the filter is unreliable:
+        # extraction can silently skip members (e.g. hardlinks whose
+        # targets were not extracted).
+        dbpaths = {
+            p
+            for p in RPMDB_PATHS
+            if (dest_dir / p).is_dir() and any((dest_dir / p).iterdir())
+        }
 
         if dbpaths and utils.RPMDB_PATH not in dbpaths:
             # If we have at least one possible rpmdb location populated by the
@@ -130,9 +159,11 @@ def _online_setup_rpmdb(dest_dir, baseimage, arch):
                 os.path.dirname(os.path.join(dest_dir, utils.RPMDB_PATH)),
                 exist_ok=True,
             )
+            link_path = os.path.join(dest_dir, utils.RPMDB_PATH)
+            target_path = os.path.join(dest_dir, dbpath)
             os.symlink(
-                os.path.join(dest_dir, dbpath),
-                os.path.join(dest_dir, utils.RPMDB_PATH),
+                os.path.relpath(target_path, os.path.dirname(link_path)),
+                link_path,
             )
 
 

--- a/tests/test_containers.py
+++ b/tests/test_containers.py
@@ -298,8 +298,8 @@ def test_resolving_image(tmp_path, input_image, digest, resolved_image, disk_is_
     assert _online_setup.mock_calls == [mock.call(img_cache, resolved_image, arch)]
 
     assert copytree.mock_calls == [
-        mock.call(img_cache, tmp_path / "d1", dirs_exist_ok=True),
-        mock.call(img_cache, tmp_path / "d2", dirs_exist_ok=True),
+        mock.call(img_cache, tmp_path / "d1", symlinks=True, dirs_exist_ok=True),
+        mock.call(img_cache, tmp_path / "d2", symlinks=True, dirs_exist_ok=True),
     ]
 
 

--- a/tests/test_containers.py
+++ b/tests/test_containers.py
@@ -1,6 +1,7 @@
 import hashlib
 import json
 import logging
+import os
 import subprocess
 import tempfile
 from abc import ABC
@@ -56,12 +57,15 @@ class FakeImage:
             # Create file structure
             for fn, content in layer.items():
                 (layer_dir / fn).parent.mkdir(parents=True, exist_ok=True)
-                content.create(layer_dir / fn)
-            # Pack it into a tarfile
+                content.create(layer_dir, fn)
+            # Pack it into a tarfile. Sort top-level entries so that
+            # tar encounters them in a deterministic order. This is
+            # important for hardlinks: tar stores the first path for a
+            # given inode as the original and later paths as LNKTYPE.
             archive = Path(temp_dir) / "layer.tar.gz"
             subprocess.run(
                 ["/usr/bin/tar", "cvfz", str(archive)]
-                + [p.name for p in layer_dir.iterdir()],
+                + sorted(p.name for p in layer_dir.iterdir()),
                 check=True,
                 cwd=layer_dir,
             )
@@ -74,7 +78,7 @@ class FakeImage:
 
 
 class FSObject(ABC):
-    def create(self, name):
+    def create(self, root, fn):
         return NotImplemented
 
 
@@ -82,16 +86,33 @@ class File(FSObject):
     def __init__(self, content):
         self.content = content
 
-    def create(self, name):
-        name.write_text(self.content, encoding="utf-8")
+    def create(self, root, fn):
+        (root / fn).write_text(self.content, encoding="utf-8")
 
 
 class Symlink(FSObject):
     def __init__(self, dest):
         self.dest = dest
 
-    def create(self, name):
-        name.symlink_to(self.dest)
+    def create(self, root, fn):
+        (root / fn).symlink_to(self.dest)
+
+
+class Hardlink(FSObject):
+    """A hardlink to another path within the same layer.
+
+    The target is a path relative to the layer root (same as the keys
+    in the layer dict). The target must already exist on disk when
+    create() is called.
+    """
+
+    def __init__(self, target):
+        self.target = target
+
+    def create(self, root, fn):
+        # pathlib.Path.hardlink_to() always follows symlinks, but we
+        # need to hardlink to the symlink itself (as ostree does).
+        os.link(root / self.target, root / fn, follow_symlinks=False)
 
 
 @pytest.mark.parametrize("rpmdb", containers.RPMDB_PATHS)
@@ -129,6 +150,26 @@ class Symlink(FSObject):
             ),
             "bar",
             id="two-layers",
+        ),
+        pytest.param(
+            FakeImage(
+                [
+                    {
+                        "sysroot/ostree/repo/objects/53/def.file": Symlink(
+                            "../../share/rpm"
+                        ),
+                        "sysroot/ostree/repo/objects/68/abc.file": File("foo"),
+                        "usr/lib/sysimage/rpm": Hardlink(
+                            "sysroot/ostree/repo/objects/53/def.file"
+                        ),
+                        "usr/share/rpm/foo": Hardlink(
+                            "sysroot/ostree/repo/objects/68/abc.file"
+                        ),
+                    }
+                ]
+            ),
+            "foo",
+            id="ostree-hardlinks",
         ),
     ],
 )


### PR DESCRIPTION
In ostree-based images (e.g. bootc), rpmdb files are stored as tar hardlinks to content-addressed objects under sysroot/ostree/repo/. The filter_rpmdb function only accepted members under RPMDB_PATHS, so the hardlink targets were filtered out and extractall silently failed to create the hardlinks, resulting in an empty rpmdb.

The first commit adds a failing test case demonstrating the layout. The second commit makes the tests pass.

Three changes:
    
1. Pre-scan layers to collect hardlink targets for rpmdb entries, and    accept them in filter_rpmdb. This allows `extractall`'s       makelink_with_filter fallback to extract the target content at the       hardlink's destination path.
    
2. Determine dbpaths from the filesystem after extraction instead of       tracking in the filter. Filter-based tracking is unreliable because       extraction can silently skip members.
    
3. Use relative symlinks and `symlinks=True` in copytree. The cache may      contain symlinks from the image that must survive copying. Since the content is coming from a base image, there may be dangling symlinks. That's actually the case with the bootc image. A relative symlink is hardlinked in two locations: once in `usr` where it points to a valid file, and once in `sysroot` where it is dangling.
