### PR TITLE
Add matchContextVersions to pin packages to context image versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,13 @@ assumeProvides:
   - nvidia-kmod
   - cuda-libs
 
+matchContextVersions:
+  # List of package name glob patterns. When a context image is used, any
+  # requested package matching a pattern will be pinned to the version found
+  # in the context image's rpmdb. This ensures packages like kernel-devel
+  # resolve to the same version as kernel-core already installed in the image.
+  - kernel-*
+
 moduleEnable: []
   # List of module streams that should be enabled during the dependency
   # resolution. The specification uses the same format as `packages` above.

--- a/rpm_lockfile/__init__.py
+++ b/rpm_lockfile/__init__.py
@@ -129,6 +129,7 @@ def resolver(
     download_filelists: bool = False,
     zchunk: bool = None,
     assume_provides: list[str] = None,
+    match_context_versions: list[str] = None,
 ):
     packages = set()
     sources = set()
@@ -186,6 +187,13 @@ def resolver(
                     baseurl=[f"file://{repo_path}"],
                 )
             base.fill_sack(load_system_repo=True)
+
+            if match_context_versions:
+                solvables = utils.pin_context_versions(
+                    base.sack.query().installed(),
+                    solvables,
+                    match_context_versions,
+                )
 
             module_base = dnf.module.module_base.ModuleBase(base)
 
@@ -320,6 +328,7 @@ def process_arch(
     upgrade_packages: set[str],
     zchunk: bool = None,
     assume_provides: list[str] = None,
+    match_context_versions: list[str] = None,
 ):
     logging.info("Running solver for %s", arch)
 
@@ -341,6 +350,7 @@ def process_arch(
                     download_filelists=download_filelists,
                     zchunk=zchunk,
                     assume_provides=assume_provides,
+                    match_context_versions=match_context_versions,
                 )
                 break
             except MissingFilelists:
@@ -609,12 +619,16 @@ def main():
 
     # Determine rpmdb source — independent of package extraction.
     containerfile = None
+    is_image_context = True
     if args.local_system or context.get("localSystem"):
         rpmdb = local_rpmdb()
+        is_image_context = False
     elif args.bare or context.get("bare") or args.rpm_ostree_treefile:
         rpmdb = empty_rpmdb()
+        is_image_context = False
     elif args.rpm_ostree_treefile or context.get("rpmOstreeTreefile"):
         rpmdb = empty_rpmdb()
+        is_image_context = False
     else:
         image = args.image or context.get("image")
         containerfile = (
@@ -679,6 +693,12 @@ def main():
             builddep_resolved = resolve_builddep_packages(cf_pkgs.builddep, source_dir)
             cf_pkgs.common |= builddep_resolved
 
+    if config.get("matchContextVersions") and not is_image_context:
+        parser.error(
+            "matchContextVersions requires a context image or containerfile.\n"
+            "It cannot be used with --bare, --local-system, or --rpm-ostree-treefile."
+        )
+
     for arch in sorted(arches):
         packages = set()
         if args.rpm_ostree_treefile or context.get("rpmOstreeTreefile"):
@@ -718,6 +738,7 @@ def main():
                 | cf_pkgs.upgrade,
                 zchunk=config.get("zchunk"),
                 assume_provides=assume_provides,
+                match_context_versions=config.get("matchContextVersions"),
             )
         )
 

--- a/rpm_lockfile/schema.py
+++ b/rpm_lockfile/schema.py
@@ -136,6 +136,10 @@ def get_schema():
                 "type": "array",
                 "items": {"type": "string", "minLength": 1},
             },
+            "matchContextVersions": {
+                "type": "array",
+                "items": {"type": "string", "minLength": 1},
+            },
             "variables": {
                 "type": "array",
                 "items": {

--- a/rpm_lockfile/utils.py
+++ b/rpm_lockfile/utils.py
@@ -1,3 +1,4 @@
+import fnmatch
 import functools
 import hashlib
 import json
@@ -369,6 +370,62 @@ def get_labels(obj, config_dir, base_vars=None):
         vars |= _get_containerfile_labels(containerfile, config_dir)
 
     return vars
+
+
+def pin_context_versions(installed_packages, solvables, patterns):
+    """Pin requested packages to versions from the context image's rpmdb.
+
+    For each glob pattern in ``patterns``, find the EVR of installed packages
+    matching it, then rewrite any requested solvable that also matches the
+    pattern to require that exact EVR.
+
+    ``installed_packages`` is an iterable of objects with ``name``,
+    ``version``, and ``release`` attributes (e.g. DNF package objects).
+    """
+    installed = {}
+    for pkg in installed_packages:
+        installed[pkg.name] = pkg
+
+    pattern_evrs = {}
+    for pattern in patterns:
+        for name, pkg in installed.items():
+            if fnmatch.fnmatch(name, pattern):
+                evr = f"{pkg.epoch}:{pkg.version}-{pkg.release}" if pkg.epoch else f"{pkg.version}-{pkg.release}"
+                if pattern not in pattern_evrs:
+                    pattern_evrs[pattern] = evr
+                elif pattern_evrs[pattern] != evr:
+                    raise RuntimeError(
+                        f"matchContextVersions: pattern {pattern!r} matches "
+                        f"installed packages with different versions "
+                        f"({name}-{pattern_evrs[pattern]} vs {name}-{evr})"
+                    )
+
+    unmatched = [p for p in patterns if p not in pattern_evrs]
+    if unmatched:
+        logging.warning(
+            "matchContextVersions: no installed packages matched patterns: %s",
+            ", ".join(unmatched),
+        )
+    if not pattern_evrs:
+        return solvables
+
+    result = set()
+    for spec in solvables:
+        pinned = False
+        for pattern in patterns:
+            if fnmatch.fnmatch(spec, pattern) and pattern in pattern_evrs:
+                versioned = f"{spec}-{pattern_evrs[pattern]}"
+                logging.info(
+                    "matchContextVersions: pinning %s to %s",
+                    spec,
+                    versioned,
+                )
+                result.add(versioned)
+                pinned = True
+                break
+        if not pinned:
+            result.add(spec)
+    return result
 
 
 CONTAINERFILE_SCHEMA = {

--- a/rpm_lockfile/utils.py
+++ b/rpm_lockfile/utils.py
@@ -392,12 +392,12 @@ def pin_context_versions(installed_packages, solvables, patterns):
             if fnmatch.fnmatch(name, pattern):
                 evr = f"{pkg.epoch}:{pkg.version}-{pkg.release}" if pkg.epoch else f"{pkg.version}-{pkg.release}"
                 if pattern not in pattern_evrs:
-                    pattern_evrs[pattern] = evr
-                elif pattern_evrs[pattern] != evr:
+                    pattern_evrs[pattern] = (evr, name)
+                elif pattern_evrs[pattern][0] != evr:
                     raise RuntimeError(
                         f"matchContextVersions: pattern {pattern!r} matches "
                         f"installed packages with different versions "
-                        f"({name}-{pattern_evrs[pattern]} vs {name}-{evr})"
+                        f"({pattern_evrs[pattern][1]}-{pattern_evrs[pattern][0]} vs {name}-{evr})"
                     )
 
     unmatched = [p for p in patterns if p not in pattern_evrs]
@@ -414,7 +414,7 @@ def pin_context_versions(installed_packages, solvables, patterns):
         pinned = False
         for pattern in patterns:
             if fnmatch.fnmatch(spec, pattern) and pattern in pattern_evrs:
-                versioned = f"{spec}-{pattern_evrs[pattern]}"
+                versioned = f"{spec}-{pattern_evrs[pattern][0]}"
                 logging.info(
                     "matchContextVersions: pinning %s to %s",
                     spec,

--- a/tests/test_match_context_versions.py
+++ b/tests/test_match_context_versions.py
@@ -1,0 +1,100 @@
+import logging
+
+import pytest
+from unittest.mock import Mock
+
+from rpm_lockfile.utils import pin_context_versions
+
+
+def _make_pkg(name, version, release, epoch=0):
+    pkg = Mock()
+    pkg.name = name
+    pkg.epoch = epoch
+    pkg.version = version
+    pkg.release = release
+    return pkg
+
+
+class TestPinContextVersions:
+    def test_pins_matching_packages(self):
+        installed = [
+            _make_pkg("kernel-core", "5.14.0", "570.120.1.el9_6"),
+            _make_pkg("kernel-modules", "5.14.0", "570.120.1.el9_6"),
+        ]
+        solvables = {"kernel-core", "kernel-devel", "kernel-headers", "gcc"}
+
+        result = pin_context_versions(installed, solvables, ["kernel-*"])
+
+        assert "kernel-core-5.14.0-570.120.1.el9_6" in result
+        assert "kernel-devel-5.14.0-570.120.1.el9_6" in result
+        assert "kernel-headers-5.14.0-570.120.1.el9_6" in result
+        assert "gcc" in result
+        assert "kernel-core" not in result
+        assert "kernel-devel" not in result
+
+    def test_no_match_returns_unchanged(self):
+        installed = [_make_pkg("bash", "5.1.8", "9.el9")]
+        solvables = {"kernel-devel", "gcc"}
+
+        result = pin_context_versions(installed, solvables, ["kernel-*"])
+
+        assert result == {"kernel-devel", "gcc"}
+
+    def test_multiple_patterns(self):
+        installed = [
+            _make_pkg("kernel-core", "5.14.0", "570.120.1.el9_6"),
+            _make_pkg("glibc", "2.34", "100.el9"),
+        ]
+        solvables = {"kernel-devel", "glibc-devel", "gcc"}
+
+        result = pin_context_versions(
+            installed, solvables, ["kernel-*", "glibc*"]
+        )
+
+        assert "kernel-devel-5.14.0-570.120.1.el9_6" in result
+        assert "glibc-devel-2.34-100.el9" in result
+        assert "gcc" in result
+
+    def test_raises_on_version_mismatch(self):
+        installed = [
+            _make_pkg("kernel-core", "5.14.0", "570.120.1.el9_6"),
+            _make_pkg("kernel-tools", "5.14.0", "570.128.1.el9_6"),
+        ]
+        solvables = {"kernel-devel"}
+
+        with pytest.raises(RuntimeError, match="different versions"):
+            pin_context_versions(installed, solvables, ["kernel-*"])
+
+    def test_no_installed_packages_warns(self, caplog):
+        solvables = {"kernel-devel"}
+
+        with caplog.at_level(logging.WARNING):
+            result = pin_context_versions([], solvables, ["kernel-*"])
+
+        assert "no installed packages matched" in caplog.text
+        assert result == {"kernel-devel"}
+
+    def test_empty_patterns_no_change(self):
+        installed = [_make_pkg("kernel-core", "5.14.0", "570.120.1.el9_6")]
+        solvables = {"kernel-devel", "gcc"}
+
+        result = pin_context_versions(installed, solvables, [])
+
+        assert result == {"kernel-devel", "gcc"}
+
+    def test_non_matching_solvables_untouched(self):
+        installed = [_make_pkg("kernel-core", "5.14.0", "570.120.1.el9_6")]
+        solvables = {"vim", "tmux", "git"}
+
+        result = pin_context_versions(installed, solvables, ["kernel-*"])
+
+        assert result == {"vim", "tmux", "git"}
+
+    def test_epoch_included_when_nonzero(self):
+        installed = [_make_pkg("dbus", "1.12.20", "8.el9", epoch=1)]
+        solvables = {"dbus", "gcc"}
+
+        result = pin_context_versions(installed, solvables, ["dbus"])
+
+        assert "dbus-1:1.12.20-8.el9" in result
+        assert "gcc" in result


### PR DESCRIPTION
## Summary

- Adds `matchContextVersions` config option: a list of package name glob patterns
- When a context image is used, matching requested packages are pinned to the EVR found in the context image rpmdb
- Prevents version-inconsistent lockfiles (e.g. kernel-devel resolving to a newer version than kernel-core already installed in the context image)

## Example

```yaml
context:
  image: registry.redhat.io/rhel9-eus/rhel-9.6-bootc:9.6-1781589459

matchContextVersions:
  - kernel-*

packages:
  - kernel-core
  - kernel-devel
  - kernel-headers
```

With `kernel-core-5.14.0-570.120.1` installed in the context image, `kernel-devel` and `kernel-headers` will be pinned to `5.14.0-570.120.1` instead of resolving to the latest available version.

## Defensive behavior

- **Version mismatch is a hard error**: if a pattern like `kernel-*` matches installed packages with different EVRs (e.g. kernel-core at `570.120.1` and kernel-tools at `570.128.1`), resolution fails with a `RuntimeError` rather than silently picking one. A non-deterministic lockfile is worse than a failed one.
- **Requires a context image**: `matchContextVersions` can only be used with `context.image` or `context.containerfile`. Using it with `--bare`, `--local-system`, or `--rpm-ostree-treefile` exits with a clear error, since the installed packages would not come from a context image.
- **Unmatched patterns are warned**: if a pattern has no matches in the context image rpmdb, a warning is logged identifying which patterns were unused.

## Changes

- `rpm_lockfile/schema.py`: add `matchContextVersions` property (array of strings)
- `rpm_lockfile/utils.py`: add `pin_context_versions()` function
- `rpm_lockfile/__init__.py`: wire through `resolver()`, `process_arch()`, and `main()`; add context-type guard
- `tests/test_match_context_versions.py`: 7 unit tests for the pinning logic
- `README.md`: document the new option

Closes #159

## Test plan

- [x] Unit tests pass (`pytest tests/test_match_context_versions.py`)
- [x] Existing tests unaffected
- [x] Integration test with a real context image and kernel packages