### PR TITLE
Add glob support and enabled filtering to repofiles

### DIFF
--- a/rpm_lockfile/content_origin/repofiles.py
+++ b/rpm_lockfile/content_origin/repofiles.py
@@ -1,4 +1,5 @@
 import configparser
+import glob
 import os
 
 import requests
@@ -80,13 +81,28 @@ class RepofileOrigin:
         yield from self.parse_repofile(resp.text)
 
     def collect_local(self, url):
-        with open(os.path.join(self.config_dir, url)) as f:
-            yield from self.parse_repofile(f.read())
+        if glob.has_magic(url):
+            if os.path.isabs(url):
+                paths = sorted(glob.glob(url))
+            else:
+                paths = sorted(glob.glob(os.path.join(self.config_dir, url)))
+            paths = [p for p in paths if os.path.isfile(p)]
+            if not paths:
+                raise FileNotFoundError(f"No files matching: {url}")
+            for path in paths:
+                with open(path) as f:
+                    yield from self.parse_repofile(f.read())
+        else:
+            path = url if os.path.isabs(url) else os.path.join(self.config_dir, url)
+            with open(path) as f:
+                yield from self.parse_repofile(f.read())
 
     def parse_repofile(self, contents):
         parser = configparser.ConfigParser(interpolation=None)
         parser.read_string(contents)
 
         for section in parser.sections():
+            if parser.get(section, "enabled", fallback="1") == "0":
+                continue
             options = {"repoid": section} | dict(parser.items(section))
             yield Repo.from_dict(options)

--- a/tests/content_origin/test_repofiles.py
+++ b/tests/content_origin/test_repofiles.py
@@ -1,3 +1,5 @@
+import pytest
+
 from unittest.mock import patch, mock_open, Mock, ANY
 
 from rpm_lockfile.content_origin import Repo, repofiles
@@ -143,3 +145,61 @@ def test_collect_http_with_global_variables():
 
     assert repos == [REPO]
     origin.session.get.assert_called_once_with(f"{repourl}?x=abcdef", timeout=ANY)
+
+
+REPOFILE_DISABLED = """
+[enabled-repo]
+baseurl = https://example.com/enabled
+
+[disabled-repo]
+baseurl = https://example.com/disabled
+enabled = 0
+"""
+
+REPOFILE_NO_ENABLED_KEY = """
+[implicit-enabled]
+baseurl = https://example.com/implicit
+"""
+
+
+def test_parse_repofile_skips_disabled():
+    origin = repofiles.RepofileOrigin("/test")
+    repos = list(origin.parse_repofile(REPOFILE_DISABLED))
+
+    assert len(repos) == 1
+    assert repos[0].repoid == "enabled-repo"
+
+
+def test_parse_repofile_enabled_by_default():
+    origin = repofiles.RepofileOrigin("/test")
+    repos = list(origin.parse_repofile(REPOFILE_NO_ENABLED_KEY))
+
+    assert len(repos) == 1
+    assert repos[0].repoid == "implicit-enabled"
+
+
+def test_collect_local_glob(tmpdir):
+    (tmpdir / "a.repo").write_text(REPOFILE, encoding="utf-8")
+    (tmpdir / "b.repo").write_text(REPOFILE_NO_ENABLED_KEY, encoding="utf-8")
+
+    origin = repofiles.RepofileOrigin("/test")
+    repos = list(origin.collect_local(str(tmpdir / "*.repo")))
+
+    assert len(repos) == 2
+    repo_ids = {r.repoid for r in repos}
+    assert repo_ids == {"repo-0", "implicit-enabled"}
+
+
+def test_collect_local_glob_no_match():
+    origin = repofiles.RepofileOrigin("/test")
+    with pytest.raises(FileNotFoundError, match="No files matching"):
+        list(origin.collect_local("/nonexistent/path/*.repo"))
+
+
+def test_collect_local_absolute_path(tmpdir):
+    (tmpdir / "test.repo").write_text(REPOFILE, encoding="utf-8")
+
+    origin = repofiles.RepofileOrigin("/other")
+    repos = list(origin.collect_local(str(tmpdir / "test.repo")))
+
+    assert repos == [REPO]


### PR DESCRIPTION
## Summary

- `repofiles` now supports glob patterns (e.g. `/etc/yum.repos.d/*.repo`)
- Repos with `enabled=0` are now skipped when parsing `.repo` files (the docstring already claimed this, but it wasn't implemented)
- Absolute paths bypass the config directory join

This lets users point at system-configured repos directly instead of shipping duplicate `.repo` files:

```yaml
contentOrigin:
  repofiles:
    - /etc/yum.repos.d/*.repo
    - cuda-rhel9.repo
```

## Changes

- `rpm_lockfile/content_origin/repofiles.py`: glob expansion in `collect_local()`, `enabled=0` filtering in `parse_repofile()`
- `tests/content_origin/test_repofiles.py`: tests for glob, no-match error, absolute paths, disabled repos

Closes #161

## Test plan

- [ ] New tests pass
- [ ] Existing repofiles tests unaffected
- [ ] Integration: register with activation key, use `/etc/yum.repos.d/*.repo` glob, verify packages resolve
