### PR TITLE
Be lenient if packages to be reinstalled are too old and need an upgrade

### DIFF
--- a/rpm_lockfile/__init__.py
+++ b/rpm_lockfile/__init__.py
@@ -198,6 +198,7 @@ def resolver(
                 base.upgrade(pkg)
             # Mark packages to remove
             for pkg in reinstall_packages:
+                pkg_reinstall_needs_upgrade = False
                 try:
                     base.reinstall(pkg)
                 except dnf.exceptions.PackagesNotInstalledError:
@@ -207,13 +208,10 @@ def resolver(
                         f"Can not reinstall {pkg}: no package matched in configured repo"
                     )
                 except dnf.exceptions.PackagesNotAvailableError:
-                    # The package is not available in the same version as in
-                    # base image. If we are supposed to update it, it's
-                    # probably okay and we don't need to reinstall as a new
-                    # copy will be used for the upgrade. Otherwise report an
-                    # error.
-                    if pkg not in upgrade_packages:
-                        raise
+                    logging.warning("Can not reinstall %s: it needs an upgrade", pkg)
+                    pkg_reinstall_needs_upgrade = True
+                if pkg_reinstall_needs_upgrade:
+                    base.upgrade(pkg)
             # Mark packages for installation
             try:
                 base.install_specs(solvables)


### PR DESCRIPTION
Currently, if `rpms.in.yaml` lists a package under `reinstallPackages` that is too old in the base image, and the exact RPM package NEVRA is absent from the repositories, then it leads to:
```
  Traceback (most recent call last):
    File "/usr/local/bin/rpm-lockfile-prototype", line 6, in <module>
      sys.exit(main())
               ~~~~^^
    File "/usr/local/lib/python3.14/site-packages/rpm_lockfile/__init__.py",
        line 699, in main
      process_arch(
      ~~~~~~~~~~~~^
          arch,
          ^^^^^
      ...<20 lines>...
          assume_provides=assume_provides,
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      )
      ^
    File "/usr/local/lib/python3.14/site-packages/rpm_lockfile/__init__.py",
        line 329, in process_arch
      packages, sources, module_metadata = resolver(
                                           ~~~~~~~~^
          arch,
          ^^^^^
      ...<12 lines>...
          assume_provides=assume_provides,
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      )
      ^
    File "/usr/local/lib/python3.14/site-packages/rpm_lockfile/__init__.py",
        line 202, in resolver
      base.reinstall(pkg)
      ~~~~~~~~~~~~~~^^^^^
    File "/usr/lib/python3.14/site-packages/dnf/base.py", line 2381, in
        reinstall
      raise dnf.exceptions.PackagesNotAvailableError(
          'no package matched', pkg_spec, installed_pkgs)
  dnf.exceptions.PackagesNotAvailableError: no package matched: tzdata
```

This happens when hacking on a Container/Dockerfile using an old base image; and trying to keep `rpms.lock.yaml` synchronized with the corresponding updates to `rpms.in.yaml` and the rest of the sources in each Git commit, in a sequence of commits, so that each passes the CI.

One alternative is to use a `upgradePackages` directive in `rpms.in.yaml` that duplicates the `reinstallPackages` directive.  The ability to avoid the duplication is a convenience, and this implements that.

https://github.com/konflux-ci/rpm-lockfile-prototype/issues/163