### PR TITLE
Add end-to-end integration test suite

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -45,7 +45,7 @@ jobs:
       run: |
         {
           echo 'FROM ${{ matrix.base-image }}'
-          echo 'RUN dnf install -y python3-pip python3-dnf gcc'
+          echo 'RUN dnf install -y python3-pip python3-dnf gcc skopeo'
           echo 'WORKDIR /src'
           echo 'RUN python3 -m pip install -e "." pytest pytest-cov'
           echo 'RUN pytest -v --cov=rpm_lockfile --cov-report=xml:coverage.xml'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,20 @@ exclude = ["rpm_lockfile/vendor"]
 requires = ["setuptools >= 61.0"]
 build-backend = "setuptools.build_meta"
 
+[tool.coverage.run]
+parallel = true
+source = ["rpm_lockfile"]
+relative_files = true
+
+[tool.coverage.paths]
+source = [
+    "rpm_lockfile/",
+    "/*/site-packages/rpm_lockfile/",
+]
+
+[tool.coverage.report]
+show_missing = true
+
 [project.entry-points."rpm_lockfile.content_origins"]
 repos = "rpm_lockfile.content_origin.repos:RepoOrigin"
 repofiles = "rpm_lockfile.content_origin.repofiles:RepofileOrigin"

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -1,0 +1,197 @@
+# Integration Tests
+
+Black-box tests that invoke `rpm-lockfile-prototype` as a subprocess, feed
+it input files, and validate the output lockfile. The tool is never
+imported directly -- it is always run as a child process.
+
+## Prerequisites
+
+- **rpm-lockfile-prototype** must be installed and on PATH. Use
+  `pip install -e .` in a virtual environment to install from the repo.
+- **skopeo** must be installed and on PATH.
+- **dnf** Python bindings must be available (system package).
+
+## Running
+
+```bash
+# Run only integration tests
+pytest tests/integration/
+
+# Run a single test case
+pytest tests/integration/ -k single-package
+
+# Run with parallel workers (requires pytest-xdist)
+pytest tests/integration/ -n 10
+
+# Run with coverage
+pytest tests/integration/ --cov rpm_lockfile --cov-report html
+
+# Speed up repeated runs by caching skopeo downloads
+SKOPEO_CACHE_DIR=/tmp/skopeo-cache pytest tests/integration/
+```
+
+## How it works
+
+Each test case is a directory under `data/success/` or `data/failure/`.
+Test cases are autodiscovered -- no manual registration needed.
+
+For each test case, the harness:
+
+1. Scans `repos/<repo-name>.yaml` and generates DNF-compatible repodata.
+2. Starts a per-test HTTP server to serve the generated repos.
+3. Copies `rpms.in.yaml` and any extra files to a temp directory, replacing
+   the `PORT` placeholder with the actual server port.
+4. Runs `rpm-lockfile-prototype rpms.in.yaml --outfile rpms.lock.yaml`.
+5. Stops the server.
+
+**Success tests** (`data/success/`): the tool must exit 0 and the output
+lockfile must match `expected.lock.yaml`. The `PORT` placeholder in the
+expected file is replaced with the actual server port before comparison.
+
+**Failure tests** (`data/failure/`): the tool must exit with a non-zero code.
+
+Both types optionally support `expected.stdout` and `expected.stderr` files
+for validating log messages (see below).
+
+## Adding a new test case
+
+### 1. Create the directory
+
+```
+tests/integration/data/success/my-new-test/
+```
+
+Or under `data/failure/` if the tool is expected to fail.
+
+### 2. Create the input file (`rpms.in.yaml`)
+
+Use `http://localhost:PORT/<repo-name>` for repo URLs. The `PORT`
+placeholder is replaced at runtime with the actual HTTP server port.
+
+```yaml
+contentOrigin:
+  repos:
+    - repoid: test-repo
+      baseurl: http://localhost:PORT/test-repo
+packages:
+  - my-package
+arches:
+  - x86_64
+context:
+  bare: true
+```
+
+### 3. Define the repo packages (`repos/<repo-name>.yaml`)
+
+Each YAML file under `repos/` defines the packages in one repository.
+The filename (minus `.yaml`) becomes the repo directory name on the
+HTTP server.
+
+```yaml
+packages:
+  - nvr: my-package-1.0-1
+
+  - nvr: my-dep-2.0-1
+    arch: x86_64
+    requires:
+      - something
+    provides:
+      - something-else
+    recommends:
+      - optional-thing
+    files:
+      - /usr/share/my-dep/data.txt
+```
+
+Supported fields per package:
+
+| Field | Default | Description |
+|---|---|---|
+| `nvr` | (required) | Name-Version-Release. Supports epoch: `name-1:2.0-1` |
+| `arch` | `noarch` | Package architecture |
+| `requires` | `[]` | Hard dependencies |
+| `provides` | `[]` | Extra capabilities (self-provide is always added) |
+| `recommends` | `[]` | Weak dependencies |
+| `files` | `[]` | File paths (for filelists.xml, used for file-based deps) |
+| `sourcerpm` | auto | Defaults to `<name>-<ver>-<rel>.src.rpm` |
+
+### 4. Generate the expected lockfile
+
+For success tests, use the `generate-expected` helper:
+
+```bash
+tests/integration/generate-expected tests/integration/data/success/my-new-test
+```
+
+This reads all `repos/*.yaml` files, computes the checksums and sizes for
+every package, and writes `expected.lock.yaml` with all packages included.
+**Edit the file to remove packages that should not appear in the output**
+(e.g., packages in the repo that the tool shouldn't resolve). The helper
+gives you a starting point with correct checksums -- you decide which
+packages belong in the expected result.
+
+### 5. (Optional) Add output expectations
+
+Create `expected.stdout` and/or `expected.stderr` to validate log messages.
+Each non-empty, non-comment line is checked as a substring that must appear
+in the corresponding output stream.
+
+```
+# Lines starting with # are comments
+Expected log message substring
+```
+
+### 6. Run the test
+
+```bash
+pytest tests/integration/ -k my-new-test -v
+```
+
+## Repo directory layout
+
+The path of each `.yaml` file under `repos/` (relative to `repos/`, minus
+the extension) becomes the directory path for the generated repodata:
+
+```
+repos/test-repo.yaml            -> <tmpdir>/test-repo/repodata/
+repos/test-repo/x86_64.yaml     -> <tmpdir>/test-repo/x86_64/repodata/
+repos/test-repo/9.yaml          -> <tmpdir>/test-repo/9/repodata/
+```
+
+This is used for `$basearch` and `$releasever` substitution tests. For
+example, with `baseurl: http://localhost:PORT/test-repo/$basearch`, place
+the repo definition at `repos/test-repo/x86_64.yaml`.
+
+## Extra files
+
+Any file in the test case directory that is not `rpms.in.yaml`,
+`expected.lock.yaml`, `expected.stdout`, `expected.stderr`,
+`Containerfile`, or `Dockerfile` is copied to the working directory.
+Files with the `.repo` extension also get `PORT` placeholder replacement.
+
+Containerfiles and Dockerfiles are copied automatically without
+placeholder replacement.
+
+## Skopeo caching
+
+The skopeo caching wrapper (`skopeo-cache`) is always enabled. It
+transparently intercepts skopeo calls and caches inspect/copy results.
+It is thread-safe for use with pytest-xdist.
+
+By default, the cache is stored in a per-user directory
+(`/tmp/rpm-lockfile-test-skopeo-cache-<user>`) that is shared across all
+xdist workers and persists across runs until the system reboots or the
+directory is manually removed. To use a different location, set
+`SKOPEO_CACHE_DIR`:
+
+```bash
+SKOPEO_CACHE_DIR=/tmp/skopeo-cache pytest tests/integration/
+```
+
+## Tool cache isolation
+
+Each test run uses a fresh `XDG_CACHE_HOME` (session-scoped temp directory)
+so the tool's internal cache does not interfere with test isolation. Within
+a single test session, the cache is shared across tests -- the first test
+using a given image exercises the cold (download) path, and subsequent
+tests hit the warm (cached) path.

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,280 @@
+"""Test fixtures and helpers for integration tests."""
+
+import dataclasses
+import http.server
+import os
+import shutil
+import subprocess
+import tempfile
+import threading
+from pathlib import Path
+
+import pytest
+import yaml
+
+from . import repogen
+
+DATA_DIR = Path(__file__).parent / "data"
+SUCCESS_DIR = DATA_DIR / "success"
+FAILURE_DIR = DATA_DIR / "failure"
+WRAPPER_DIR = Path(__file__).parent
+PORT_PLACEHOLDER = "PORT"
+
+
+@pytest.fixture(scope="session")
+def shared_cache(tmp_path_factory):
+    """Tool cache directory (XDG_CACHE_HOME) for the test session.
+
+    Each pytest-xdist worker gets its own cache directory, ensuring every
+    worker exercises the cold (download) path at least once. Within a
+    single worker, the cache is reused across tests.
+    """
+    return str(tmp_path_factory.mktemp("cache"))
+
+
+@pytest.fixture(scope="session")
+def _skopeo_cache_dir(tmp_path_factory):
+    """Skopeo download cache directory, shared across all workers.
+
+    Uses SKOPEO_CACHE_DIR if set (persistent across runs), otherwise
+    uses a fixed path under the system temp directory so all xdist
+    workers share the same cache within a run.
+    """
+    persistent = os.environ.get("SKOPEO_CACHE_DIR")
+    if persistent:
+        os.makedirs(persistent, exist_ok=True)
+        return persistent
+    import getpass
+    default = Path(tempfile.gettempdir()) / f"rpm-lockfile-test-skopeo-cache-{getpass.getuser()}"
+    default.mkdir(exist_ok=True)
+    return str(default)
+
+
+@pytest.fixture(scope="session")
+def _skopeo_wrapper_dir(tmp_path_factory):
+    """Create a directory with a 'skopeo' symlink to the caching wrapper."""
+    wrapper_dir = tmp_path_factory.mktemp("skopeo-wrapper")
+    (wrapper_dir / "skopeo").symlink_to(WRAPPER_DIR / "skopeo-cache")
+    return str(wrapper_dir)
+
+
+class _QuietHTTPHandler(http.server.SimpleHTTPRequestHandler):
+    """HTTP handler that suppresses request logging."""
+
+    def log_message(self, format, *args):
+        pass
+
+
+def _make_handler(directory):
+    """Create an HTTP handler class that serves from the given directory."""
+    def handler(*args, **kwargs):
+        return _QuietHTTPHandler(*args, directory=str(directory), **kwargs)
+    return handler
+
+
+def _start_http_server(directory):
+    """Start an HTTP server on a random port. Returns (server, port)."""
+    server = http.server.HTTPServer(("localhost", 0), _make_handler(directory))
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    return server, port
+
+
+def _replace_port(filepath, actual_port):
+    """Replace the PORT placeholder with the actual port in a file."""
+    text = filepath.read_text()
+    text = text.replace(PORT_PLACEHOLDER, str(actual_port))
+    filepath.write_text(text)
+
+
+def _find_test_case_dir(test_case_name):
+    """Find the test case directory in success/ or failure/ subdirectories."""
+    matches = [
+        parent / test_case_name
+        for parent in (SUCCESS_DIR, FAILURE_DIR)
+        if (parent / test_case_name).exists()
+    ]
+    if len(matches) > 1:
+        raise ValueError(
+            f"Test case '{test_case_name}' exists in both success/ and failure/"
+        )
+    if not matches:
+        raise FileNotFoundError(
+            f"Test case directory not found: {test_case_name} "
+            f"(looked in {SUCCESS_DIR} and {FAILURE_DIR})"
+        )
+    return matches[0]
+
+
+def prepare_test_case(test_case_name, tmp_path, port):
+    """Set up a test case: generate repos and copy input files.
+
+    Returns the path to the prepared rpms.in.yaml in tmp_path.
+    """
+    test_case_dir = _find_test_case_dir(test_case_name)
+
+    rpms_in = test_case_dir / "rpms.in.yaml"
+
+    # Generate repos from YAML definitions. The path of each .yaml file
+    # relative to repos/ (minus extension) becomes the repo directory.
+    # Examples:
+    #   repos/test-repo.yaml          -> <tmpdir>/test-repo/repodata/
+    #   repos/test-repo/x86_64.yaml   -> <tmpdir>/test-repo/x86_64/repodata/
+    #   repos/test-repo/9.yaml        -> <tmpdir>/test-repo/9/repodata/
+    repos_dir = test_case_dir / "repos"
+    if repos_dir.exists():
+        for repo_yaml in sorted(repos_dir.rglob("*.yaml")):
+            rel = repo_yaml.relative_to(repos_dir).with_suffix("")
+            repo_dir = tmp_path / rel
+            repogen.create_repo_from_yaml(repo_yaml, repo_dir)
+
+    # Copy rpms.in.yaml and replace PORT placeholder with actual port
+    dest_rpms_in = tmp_path / "rpms.in.yaml"
+    shutil.copy2(rpms_in, dest_rpms_in)
+    _replace_port(dest_rpms_in, port)
+
+    # Copy Containerfile if present
+    for cf_name in ["Containerfile", "Dockerfile"]:
+        cf = test_case_dir / cf_name
+        if cf.exists():
+            shutil.copy2(cf, tmp_path / cf_name)
+
+    # Copy any extra files (.repo files etc.) and replace PORT placeholder
+    for extra in test_case_dir.glob("*"):
+        if extra.is_dir():
+            continue
+        if extra.name in ("rpms.in.yaml", "expected.lock.yaml",
+                          "expected.stdout", "expected.stderr",
+                          "Containerfile", "Dockerfile"):
+            continue
+        dest = tmp_path / extra.name
+        shutil.copy2(extra, dest)
+        if extra.suffix in (".repo",):
+            _replace_port(dest, port)
+
+    return dest_rpms_in
+
+
+def load_expected(test_case_name, actual_port):
+    """Load the expected lockfile, replacing PORT placeholder with actual."""
+    expected_path = _find_test_case_dir(test_case_name) / "expected.lock.yaml"
+    text = expected_path.read_text()
+    text = text.replace(PORT_PLACEHOLDER, str(actual_port))
+    return yaml.safe_load(text)
+
+
+def _load_expected_patterns(test_case_name, filename):
+    """Load expected output patterns from a file, if it exists.
+
+    Returns a list of substring patterns that must each appear somewhere
+    in the corresponding output stream, or None if the file doesn't exist.
+    Lines starting with # and blank lines are ignored.
+    """
+    expected_path = _find_test_case_dir(test_case_name) / filename
+    if not expected_path.exists():
+        return None
+    return [
+        line for line in expected_path.read_text().splitlines()
+        if line.strip() and not line.strip().startswith("#")
+    ]
+
+
+def load_expected_stdout(test_case_name):
+    """Load expected stdout patterns, if defined."""
+    return _load_expected_patterns(test_case_name, "expected.stdout")
+
+
+def load_expected_stderr(test_case_name):
+    """Load expected stderr patterns, if defined."""
+    return _load_expected_patterns(test_case_name, "expected.stderr")
+
+
+@dataclasses.dataclass
+class RunResult:
+    rc: int
+    lockfile: object
+    stdout: str
+    stderr: str
+    port: int
+
+
+def run_test_case_ok(
+    test_case_name, tmp_path, cache_dir,
+    _skopeo_wrapper_dir=None, _skopeo_cache_dir=None,
+    extra_args=None,
+):
+    """Run a test case, assert it succeeds, and return RunResult."""
+    result = run_test_case(
+        test_case_name, tmp_path, cache_dir,
+        _skopeo_wrapper_dir, _skopeo_cache_dir, extra_args,
+    )
+    assert result.rc == 0, f"Tool failed with exit code {result.rc}:\n{result.stderr}"
+    assert result.lockfile is not None, "Lockfile was not produced"
+    return result
+
+
+def run_test_case(
+    test_case_name, tmp_path, cache_dir,
+    _skopeo_wrapper_dir=None, _skopeo_cache_dir=None,
+    extra_args=None,
+):
+    """Prepare and run a test case.
+
+    Returns RunResult.
+    """
+    server, port = _start_http_server(tmp_path)
+    try:
+        rpms_in = prepare_test_case(test_case_name, tmp_path, port)
+        outfile = tmp_path / "rpms.lock.yaml"
+
+        cmd = ["rpm-lockfile-prototype"]
+        if extra_args:
+            cmd.extend(extra_args)
+        cmd.extend([str(rpms_in), "--outfile", str(outfile)])
+
+        # Point XDG_CACHE_HOME at a session-scoped directory so the tool
+        # doesn't use the user's real cache.
+        # Ensure localhost is in no_proxy so HTTP(S)_PROXY settings don't
+        # intercept requests to the local test HTTP server.
+        no_proxy = os.environ.get("no_proxy", "")
+        if "localhost" not in no_proxy:
+            no_proxy = f"localhost,{no_proxy}" if no_proxy else "localhost"
+        env = {**os.environ, "XDG_CACHE_HOME": cache_dir, "no_proxy": no_proxy}
+
+        # Always use the skopeo caching wrapper to avoid redundant downloads.
+        if _skopeo_wrapper_dir and _skopeo_cache_dir:
+            existing_path = env.get("PATH", "")
+            if existing_path:
+                env["PATH"] = f"{_skopeo_wrapper_dir}:{existing_path}"
+            else:
+                env["PATH"] = _skopeo_wrapper_dir
+            env["SKOPEO_CACHE_DIR"] = _skopeo_cache_dir
+
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            cwd=str(tmp_path),
+            env=env,
+            timeout=120,
+        )
+
+        lockfile = None
+        if outfile.exists():
+            try:
+                with open(outfile) as f:
+                    lockfile = yaml.safe_load(f)
+            except yaml.YAMLError:
+                pass
+
+        return RunResult(
+            rc=result.returncode,
+            lockfile=lockfile,
+            stdout=result.stdout,
+            stderr=result.stderr,
+            port=port,
+        )
+    finally:
+        server.shutdown()
+        server.server_close()

--- a/tests/integration/data/failure/match-context-versions-bare/expected.stderr
+++ b/tests/integration/data/failure/match-context-versions-bare/expected.stderr
@@ -1,0 +1,2 @@
+# matchContextVersions requires an image context
+matchContextVersions requires a context image or containerfile

--- a/tests/integration/data/failure/match-context-versions-bare/repos/test-repo.yaml
+++ b/tests/integration/data/failure/match-context-versions-bare/repos/test-repo.yaml
@@ -1,0 +1,2 @@
+packages:
+  - nvr: test-base-1.0-1

--- a/tests/integration/data/failure/match-context-versions-bare/rpms.in.yaml
+++ b/tests/integration/data/failure/match-context-versions-bare/rpms.in.yaml
@@ -1,0 +1,12 @@
+contentOrigin:
+  repos:
+    - repoid: test-repo
+      baseurl: http://localhost:PORT/test-repo
+packages:
+  - test-base
+matchContextVersions:
+  - "test*"
+arches:
+  - x86_64
+context:
+  bare: true

--- a/tests/integration/data/failure/missing-package/expected.stderr
+++ b/tests/integration/data/failure/missing-package/expected.stderr
@@ -1,0 +1,2 @@
+# DNF should report the missing package
+missing packages: nonexistent-pkg

--- a/tests/integration/data/failure/missing-package/repos/test-repo.yaml
+++ b/tests/integration/data/failure/missing-package/repos/test-repo.yaml
@@ -1,0 +1,2 @@
+packages:
+  - nvr: test-base-1.0-1

--- a/tests/integration/data/failure/missing-package/rpms.in.yaml
+++ b/tests/integration/data/failure/missing-package/rpms.in.yaml
@@ -1,0 +1,10 @@
+contentOrigin:
+  repos:
+    - repoid: test-repo
+      baseurl: http://localhost:PORT/test-repo
+packages:
+  - nonexistent-pkg
+arches:
+  - x86_64
+context:
+  bare: true

--- a/tests/integration/data/failure/reinstall-not-in-repo/expected.stderr
+++ b/tests/integration/data/failure/reinstall-not-in-repo/expected.stderr
@@ -1,0 +1,2 @@
+# Reinstalling a package that exists in the image but not in any repo
+PackagesNotAvailableError

--- a/tests/integration/data/failure/reinstall-not-in-repo/repos/test-repo.yaml
+++ b/tests/integration/data/failure/reinstall-not-in-repo/repos/test-repo.yaml
@@ -1,0 +1,2 @@
+packages:
+  - nvr: unrelated-package-1.0-1

--- a/tests/integration/data/failure/reinstall-not-in-repo/rpms.in.yaml
+++ b/tests/integration/data/failure/reinstall-not-in-repo/rpms.in.yaml
@@ -1,0 +1,11 @@
+contentOrigin:
+  repos:
+    - repoid: test-repo
+      baseurl: http://localhost:PORT/test-repo
+packages: []
+reinstallPackages:
+  - findutils
+arches:
+  - x86_64
+context:
+  image: registry.access.redhat.com/ubi9/ubi-minimal@sha256:062c52ff973065752b0965787649db2bcf551a6c727a00e95a3eb42cebadbdab

--- a/tests/integration/data/failure/reinstall-version-mismatch/expected.stderr
+++ b/tests/integration/data/failure/reinstall-version-mismatch/expected.stderr
@@ -1,0 +1,3 @@
+# Reinstalling when the repo has a different version and the package
+# is not listed for upgrade
+PackagesNotAvailableError

--- a/tests/integration/data/failure/reinstall-version-mismatch/repos/test-repo.yaml
+++ b/tests/integration/data/failure/reinstall-version-mismatch/repos/test-repo.yaml
@@ -1,0 +1,3 @@
+packages:
+  - nvr: findutils-1:99.0-1
+    arch: x86_64

--- a/tests/integration/data/failure/reinstall-version-mismatch/rpms.in.yaml
+++ b/tests/integration/data/failure/reinstall-version-mismatch/rpms.in.yaml
@@ -1,0 +1,11 @@
+contentOrigin:
+  repos:
+    - repoid: test-repo
+      baseurl: http://localhost:PORT/test-repo
+packages: []
+reinstallPackages:
+  - findutils
+arches:
+  - x86_64
+context:
+  image: registry.access.redhat.com/ubi9/ubi-minimal@sha256:062c52ff973065752b0965787649db2bcf551a6c727a00e95a3eb42cebadbdab

--- a/tests/integration/data/success/already-installed-in-image/expected.lock.yaml
+++ b/tests/integration/data/success/already-installed-in-image/expected.lock.yaml
@@ -1,0 +1,8 @@
+---
+lockfileVersion: 1
+lockfileVendor: redhat
+arches:
+- arch: x86_64
+  packages: []
+  source: []
+  module_metadata: []

--- a/tests/integration/data/success/already-installed-in-image/repos/test-repo.yaml
+++ b/tests/integration/data/success/already-installed-in-image/repos/test-repo.yaml
@@ -1,0 +1,3 @@
+packages:
+  - nvr: findutils-1:99.0-1
+    arch: x86_64

--- a/tests/integration/data/success/already-installed-in-image/rpms.in.yaml
+++ b/tests/integration/data/success/already-installed-in-image/rpms.in.yaml
@@ -1,0 +1,10 @@
+contentOrigin:
+  repos:
+    - repoid: test-repo
+      baseurl: http://localhost:PORT/test-repo
+packages:
+  - findutils
+arches:
+  - x86_64
+context:
+  image: registry.access.redhat.com/ubi9/ubi-minimal@sha256:062c52ff973065752b0965787649db2bcf551a6c727a00e95a3eb42cebadbdab

--- a/tests/integration/data/success/assume-provides/expected.lock.yaml
+++ b/tests/integration/data/success/assume-provides/expected.lock.yaml
@@ -1,0 +1,34 @@
+---
+lockfileVersion: 1
+lockfileVendor: redhat
+arches:
+- arch: x86_64
+  packages:
+  - url: http://localhost:PORT/test-repo/test-app-1.0-1.x86_64.rpm
+    repoid: test-repo
+    size: 46466
+    checksum: sha256:c21072f7d6fdd53e1392028e10d754746d098ded0e0955d257fde886419d2f4a
+    name: test-app
+    evr: 1.0-1
+    sourcerpm: test-app-1.0-1.src.rpm
+  - url: http://localhost:PORT/test-repo/test-optional-1.0-1.noarch.rpm
+    repoid: test-repo
+    size: 25902
+    checksum: sha256:8d9619306f7c356ca9ef8d54db44f0d30b9f94da8a0a6029afc221e170cef15e
+    name: test-optional
+    evr: 1.0-1
+    sourcerpm: test-optional-1.0-1.src.rpm
+  source:
+  - url: http://localhost:PORT/test-repo/test-app-1.0-1.src.rpm
+    repoid: test-repo
+    size: 6803
+    checksum: sha256:ee8a029197f249dd51b673fb93d8d7ac5ed496ee11d5b31d0ab3d452ef4208fb
+    name: test-app
+    evr: 1.0-1
+  - url: http://localhost:PORT/test-repo/test-optional-1.0-1.src.rpm
+    repoid: test-repo
+    size: 99688
+    checksum: sha256:bbe00c0383b406fad721afbbf52941477c97e6b9dfce0009aa96e892f25c7920
+    name: test-optional
+    evr: 1.0-1
+  module_metadata: []

--- a/tests/integration/data/success/assume-provides/repos/test-repo.yaml
+++ b/tests/integration/data/success/assume-provides/repos/test-repo.yaml
@@ -1,0 +1,17 @@
+packages:
+  - nvr: test-base-1.0-1
+
+  - nvr: test-lib-1.0-1
+    arch: x86_64
+    provides:
+      - libtest
+
+  - nvr: test-app-1.0-1
+    arch: x86_64
+    requires:
+      - test-lib
+      - test-base
+    recommends:
+      - test-optional
+
+  - nvr: test-optional-1.0-1

--- a/tests/integration/data/success/assume-provides/rpms.in.yaml
+++ b/tests/integration/data/success/assume-provides/rpms.in.yaml
@@ -1,0 +1,13 @@
+contentOrigin:
+  repos:
+    - repoid: test-repo
+      baseurl: http://localhost:PORT/test-repo
+packages:
+  - test-app
+arches:
+  - x86_64
+context:
+  bare: true
+assumeProvides:
+  - test-lib
+  - test-base

--- a/tests/integration/data/success/basearch-substitution/expected.lock.yaml
+++ b/tests/integration/data/success/basearch-substitution/expected.lock.yaml
@@ -1,0 +1,21 @@
+---
+lockfileVersion: 1
+lockfileVendor: redhat
+arches:
+- arch: x86_64
+  packages:
+  - url: http://localhost:PORT/test-repo/x86_64/test-base-1.0-1.noarch.rpm
+    repoid: test-repo
+    size: 17899
+    checksum: sha256:e3ca3c340759b02d09400e29a1c739e1f2c2bf8c793b2baf7bcebc3f44da5c53
+    name: test-base
+    evr: 1.0-1
+    sourcerpm: test-base-1.0-1.src.rpm
+  source:
+  - url: http://localhost:PORT/test-repo/x86_64/test-base-1.0-1.src.rpm
+    repoid: test-repo
+    size: 2327
+    checksum: sha256:6a3850963dc1c535e77b51fcbad730f392c4dad235c1c690a77044e418243fbf
+    name: test-base
+    evr: 1.0-1
+  module_metadata: []

--- a/tests/integration/data/success/basearch-substitution/repos/test-repo/x86_64.yaml
+++ b/tests/integration/data/success/basearch-substitution/repos/test-repo/x86_64.yaml
@@ -1,0 +1,4 @@
+packages:
+  - nvr: test-base-1.0-1
+
+  - nvr: test-decoy-1.0-1

--- a/tests/integration/data/success/basearch-substitution/rpms.in.yaml
+++ b/tests/integration/data/success/basearch-substitution/rpms.in.yaml
@@ -1,0 +1,10 @@
+contentOrigin:
+  repos:
+    - repoid: test-repo
+      baseurl: http://localhost:PORT/test-repo/$basearch
+packages:
+  - test-base
+arches:
+  - x86_64
+context:
+  bare: true

--- a/tests/integration/data/success/container-yaml/container.yaml
+++ b/tests/integration/data/success/container-yaml/container.yaml
@@ -1,0 +1,11 @@
+flatpak:
+  packages:
+    - test-common
+    - name: test-x86-only
+      platforms:
+        only:
+          - x86_64
+    - name: test-not-aarch64
+      platforms:
+        not:
+          - aarch64

--- a/tests/integration/data/success/container-yaml/expected.lock.yaml
+++ b/tests/integration/data/success/container-yaml/expected.lock.yaml
@@ -1,0 +1,64 @@
+---
+lockfileVersion: 1
+lockfileVendor: redhat
+arches:
+- arch: aarch64
+  packages:
+  - url: http://localhost:PORT/test-repo/test-common-1.0-1.noarch.rpm
+    repoid: test-repo
+    size: 33488
+    checksum: sha256:f744da761b44ab0c00f94f391f3386dee075a81c12c9db4bc1ed6f6e4bf23ed8
+    name: test-common
+    evr: 1.0-1
+    sourcerpm: test-common-1.0-1.src.rpm
+  source:
+  - url: http://localhost:PORT/test-repo/test-common-1.0-1.src.rpm
+    repoid: test-repo
+    size: 17508
+    checksum: sha256:f2dff9061e5b23158b3cd4e2aae77f235abd6f127e6227935d3be9f0d9e0b5c4
+    name: test-common
+    evr: 1.0-1
+  module_metadata: []
+- arch: x86_64
+  packages:
+  - url: http://localhost:PORT/test-repo/test-common-1.0-1.noarch.rpm
+    repoid: test-repo
+    size: 33488
+    checksum: sha256:f744da761b44ab0c00f94f391f3386dee075a81c12c9db4bc1ed6f6e4bf23ed8
+    name: test-common
+    evr: 1.0-1
+    sourcerpm: test-common-1.0-1.src.rpm
+  - url: http://localhost:PORT/test-repo/test-not-aarch64-1.0-1.noarch.rpm
+    repoid: test-repo
+    size: 50836
+    checksum: sha256:3046fe25e2f92d0a514caf3947917fd55f227eb8f024ae635da9f2a8a25042cc
+    name: test-not-aarch64
+    evr: 1.0-1
+    sourcerpm: test-not-aarch64-1.0-1.src.rpm
+  - url: http://localhost:PORT/test-repo/test-x86-only-1.0-1.noarch.rpm
+    repoid: test-repo
+    size: 21449
+    checksum: sha256:06afa5c5d23c80153a6ef5db268c7d1758e627b9e18cbef25acc291167a991a1
+    name: test-x86-only
+    evr: 1.0-1
+    sourcerpm: test-x86-only-1.0-1.src.rpm
+  source:
+  - url: http://localhost:PORT/test-repo/test-common-1.0-1.src.rpm
+    repoid: test-repo
+    size: 17508
+    checksum: sha256:f2dff9061e5b23158b3cd4e2aae77f235abd6f127e6227935d3be9f0d9e0b5c4
+    name: test-common
+    evr: 1.0-1
+  - url: http://localhost:PORT/test-repo/test-not-aarch64-1.0-1.src.rpm
+    repoid: test-repo
+    size: 12605
+    checksum: sha256:fd49b5bba9fab84858efac5dab5f4b4a45ce51705a19187754316ca99f81db65
+    name: test-not-aarch64
+    evr: 1.0-1
+  - url: http://localhost:PORT/test-repo/test-x86-only-1.0-1.src.rpm
+    repoid: test-repo
+    size: 6732
+    checksum: sha256:7ac5991d586afd7c7cec8080baf22c34e4c9987a410e99746587757bc3c1e664
+    name: test-x86-only
+    evr: 1.0-1
+  module_metadata: []

--- a/tests/integration/data/success/container-yaml/repos/test-repo.yaml
+++ b/tests/integration/data/success/container-yaml/repos/test-repo.yaml
@@ -1,0 +1,6 @@
+packages:
+  - nvr: test-common-1.0-1
+
+  - nvr: test-x86-only-1.0-1
+
+  - nvr: test-not-aarch64-1.0-1

--- a/tests/integration/data/success/container-yaml/rpms.in.yaml
+++ b/tests/integration/data/success/container-yaml/rpms.in.yaml
@@ -1,0 +1,11 @@
+contentOrigin:
+  repos:
+    - repoid: test-repo
+      baseurl: http://localhost:PORT/test-repo
+packages: []
+arches:
+  - x86_64
+  - aarch64
+context:
+  bare: true
+  flatpak: true

--- a/tests/integration/data/success/containerfile-arch-packages/Dockerfile
+++ b/tests/integration/data/success/containerfile-arch-packages/Dockerfile
@@ -1,0 +1,4 @@
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+RUN microdnf install -y test-common && \
+    if [ $(arch) = x86_64 ]; then microdnf install -y test-x86-only; fi && \
+    if [ $(arch) = aarch64 ]; then microdnf install -y test-aarch64-only; fi

--- a/tests/integration/data/success/containerfile-arch-packages/expected.lock.yaml
+++ b/tests/integration/data/success/containerfile-arch-packages/expected.lock.yaml
@@ -1,0 +1,64 @@
+---
+lockfileVersion: 1
+lockfileVendor: redhat
+arches:
+- arch: aarch64
+  packages:
+  - url: http://localhost:PORT/test-repo/test-aarch64-only-1.0-1.noarch.rpm
+    repoid: test-repo
+    size: 37590
+    checksum: sha256:cbe3bcefb2bba1d42b975906c7812a9c7b126f202f14d644bbed9eca7b4ffede
+    name: test-aarch64-only
+    evr: 1.0-1
+    sourcerpm: test-aarch64-only-1.0-1.src.rpm
+  - url: http://localhost:PORT/test-repo/test-common-1.0-1.noarch.rpm
+    repoid: test-repo
+    size: 33488
+    checksum: sha256:f744da761b44ab0c00f94f391f3386dee075a81c12c9db4bc1ed6f6e4bf23ed8
+    name: test-common
+    evr: 1.0-1
+    sourcerpm: test-common-1.0-1.src.rpm
+  source:
+  - url: http://localhost:PORT/test-repo/test-aarch64-only-1.0-1.src.rpm
+    repoid: test-repo
+    size: 62964
+    checksum: sha256:66ab8abbb8269707905ee7c874ee750b006a083802dbd7b0f2dfea64e0791e54
+    name: test-aarch64-only
+    evr: 1.0-1
+  - url: http://localhost:PORT/test-repo/test-common-1.0-1.src.rpm
+    repoid: test-repo
+    size: 17508
+    checksum: sha256:f2dff9061e5b23158b3cd4e2aae77f235abd6f127e6227935d3be9f0d9e0b5c4
+    name: test-common
+    evr: 1.0-1
+  module_metadata: []
+- arch: x86_64
+  packages:
+  - url: http://localhost:PORT/test-repo/test-common-1.0-1.noarch.rpm
+    repoid: test-repo
+    size: 33488
+    checksum: sha256:f744da761b44ab0c00f94f391f3386dee075a81c12c9db4bc1ed6f6e4bf23ed8
+    name: test-common
+    evr: 1.0-1
+    sourcerpm: test-common-1.0-1.src.rpm
+  - url: http://localhost:PORT/test-repo/test-x86-only-1.0-1.noarch.rpm
+    repoid: test-repo
+    size: 21449
+    checksum: sha256:06afa5c5d23c80153a6ef5db268c7d1758e627b9e18cbef25acc291167a991a1
+    name: test-x86-only
+    evr: 1.0-1
+    sourcerpm: test-x86-only-1.0-1.src.rpm
+  source:
+  - url: http://localhost:PORT/test-repo/test-common-1.0-1.src.rpm
+    repoid: test-repo
+    size: 17508
+    checksum: sha256:f2dff9061e5b23158b3cd4e2aae77f235abd6f127e6227935d3be9f0d9e0b5c4
+    name: test-common
+    evr: 1.0-1
+  - url: http://localhost:PORT/test-repo/test-x86-only-1.0-1.src.rpm
+    repoid: test-repo
+    size: 6732
+    checksum: sha256:7ac5991d586afd7c7cec8080baf22c34e4c9987a410e99746587757bc3c1e664
+    name: test-x86-only
+    evr: 1.0-1
+  module_metadata: []

--- a/tests/integration/data/success/containerfile-arch-packages/expected.stdout
+++ b/tests/integration/data/success/containerfile-arch-packages/expected.stdout
@@ -1,0 +1,3 @@
+# The implicit extraction from Containerfile (no packagesFromContainerfile key)
+# should emit a deprecation warning.
+Implicit package extraction from Containerfile is deprecated

--- a/tests/integration/data/success/containerfile-arch-packages/repos/test-repo.yaml
+++ b/tests/integration/data/success/containerfile-arch-packages/repos/test-repo.yaml
@@ -1,0 +1,6 @@
+packages:
+  - nvr: test-common-1.0-1
+
+  - nvr: test-x86-only-1.0-1
+
+  - nvr: test-aarch64-only-1.0-1

--- a/tests/integration/data/success/containerfile-arch-packages/rpms.in.yaml
+++ b/tests/integration/data/success/containerfile-arch-packages/rpms.in.yaml
@@ -1,0 +1,9 @@
+contentOrigin:
+  repos:
+    - repoid: test-repo
+      baseurl: http://localhost:PORT/test-repo
+arches:
+  - x86_64
+  - aarch64
+context:
+  containerfile: Dockerfile

--- a/tests/integration/data/success/containerfile-arg-expansion/Containerfile
+++ b/tests/integration/data/success/containerfile-arg-expansion/Containerfile
@@ -1,0 +1,9 @@
+ARG REGISTRY=registry.access.redhat.com
+ARG IMAGE_NAME="ubi9/ubi-minimal"
+ARG IMAGE_TAG='latest'
+
+FROM ${REGISTRY}/${IMAGE_NAME}:${IMAGE_TAG} AS builder
+RUN microdnf install -y test-builder-pkg
+
+FROM $REGISTRY/$IMAGE_NAME:$IMAGE_TAG AS runtime
+RUN microdnf install -y test-runtime-pkg

--- a/tests/integration/data/success/containerfile-arg-expansion/expected.lock.yaml
+++ b/tests/integration/data/success/containerfile-arg-expansion/expected.lock.yaml
@@ -1,0 +1,21 @@
+---
+lockfileVersion: 1
+lockfileVendor: redhat
+arches:
+- arch: x86_64
+  packages:
+  - url: http://localhost:PORT/test-repo/test-base-1.0-1.noarch.rpm
+    repoid: test-repo
+    size: 17899
+    checksum: sha256:e3ca3c340759b02d09400e29a1c739e1f2c2bf8c793b2baf7bcebc3f44da5c53
+    name: test-base
+    evr: 1.0-1
+    sourcerpm: test-base-1.0-1.src.rpm
+  source:
+  - url: http://localhost:PORT/test-repo/test-base-1.0-1.src.rpm
+    repoid: test-repo
+    size: 2327
+    checksum: sha256:6a3850963dc1c535e77b51fcbad730f392c4dad235c1c690a77044e418243fbf
+    name: test-base
+    evr: 1.0-1
+  module_metadata: []

--- a/tests/integration/data/success/containerfile-arg-expansion/repos/test-repo.yaml
+++ b/tests/integration/data/success/containerfile-arg-expansion/repos/test-repo.yaml
@@ -1,0 +1,6 @@
+packages:
+  - nvr: test-base-1.0-1
+    requires:
+      - bash
+
+  - nvr: test-decoy-1.0-1

--- a/tests/integration/data/success/containerfile-arg-expansion/rpms.in.yaml
+++ b/tests/integration/data/success/containerfile-arg-expansion/rpms.in.yaml
@@ -1,0 +1,10 @@
+contentOrigin:
+  repos:
+    - repoid: test-repo
+      baseurl: http://localhost:PORT/test-repo
+packages:
+  - test-base
+arches:
+  - x86_64
+context:
+  containerfile: Containerfile

--- a/tests/integration/data/success/containerfile-image-pattern/Containerfile
+++ b/tests/integration/data/success/containerfile-image-pattern/Containerfile
@@ -1,0 +1,5 @@
+FROM registry.invalid/does-not-exist@sha256:0000000000000000000000000000000000000000000000000000000000000000
+RUN echo "stage 1"
+
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+RUN echo "stage 2"

--- a/tests/integration/data/success/containerfile-image-pattern/expected.lock.yaml
+++ b/tests/integration/data/success/containerfile-image-pattern/expected.lock.yaml
@@ -1,0 +1,21 @@
+---
+lockfileVersion: 1
+lockfileVendor: redhat
+arches:
+- arch: x86_64
+  packages:
+  - url: http://localhost:PORT/test-repo/test-base-1.0-1.noarch.rpm
+    repoid: test-repo
+    size: 17899
+    checksum: sha256:e3ca3c340759b02d09400e29a1c739e1f2c2bf8c793b2baf7bcebc3f44da5c53
+    name: test-base
+    evr: 1.0-1
+    sourcerpm: test-base-1.0-1.src.rpm
+  source:
+  - url: http://localhost:PORT/test-repo/test-base-1.0-1.src.rpm
+    repoid: test-repo
+    size: 2327
+    checksum: sha256:6a3850963dc1c535e77b51fcbad730f392c4dad235c1c690a77044e418243fbf
+    name: test-base
+    evr: 1.0-1
+  module_metadata: []

--- a/tests/integration/data/success/containerfile-image-pattern/repos/test-repo.yaml
+++ b/tests/integration/data/success/containerfile-image-pattern/repos/test-repo.yaml
@@ -1,0 +1,6 @@
+packages:
+  - nvr: test-base-1.0-1
+    requires:
+      - bash
+
+  - nvr: test-decoy-1.0-1

--- a/tests/integration/data/success/containerfile-image-pattern/rpms.in.yaml
+++ b/tests/integration/data/success/containerfile-image-pattern/rpms.in.yaml
@@ -1,0 +1,12 @@
+contentOrigin:
+  repos:
+    - repoid: test-repo
+      baseurl: http://localhost:PORT/test-repo
+packages:
+  - test-base
+arches:
+  - x86_64
+context:
+  containerfile:
+    file: Containerfile
+    imagePattern: ubi-minimal

--- a/tests/integration/data/success/containerfile-packages/Dockerfile
+++ b/tests/integration/data/success/containerfile-packages/Dockerfile
@@ -1,0 +1,11 @@
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+
+ARG EXTRA_PKG=test-from-arg
+
+RUN microdnf install -y test-base && microdnf clean all
+
+RUN microdnf install -y $EXTRA_PKG
+
+RUN microdnf upgrade -y findutils
+
+RUN microdnf reinstall -y shadow-utils

--- a/tests/integration/data/success/containerfile-packages/expected.lock.yaml
+++ b/tests/integration/data/success/containerfile-packages/expected.lock.yaml
@@ -1,0 +1,60 @@
+---
+lockfileVersion: 1
+lockfileVendor: redhat
+arches:
+- arch: x86_64
+  packages:
+  - url: http://localhost:PORT/test-repo/findutils-99.0-1.x86_64.rpm
+    repoid: test-repo
+    size: 41761
+    checksum: sha256:f16dc7e1623df6fa9421adf3d55a8fb2b43d7c8cab0f3f8a005b2c91387dd889
+    name: findutils
+    evr: 1:99.0-1
+    sourcerpm: findutils-99.0-1.src.rpm
+  - url: http://localhost:PORT/test-repo/shadow-utils-4.9-16.el9.x86_64.rpm
+    repoid: test-repo
+    size: 14939
+    checksum: sha256:6dbd57914ec01eb55fe7f47adcd056eb3a800cd9be7e41452d25dec98ceae6f3
+    name: shadow-utils
+    evr: 2:4.9-16.el9
+    sourcerpm: shadow-utils-4.9-16.el9.src.rpm
+  - url: http://localhost:PORT/test-repo/test-base-1.0-1.noarch.rpm
+    repoid: test-repo
+    size: 17899
+    checksum: sha256:e3ca3c340759b02d09400e29a1c739e1f2c2bf8c793b2baf7bcebc3f44da5c53
+    name: test-base
+    evr: 1.0-1
+    sourcerpm: test-base-1.0-1.src.rpm
+  - url: http://localhost:PORT/test-repo/test-from-arg-1.0-1.noarch.rpm
+    repoid: test-repo
+    size: 91629
+    checksum: sha256:0ec74d92de9a134e95f8e50423682304559eb939bd636ce488af52b6f2c3d50d
+    name: test-from-arg
+    evr: 1.0-1
+    sourcerpm: test-from-arg-1.0-1.src.rpm
+  source:
+  - url: http://localhost:PORT/test-repo/findutils-99.0-1.src.rpm
+    repoid: test-repo
+    size: 35999
+    checksum: sha256:9480bc1636fd7dc5a2d2ad4b6278db7d44747a30b43d3f1a01cc66d654d3be07
+    name: findutils
+    evr: 99.0-1
+  - url: http://localhost:PORT/test-repo/shadow-utils-4.9-16.el9.src.rpm
+    repoid: test-repo
+    size: 36398
+    checksum: sha256:9ee29325bfbd5ed18444d8b4dd171fc2a6f48a59c8165487d38293f9b6614d56
+    name: shadow-utils
+    evr: 4.9-16.el9
+  - url: http://localhost:PORT/test-repo/test-base-1.0-1.src.rpm
+    repoid: test-repo
+    size: 2327
+    checksum: sha256:6a3850963dc1c535e77b51fcbad730f392c4dad235c1c690a77044e418243fbf
+    name: test-base
+    evr: 1.0-1
+  - url: http://localhost:PORT/test-repo/test-from-arg-1.0-1.src.rpm
+    repoid: test-repo
+    size: 52669
+    checksum: sha256:64fb0740f19af519bf8c1ba05d5f6886506faef07a4f55efc1d5752b077cdd55
+    name: test-from-arg
+    evr: 1.0-1
+  module_metadata: []

--- a/tests/integration/data/success/containerfile-packages/expected.stdout
+++ b/tests/integration/data/success/containerfile-packages/expected.stdout
@@ -1,0 +1,3 @@
+# The implicit extraction from Containerfile (no packagesFromContainerfile key)
+# should emit a deprecation warning.
+Implicit package extraction from Containerfile is deprecated

--- a/tests/integration/data/success/containerfile-packages/repos/test-repo.yaml
+++ b/tests/integration/data/success/containerfile-packages/repos/test-repo.yaml
@@ -1,0 +1,15 @@
+packages:
+  - nvr: test-base-1.0-1
+
+  - nvr: test-from-arg-1.0-1
+
+  - nvr: test-not-in-dockerfile-1.0-1
+
+  - nvr: findutils-1:99.0-1
+    arch: x86_64
+
+  - nvr: shadow-utils-2:4.9-16.el9
+    arch: x86_64
+
+  - nvr: shadow-utils-2:99.0-1
+    arch: x86_64

--- a/tests/integration/data/success/containerfile-packages/rpms.in.yaml
+++ b/tests/integration/data/success/containerfile-packages/rpms.in.yaml
@@ -1,0 +1,8 @@
+contentOrigin:
+  repos:
+    - repoid: test-repo
+      baseurl: http://localhost:PORT/test-repo
+arches:
+  - x86_64
+context:
+  containerfile: Dockerfile

--- a/tests/integration/data/success/containerfile-script-packages/Dockerfile
+++ b/tests/integration/data/success/containerfile-script-packages/Dockerfile
@@ -1,0 +1,3 @@
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+COPY install-deps.sh /tmp/
+RUN /tmp/install-deps.sh

--- a/tests/integration/data/success/containerfile-script-packages/expected.lock.yaml
+++ b/tests/integration/data/success/containerfile-script-packages/expected.lock.yaml
@@ -1,0 +1,21 @@
+---
+lockfileVersion: 1
+lockfileVendor: redhat
+arches:
+- arch: x86_64
+  packages:
+  - url: http://localhost:PORT/test-repo/test-from-script-1.0-1.noarch.rpm
+    repoid: test-repo
+    size: 12491
+    checksum: sha256:2ab79f31c4d1b25155ade3549733d28b4148a2ba4fe24bfee58014ca6f9bb3ab
+    name: test-from-script
+    evr: 1.0-1
+    sourcerpm: test-from-script-1.0-1.src.rpm
+  source:
+  - url: http://localhost:PORT/test-repo/test-from-script-1.0-1.src.rpm
+    repoid: test-repo
+    size: 83793
+    checksum: sha256:528aa42629845f4ba2fb5d2442f12c9f597b9a6b5a7aac0e2ed2c5fbdf697ff1
+    name: test-from-script
+    evr: 1.0-1
+  module_metadata: []

--- a/tests/integration/data/success/containerfile-script-packages/expected.stdout
+++ b/tests/integration/data/success/containerfile-script-packages/expected.stdout
@@ -1,0 +1,3 @@
+# The implicit extraction from Containerfile (no packagesFromContainerfile key)
+# should emit a deprecation warning.
+Implicit package extraction from Containerfile is deprecated

--- a/tests/integration/data/success/containerfile-script-packages/install-deps.sh
+++ b/tests/integration/data/success/containerfile-script-packages/install-deps.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+set -ex
+microdnf install -y test-from-script

--- a/tests/integration/data/success/containerfile-script-packages/repos/test-repo.yaml
+++ b/tests/integration/data/success/containerfile-script-packages/repos/test-repo.yaml
@@ -1,0 +1,4 @@
+packages:
+  - nvr: test-from-script-1.0-1
+
+  - nvr: test-not-in-script-1.0-1

--- a/tests/integration/data/success/containerfile-script-packages/rpms.in.yaml
+++ b/tests/integration/data/success/containerfile-script-packages/rpms.in.yaml
@@ -1,0 +1,8 @@
+contentOrigin:
+  repos:
+    - repoid: test-repo
+      baseurl: http://localhost:PORT/test-repo
+arches:
+  - x86_64
+context:
+  containerfile: Dockerfile

--- a/tests/integration/data/success/containerfile-stage-name/Containerfile
+++ b/tests/integration/data/success/containerfile-stage-name/Containerfile
@@ -1,0 +1,5 @@
+FROM registry.invalid/does-not-exist@sha256:0000000000000000000000000000000000000000000000000000000000000000
+RUN echo "stage 1"
+
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest AS builder
+RUN echo "stage 2"

--- a/tests/integration/data/success/containerfile-stage-name/expected.lock.yaml
+++ b/tests/integration/data/success/containerfile-stage-name/expected.lock.yaml
@@ -1,0 +1,21 @@
+---
+lockfileVersion: 1
+lockfileVendor: redhat
+arches:
+- arch: x86_64
+  packages:
+  - url: http://localhost:PORT/test-repo/test-base-1.0-1.noarch.rpm
+    repoid: test-repo
+    size: 17899
+    checksum: sha256:e3ca3c340759b02d09400e29a1c739e1f2c2bf8c793b2baf7bcebc3f44da5c53
+    name: test-base
+    evr: 1.0-1
+    sourcerpm: test-base-1.0-1.src.rpm
+  source:
+  - url: http://localhost:PORT/test-repo/test-base-1.0-1.src.rpm
+    repoid: test-repo
+    size: 2327
+    checksum: sha256:6a3850963dc1c535e77b51fcbad730f392c4dad235c1c690a77044e418243fbf
+    name: test-base
+    evr: 1.0-1
+  module_metadata: []

--- a/tests/integration/data/success/containerfile-stage-name/repos/test-repo.yaml
+++ b/tests/integration/data/success/containerfile-stage-name/repos/test-repo.yaml
@@ -1,0 +1,6 @@
+packages:
+  - nvr: test-base-1.0-1
+    requires:
+      - bash
+
+  - nvr: test-decoy-1.0-1

--- a/tests/integration/data/success/containerfile-stage-name/rpms.in.yaml
+++ b/tests/integration/data/success/containerfile-stage-name/rpms.in.yaml
@@ -1,0 +1,12 @@
+contentOrigin:
+  repos:
+    - repoid: test-repo
+      baseurl: http://localhost:PORT/test-repo
+packages:
+  - test-base
+arches:
+  - x86_64
+context:
+  containerfile:
+    file: Containerfile
+    stageName: builder

--- a/tests/integration/data/success/containerfile-stage-num/Containerfile
+++ b/tests/integration/data/success/containerfile-stage-num/Containerfile
@@ -1,0 +1,5 @@
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest AS builder
+RUN echo "stage 1"
+
+FROM registry.invalid/does-not-exist@sha256:0000000000000000000000000000000000000000000000000000000000000000
+RUN echo "stage 2"

--- a/tests/integration/data/success/containerfile-stage-num/expected.lock.yaml
+++ b/tests/integration/data/success/containerfile-stage-num/expected.lock.yaml
@@ -1,0 +1,21 @@
+---
+lockfileVersion: 1
+lockfileVendor: redhat
+arches:
+- arch: x86_64
+  packages:
+  - url: http://localhost:PORT/test-repo/test-base-1.0-1.noarch.rpm
+    repoid: test-repo
+    size: 17899
+    checksum: sha256:e3ca3c340759b02d09400e29a1c739e1f2c2bf8c793b2baf7bcebc3f44da5c53
+    name: test-base
+    evr: 1.0-1
+    sourcerpm: test-base-1.0-1.src.rpm
+  source:
+  - url: http://localhost:PORT/test-repo/test-base-1.0-1.src.rpm
+    repoid: test-repo
+    size: 2327
+    checksum: sha256:6a3850963dc1c535e77b51fcbad730f392c4dad235c1c690a77044e418243fbf
+    name: test-base
+    evr: 1.0-1
+  module_metadata: []

--- a/tests/integration/data/success/containerfile-stage-num/repos/test-repo.yaml
+++ b/tests/integration/data/success/containerfile-stage-num/repos/test-repo.yaml
@@ -1,0 +1,6 @@
+packages:
+  - nvr: test-base-1.0-1
+    requires:
+      - bash
+
+  - nvr: test-decoy-1.0-1

--- a/tests/integration/data/success/containerfile-stage-num/rpms.in.yaml
+++ b/tests/integration/data/success/containerfile-stage-num/rpms.in.yaml
@@ -1,0 +1,12 @@
+contentOrigin:
+  repos:
+    - repoid: test-repo
+      baseurl: http://localhost:PORT/test-repo
+packages:
+  - test-base
+arches:
+  - x86_64
+context:
+  containerfile:
+    file: Containerfile
+    stageNum: 1

--- a/tests/integration/data/success/containerfile-stage-select-num/Dockerfile
+++ b/tests/integration/data/success/containerfile-stage-select-num/Dockerfile
@@ -1,0 +1,5 @@
+FROM registry.invalid/does-not-exist@sha256:0000000000000000000000000000000000000000000000000000000000000000 AS builder
+RUN dnf install -y test-builder-only
+
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest AS runtime
+RUN microdnf install -y test-runtime-only

--- a/tests/integration/data/success/containerfile-stage-select-num/expected.lock.yaml
+++ b/tests/integration/data/success/containerfile-stage-select-num/expected.lock.yaml
@@ -1,0 +1,21 @@
+---
+lockfileVersion: 1
+lockfileVendor: redhat
+arches:
+- arch: x86_64
+  packages:
+  - url: http://localhost:PORT/test-repo/test-runtime-only-1.0-1.noarch.rpm
+    repoid: test-repo
+    size: 65757
+    checksum: sha256:33764a85df51e5d1df229c82c5f718111a543d90a617fdb973a466194ee6e605
+    name: test-runtime-only
+    evr: 1.0-1
+    sourcerpm: test-runtime-only-1.0-1.src.rpm
+  source:
+  - url: http://localhost:PORT/test-repo/test-runtime-only-1.0-1.src.rpm
+    repoid: test-repo
+    size: 81930
+    checksum: sha256:31aad7c9381775b0a08257dc64e4ab8e6cc728cf57cc968cd83b9582c277df32
+    name: test-runtime-only
+    evr: 1.0-1
+  module_metadata: []

--- a/tests/integration/data/success/containerfile-stage-select-num/expected.stdout
+++ b/tests/integration/data/success/containerfile-stage-select-num/expected.stdout
@@ -1,0 +1,3 @@
+# The implicit extraction from Containerfile (no packagesFromContainerfile key)
+# should emit a deprecation warning.
+Implicit package extraction from Containerfile is deprecated

--- a/tests/integration/data/success/containerfile-stage-select-num/repos/test-repo.yaml
+++ b/tests/integration/data/success/containerfile-stage-select-num/repos/test-repo.yaml
@@ -1,0 +1,4 @@
+packages:
+  - nvr: test-builder-only-1.0-1
+
+  - nvr: test-runtime-only-1.0-1

--- a/tests/integration/data/success/containerfile-stage-select-num/rpms.in.yaml
+++ b/tests/integration/data/success/containerfile-stage-select-num/rpms.in.yaml
@@ -1,0 +1,10 @@
+contentOrigin:
+  repos:
+    - repoid: test-repo
+      baseurl: http://localhost:PORT/test-repo
+arches:
+  - x86_64
+context:
+  containerfile:
+    file: Dockerfile
+    stageNum: 2

--- a/tests/integration/data/success/containerfile-stage-select-pattern/Dockerfile
+++ b/tests/integration/data/success/containerfile-stage-select-pattern/Dockerfile
@@ -1,0 +1,5 @@
+FROM registry.invalid/does-not-exist@sha256:0000000000000000000000000000000000000000000000000000000000000000 AS builder
+RUN dnf install -y test-builder-only
+
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest AS runtime
+RUN microdnf install -y test-runtime-only

--- a/tests/integration/data/success/containerfile-stage-select-pattern/expected.lock.yaml
+++ b/tests/integration/data/success/containerfile-stage-select-pattern/expected.lock.yaml
@@ -1,0 +1,21 @@
+---
+lockfileVersion: 1
+lockfileVendor: redhat
+arches:
+- arch: x86_64
+  packages:
+  - url: http://localhost:PORT/test-repo/test-runtime-only-1.0-1.noarch.rpm
+    repoid: test-repo
+    size: 65757
+    checksum: sha256:33764a85df51e5d1df229c82c5f718111a543d90a617fdb973a466194ee6e605
+    name: test-runtime-only
+    evr: 1.0-1
+    sourcerpm: test-runtime-only-1.0-1.src.rpm
+  source:
+  - url: http://localhost:PORT/test-repo/test-runtime-only-1.0-1.src.rpm
+    repoid: test-repo
+    size: 81930
+    checksum: sha256:31aad7c9381775b0a08257dc64e4ab8e6cc728cf57cc968cd83b9582c277df32
+    name: test-runtime-only
+    evr: 1.0-1
+  module_metadata: []

--- a/tests/integration/data/success/containerfile-stage-select-pattern/expected.stdout
+++ b/tests/integration/data/success/containerfile-stage-select-pattern/expected.stdout
@@ -1,0 +1,3 @@
+# The implicit extraction from Containerfile (no packagesFromContainerfile key)
+# should emit a deprecation warning.
+Implicit package extraction from Containerfile is deprecated

--- a/tests/integration/data/success/containerfile-stage-select-pattern/repos/test-repo.yaml
+++ b/tests/integration/data/success/containerfile-stage-select-pattern/repos/test-repo.yaml
@@ -1,0 +1,4 @@
+packages:
+  - nvr: test-builder-only-1.0-1
+
+  - nvr: test-runtime-only-1.0-1

--- a/tests/integration/data/success/containerfile-stage-select-pattern/rpms.in.yaml
+++ b/tests/integration/data/success/containerfile-stage-select-pattern/rpms.in.yaml
@@ -1,0 +1,10 @@
+contentOrigin:
+  repos:
+    - repoid: test-repo
+      baseurl: http://localhost:PORT/test-repo
+arches:
+  - x86_64
+context:
+  containerfile:
+    file: Dockerfile
+    imagePattern: ubi-minimal

--- a/tests/integration/data/success/containerfile-stage-select/Dockerfile
+++ b/tests/integration/data/success/containerfile-stage-select/Dockerfile
@@ -1,0 +1,5 @@
+FROM registry.invalid/does-not-exist@sha256:0000000000000000000000000000000000000000000000000000000000000000 AS builder
+RUN dnf install -y test-builder-only
+
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest AS runtime
+RUN microdnf install -y test-runtime-only

--- a/tests/integration/data/success/containerfile-stage-select/expected.lock.yaml
+++ b/tests/integration/data/success/containerfile-stage-select/expected.lock.yaml
@@ -1,0 +1,21 @@
+---
+lockfileVersion: 1
+lockfileVendor: redhat
+arches:
+- arch: x86_64
+  packages:
+  - url: http://localhost:PORT/test-repo/test-runtime-only-1.0-1.noarch.rpm
+    repoid: test-repo
+    size: 65757
+    checksum: sha256:33764a85df51e5d1df229c82c5f718111a543d90a617fdb973a466194ee6e605
+    name: test-runtime-only
+    evr: 1.0-1
+    sourcerpm: test-runtime-only-1.0-1.src.rpm
+  source:
+  - url: http://localhost:PORT/test-repo/test-runtime-only-1.0-1.src.rpm
+    repoid: test-repo
+    size: 81930
+    checksum: sha256:31aad7c9381775b0a08257dc64e4ab8e6cc728cf57cc968cd83b9582c277df32
+    name: test-runtime-only
+    evr: 1.0-1
+  module_metadata: []

--- a/tests/integration/data/success/containerfile-stage-select/expected.stdout
+++ b/tests/integration/data/success/containerfile-stage-select/expected.stdout
@@ -1,0 +1,3 @@
+# The implicit extraction from Containerfile (no packagesFromContainerfile key)
+# should emit a deprecation warning.
+Implicit package extraction from Containerfile is deprecated

--- a/tests/integration/data/success/containerfile-stage-select/repos/test-repo.yaml
+++ b/tests/integration/data/success/containerfile-stage-select/repos/test-repo.yaml
@@ -1,0 +1,4 @@
+packages:
+  - nvr: test-builder-only-1.0-1
+
+  - nvr: test-runtime-only-1.0-1

--- a/tests/integration/data/success/containerfile-stage-select/rpms.in.yaml
+++ b/tests/integration/data/success/containerfile-stage-select/rpms.in.yaml
@@ -1,0 +1,10 @@
+contentOrigin:
+  repos:
+    - repoid: test-repo
+      baseurl: http://localhost:PORT/test-repo
+arches:
+  - x86_64
+context:
+  containerfile:
+    file: Dockerfile
+    stageName: runtime

--- a/tests/integration/data/success/containerfile-string/Containerfile
+++ b/tests/integration/data/success/containerfile-string/Containerfile
@@ -1,0 +1,1 @@
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest

--- a/tests/integration/data/success/containerfile-string/expected.lock.yaml
+++ b/tests/integration/data/success/containerfile-string/expected.lock.yaml
@@ -1,0 +1,21 @@
+---
+lockfileVersion: 1
+lockfileVendor: redhat
+arches:
+- arch: x86_64
+  packages:
+  - url: http://localhost:PORT/test-repo/test-base-1.0-1.noarch.rpm
+    repoid: test-repo
+    size: 17899
+    checksum: sha256:e3ca3c340759b02d09400e29a1c739e1f2c2bf8c793b2baf7bcebc3f44da5c53
+    name: test-base
+    evr: 1.0-1
+    sourcerpm: test-base-1.0-1.src.rpm
+  source:
+  - url: http://localhost:PORT/test-repo/test-base-1.0-1.src.rpm
+    repoid: test-repo
+    size: 2327
+    checksum: sha256:6a3850963dc1c535e77b51fcbad730f392c4dad235c1c690a77044e418243fbf
+    name: test-base
+    evr: 1.0-1
+  module_metadata: []

--- a/tests/integration/data/success/containerfile-string/repos/test-repo.yaml
+++ b/tests/integration/data/success/containerfile-string/repos/test-repo.yaml
@@ -1,0 +1,6 @@
+packages:
+  - nvr: test-base-1.0-1
+    requires:
+      - bash
+
+  - nvr: test-decoy-1.0-1

--- a/tests/integration/data/success/containerfile-string/rpms.in.yaml
+++ b/tests/integration/data/success/containerfile-string/rpms.in.yaml
@@ -1,0 +1,10 @@
+contentOrigin:
+  repos:
+    - repoid: test-repo
+      baseurl: http://localhost:PORT/test-repo
+packages:
+  - test-base
+arches:
+  - x86_64
+context:
+  containerfile: Containerfile

--- a/tests/integration/data/success/containerfile/Containerfile
+++ b/tests/integration/data/success/containerfile/Containerfile
@@ -1,0 +1,1 @@
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest

--- a/tests/integration/data/success/containerfile/expected.lock.yaml
+++ b/tests/integration/data/success/containerfile/expected.lock.yaml
@@ -1,0 +1,21 @@
+---
+lockfileVersion: 1
+lockfileVendor: redhat
+arches:
+- arch: x86_64
+  packages:
+  - url: http://localhost:PORT/test-repo/test-base-1.0-1.noarch.rpm
+    repoid: test-repo
+    size: 17899
+    checksum: sha256:e3ca3c340759b02d09400e29a1c739e1f2c2bf8c793b2baf7bcebc3f44da5c53
+    name: test-base
+    evr: 1.0-1
+    sourcerpm: test-base-1.0-1.src.rpm
+  source:
+  - url: http://localhost:PORT/test-repo/test-base-1.0-1.src.rpm
+    repoid: test-repo
+    size: 2327
+    checksum: sha256:6a3850963dc1c535e77b51fcbad730f392c4dad235c1c690a77044e418243fbf
+    name: test-base
+    evr: 1.0-1
+  module_metadata: []

--- a/tests/integration/data/success/containerfile/repos/test-repo.yaml
+++ b/tests/integration/data/success/containerfile/repos/test-repo.yaml
@@ -1,0 +1,4 @@
+packages:
+  - nvr: test-base-1.0-1
+
+  - nvr: test-decoy-1.0-1

--- a/tests/integration/data/success/containerfile/rpms.in.yaml
+++ b/tests/integration/data/success/containerfile/rpms.in.yaml
@@ -1,0 +1,8 @@
+contentOrigin:
+  repos:
+    - repoid: test-repo
+      baseurl: http://localhost:PORT/test-repo
+packages:
+  - test-base
+arches:
+  - x86_64

--- a/tests/integration/data/success/dep-satisfied-by-image/expected.lock.yaml
+++ b/tests/integration/data/success/dep-satisfied-by-image/expected.lock.yaml
@@ -1,0 +1,21 @@
+---
+lockfileVersion: 1
+lockfileVendor: redhat
+arches:
+- arch: x86_64
+  packages:
+  - url: http://localhost:PORT/test-repo/test-needs-bash-1.0-1.noarch.rpm
+    repoid: test-repo
+    size: 2628
+    checksum: sha256:cc24aa47d6c03926ed7783d89101c7c9f461092ad012b3278d88013d8a1cb1cc
+    name: test-needs-bash
+    evr: 1.0-1
+    sourcerpm: test-needs-bash-1.0-1.src.rpm
+  source:
+  - url: http://localhost:PORT/test-repo/test-needs-bash-1.0-1.src.rpm
+    repoid: test-repo
+    size: 11355
+    checksum: sha256:bb3771440341af27f0b79c67148c90be4e1a111a1acedbf1be512f58e92252eb
+    name: test-needs-bash
+    evr: 1.0-1
+  module_metadata: []

--- a/tests/integration/data/success/dep-satisfied-by-image/repos/test-repo.yaml
+++ b/tests/integration/data/success/dep-satisfied-by-image/repos/test-repo.yaml
@@ -1,0 +1,6 @@
+packages:
+  - nvr: test-needs-bash-1.0-1
+    requires:
+      - bash
+
+  - nvr: test-decoy-1.0-1

--- a/tests/integration/data/success/dep-satisfied-by-image/rpms.in.yaml
+++ b/tests/integration/data/success/dep-satisfied-by-image/rpms.in.yaml
@@ -1,0 +1,10 @@
+contentOrigin:
+  repos:
+    - repoid: test-repo
+      baseurl: http://localhost:PORT/test-repo
+packages:
+  - test-needs-bash
+arches:
+  - x86_64
+context:
+  image: registry.access.redhat.com/ubi9/ubi-minimal:latest

--- a/tests/integration/data/success/filelists-needed/expected.lock.yaml
+++ b/tests/integration/data/success/filelists-needed/expected.lock.yaml
@@ -1,0 +1,34 @@
+---
+lockfileVersion: 1
+lockfileVendor: redhat
+arches:
+- arch: x86_64
+  packages:
+  - url: http://localhost:PORT/test-repo/test-app-1.0-1.noarch.rpm
+    repoid: test-repo
+    size: 32658
+    checksum: sha256:6d69d191e63688e2ca93f8c0d6114cf73affc3a7b864291f93cb4f4d03476a72
+    name: test-app
+    evr: 1.0-1
+    sourcerpm: test-app-1.0-1.src.rpm
+  - url: http://localhost:PORT/test-repo/test-data-provider-1.0-1.noarch.rpm
+    repoid: test-repo
+    size: 54264
+    checksum: sha256:1824f16d287ff0259132e45334c8f56f99d65fa741ad1024205e0ee688522548
+    name: test-data-provider
+    evr: 1.0-1
+    sourcerpm: test-data-provider-1.0-1.src.rpm
+  source:
+  - url: http://localhost:PORT/test-repo/test-app-1.0-1.src.rpm
+    repoid: test-repo
+    size: 6803
+    checksum: sha256:ee8a029197f249dd51b673fb93d8d7ac5ed496ee11d5b31d0ab3d452ef4208fb
+    name: test-app
+    evr: 1.0-1
+  - url: http://localhost:PORT/test-repo/test-data-provider-1.0-1.src.rpm
+    repoid: test-repo
+    size: 88939
+    checksum: sha256:f532e483f8ff64a11da3bf6ac48a8147de3a8d4caccea33425c4089acf17183b
+    name: test-data-provider
+    evr: 1.0-1
+  module_metadata: []

--- a/tests/integration/data/success/filelists-needed/repos/test-repo.yaml
+++ b/tests/integration/data/success/filelists-needed/repos/test-repo.yaml
@@ -1,0 +1,10 @@
+packages:
+  - nvr: test-app-1.0-1
+    requires:
+      - /usr/share/test-data/config.ini
+
+  - nvr: test-data-provider-1.0-1
+    files:
+      - /usr/share/test-data/config.ini
+
+  - nvr: test-unrelated-1.0-1

--- a/tests/integration/data/success/filelists-needed/rpms.in.yaml
+++ b/tests/integration/data/success/filelists-needed/rpms.in.yaml
@@ -1,0 +1,10 @@
+contentOrigin:
+  repos:
+    - repoid: test-repo
+      baseurl: http://localhost:PORT/test-repo
+packages:
+  - test-app
+arches:
+  - x86_64
+context:
+  bare: true

--- a/tests/integration/data/success/filelists-package-by-path/expected.lock.yaml
+++ b/tests/integration/data/success/filelists-package-by-path/expected.lock.yaml
@@ -1,0 +1,21 @@
+---
+lockfileVersion: 1
+lockfileVendor: redhat
+arches:
+- arch: x86_64
+  packages:
+  - url: http://localhost:PORT/test-repo/test-data-provider-1.0-1.noarch.rpm
+    repoid: test-repo
+    size: 54264
+    checksum: sha256:1824f16d287ff0259132e45334c8f56f99d65fa741ad1024205e0ee688522548
+    name: test-data-provider
+    evr: 1.0-1
+    sourcerpm: test-data-provider-1.0-1.src.rpm
+  source:
+  - url: http://localhost:PORT/test-repo/test-data-provider-1.0-1.src.rpm
+    repoid: test-repo
+    size: 88939
+    checksum: sha256:f532e483f8ff64a11da3bf6ac48a8147de3a8d4caccea33425c4089acf17183b
+    name: test-data-provider
+    evr: 1.0-1
+  module_metadata: []

--- a/tests/integration/data/success/filelists-package-by-path/repos/test-repo.yaml
+++ b/tests/integration/data/success/filelists-package-by-path/repos/test-repo.yaml
@@ -1,0 +1,6 @@
+packages:
+  - nvr: test-data-provider-1.0-1
+    files:
+      - /usr/share/test-data/config.ini
+
+  - nvr: test-decoy-1.0-1

--- a/tests/integration/data/success/filelists-package-by-path/rpms.in.yaml
+++ b/tests/integration/data/success/filelists-package-by-path/rpms.in.yaml
@@ -1,0 +1,10 @@
+contentOrigin:
+  repos:
+    - repoid: test-repo
+      baseurl: http://localhost:PORT/test-repo
+packages:
+  - /usr/share/test-data/config.ini
+arches:
+  - x86_64
+context:
+  bare: true

--- a/tests/integration/data/success/image-ubi10/expected.lock.yaml
+++ b/tests/integration/data/success/image-ubi10/expected.lock.yaml
@@ -1,0 +1,21 @@
+---
+lockfileVersion: 1
+lockfileVendor: redhat
+arches:
+- arch: x86_64
+  packages:
+  - url: http://localhost:PORT/test-repo/test-base-1.0-1.noarch.rpm
+    repoid: test-repo
+    size: 17899
+    checksum: sha256:e3ca3c340759b02d09400e29a1c739e1f2c2bf8c793b2baf7bcebc3f44da5c53
+    name: test-base
+    evr: 1.0-1
+    sourcerpm: test-base-1.0-1.src.rpm
+  source:
+  - url: http://localhost:PORT/test-repo/test-base-1.0-1.src.rpm
+    repoid: test-repo
+    size: 2327
+    checksum: sha256:6a3850963dc1c535e77b51fcbad730f392c4dad235c1c690a77044e418243fbf
+    name: test-base
+    evr: 1.0-1
+  module_metadata: []

--- a/tests/integration/data/success/image-ubi10/repos/test-repo.yaml
+++ b/tests/integration/data/success/image-ubi10/repos/test-repo.yaml
@@ -1,0 +1,4 @@
+packages:
+  - nvr: test-base-1.0-1
+
+  - nvr: test-decoy-1.0-1

--- a/tests/integration/data/success/image-ubi10/rpms.in.yaml
+++ b/tests/integration/data/success/image-ubi10/rpms.in.yaml
@@ -1,0 +1,10 @@
+contentOrigin:
+  repos:
+    - repoid: test-repo
+      baseurl: http://localhost:PORT/test-repo
+packages:
+  - test-base
+arches:
+  - x86_64
+context:
+  image: registry.access.redhat.com/ubi10/ubi-minimal:latest

--- a/tests/integration/data/success/image-ubi9/expected.lock.yaml
+++ b/tests/integration/data/success/image-ubi9/expected.lock.yaml
@@ -1,0 +1,21 @@
+---
+lockfileVersion: 1
+lockfileVendor: redhat
+arches:
+- arch: x86_64
+  packages:
+  - url: http://localhost:PORT/test-repo/test-base-1.0-1.noarch.rpm
+    repoid: test-repo
+    size: 17899
+    checksum: sha256:e3ca3c340759b02d09400e29a1c739e1f2c2bf8c793b2baf7bcebc3f44da5c53
+    name: test-base
+    evr: 1.0-1
+    sourcerpm: test-base-1.0-1.src.rpm
+  source:
+  - url: http://localhost:PORT/test-repo/test-base-1.0-1.src.rpm
+    repoid: test-repo
+    size: 2327
+    checksum: sha256:6a3850963dc1c535e77b51fcbad730f392c4dad235c1c690a77044e418243fbf
+    name: test-base
+    evr: 1.0-1
+  module_metadata: []

--- a/tests/integration/data/success/image-ubi9/repos/test-repo.yaml
+++ b/tests/integration/data/success/image-ubi9/repos/test-repo.yaml
@@ -1,0 +1,4 @@
+packages:
+  - nvr: test-base-1.0-1
+
+  - nvr: test-decoy-1.0-1

--- a/tests/integration/data/success/image-ubi9/rpms.in.yaml
+++ b/tests/integration/data/success/image-ubi9/rpms.in.yaml
@@ -1,0 +1,10 @@
+contentOrigin:
+  repos:
+    - repoid: test-repo
+      baseurl: http://localhost:PORT/test-repo
+packages:
+  - test-base
+arches:
+  - x86_64
+context:
+  image: registry.access.redhat.com/ubi9/ubi-minimal:latest

--- a/tests/integration/data/success/match-context-versions-unmatched/expected.lock.yaml
+++ b/tests/integration/data/success/match-context-versions-unmatched/expected.lock.yaml
@@ -1,0 +1,21 @@
+---
+lockfileVersion: 1
+lockfileVendor: redhat
+arches:
+- arch: x86_64
+  packages:
+  - url: http://localhost:PORT/test-repo/test-base-1.0-1.noarch.rpm
+    repoid: test-repo
+    size: 17899
+    checksum: sha256:e3ca3c340759b02d09400e29a1c739e1f2c2bf8c793b2baf7bcebc3f44da5c53
+    name: test-base
+    evr: 1.0-1
+    sourcerpm: test-base-1.0-1.src.rpm
+  source:
+  - url: http://localhost:PORT/test-repo/test-base-1.0-1.src.rpm
+    repoid: test-repo
+    size: 2327
+    checksum: sha256:6a3850963dc1c535e77b51fcbad730f392c4dad235c1c690a77044e418243fbf
+    name: test-base
+    evr: 1.0-1
+  module_metadata: []

--- a/tests/integration/data/success/match-context-versions-unmatched/expected.stdout
+++ b/tests/integration/data/success/match-context-versions-unmatched/expected.stdout
@@ -1,0 +1,2 @@
+# Should warn that the pattern didn't match any installed packages
+no installed packages matched patterns

--- a/tests/integration/data/success/match-context-versions-unmatched/repos/test-repo.yaml
+++ b/tests/integration/data/success/match-context-versions-unmatched/repos/test-repo.yaml
@@ -1,0 +1,4 @@
+packages:
+  - nvr: test-base-1.0-1
+
+  - nvr: test-decoy-1.0-1

--- a/tests/integration/data/success/match-context-versions-unmatched/rpms.in.yaml
+++ b/tests/integration/data/success/match-context-versions-unmatched/rpms.in.yaml
@@ -1,0 +1,12 @@
+contentOrigin:
+  repos:
+    - repoid: test-repo
+      baseurl: http://localhost:PORT/test-repo
+packages:
+  - test-base
+matchContextVersions:
+  - "nonexistent-pattern*"
+arches:
+  - x86_64
+context:
+  image: registry.access.redhat.com/ubi9/ubi-minimal@sha256:062c52ff973065752b0965787649db2bcf551a6c727a00e95a3eb42cebadbdab

--- a/tests/integration/data/success/match-context-versions/expected.lock.yaml
+++ b/tests/integration/data/success/match-context-versions/expected.lock.yaml
@@ -1,0 +1,34 @@
+---
+lockfileVersion: 1
+lockfileVendor: redhat
+arches:
+- arch: x86_64
+  packages:
+  - url: http://localhost:PORT/test-repo/findutils-extra-4.8.0-7.el9.x86_64.rpm
+    repoid: test-repo
+    size: 16178
+    checksum: sha256:2bd057821b7da381a1f8482a1af160a4bf6d918b9d4d3d41838bdb2859dda9c2
+    name: findutils-extra
+    evr: 1:4.8.0-7.el9
+    sourcerpm: findutils-extra-4.8.0-7.el9.src.rpm
+  - url: http://localhost:PORT/test-repo/unrelated-pkg-5.0-1.noarch.rpm
+    repoid: test-repo
+    size: 76318
+    checksum: sha256:596d339d769bfce996ae4ae6d6011680828c8e9589da69871bfc4fefeec86c3e
+    name: unrelated-pkg
+    evr: 5.0-1
+    sourcerpm: unrelated-pkg-5.0-1.src.rpm
+  source:
+  - url: http://localhost:PORT/test-repo/findutils-extra-4.8.0-7.el9.src.rpm
+    repoid: test-repo
+    size: 17398
+    checksum: sha256:5c11593c8c560edf1907b178a6c12e321c7e011a9876a2a10e4d2de28169bd0e
+    name: findutils-extra
+    evr: 4.8.0-7.el9
+  - url: http://localhost:PORT/test-repo/unrelated-pkg-5.0-1.src.rpm
+    repoid: test-repo
+    size: 48945
+    checksum: sha256:06cd62be89e321140d635a88bc250c4a0539020301b23d2398e1d35e84ade859
+    name: unrelated-pkg
+    evr: 5.0-1
+  module_metadata: []

--- a/tests/integration/data/success/match-context-versions/expected.stdout
+++ b/tests/integration/data/success/match-context-versions/expected.stdout
@@ -1,0 +1,2 @@
+# The tool should log that it's pinning findutils-extra to the image version
+pinning findutils-extra to findutils-extra-1:4.8.0-7.el9

--- a/tests/integration/data/success/match-context-versions/repos/test-repo.yaml
+++ b/tests/integration/data/success/match-context-versions/repos/test-repo.yaml
@@ -1,0 +1,11 @@
+packages:
+  # Matching version from the image (findutils is 1:4.8.0-7.el9 in the image)
+  - nvr: findutils-extra-1:4.8.0-7.el9
+    arch: x86_64
+
+  # Higher version that would be picked without pinning
+  - nvr: findutils-extra-1:99.0-1
+    arch: x86_64
+
+  # Not matched by the findutils* pattern, gets latest version
+  - nvr: unrelated-pkg-5.0-1

--- a/tests/integration/data/success/match-context-versions/rpms.in.yaml
+++ b/tests/integration/data/success/match-context-versions/rpms.in.yaml
@@ -1,0 +1,13 @@
+contentOrigin:
+  repos:
+    - repoid: test-repo
+      baseurl: http://localhost:PORT/test-repo
+packages:
+  - findutils-extra
+  - unrelated-pkg
+matchContextVersions:
+  - "findutils*"
+arches:
+  - x86_64
+context:
+  image: registry.access.redhat.com/ubi9/ubi-minimal@sha256:062c52ff973065752b0965787649db2bcf551a6c727a00e95a3eb42cebadbdab

--- a/tests/integration/data/success/multi-arch/expected.lock.yaml
+++ b/tests/integration/data/success/multi-arch/expected.lock.yaml
@@ -1,0 +1,64 @@
+---
+lockfileVersion: 1
+lockfileVendor: redhat
+arches:
+- arch: aarch64
+  packages:
+  - url: http://localhost:PORT/test-repo/test-common-1.0-1.noarch.rpm
+    repoid: test-repo
+    size: 33488
+    checksum: sha256:f744da761b44ab0c00f94f391f3386dee075a81c12c9db4bc1ed6f6e4bf23ed8
+    name: test-common
+    evr: 1.0-1
+    sourcerpm: test-common-1.0-1.src.rpm
+  source:
+  - url: http://localhost:PORT/test-repo/test-common-1.0-1.src.rpm
+    repoid: test-repo
+    size: 17508
+    checksum: sha256:f2dff9061e5b23158b3cd4e2aae77f235abd6f127e6227935d3be9f0d9e0b5c4
+    name: test-common
+    evr: 1.0-1
+  module_metadata: []
+- arch: x86_64
+  packages:
+  - url: http://localhost:PORT/test-repo/test-common-1.0-1.noarch.rpm
+    repoid: test-repo
+    size: 33488
+    checksum: sha256:f744da761b44ab0c00f94f391f3386dee075a81c12c9db4bc1ed6f6e4bf23ed8
+    name: test-common
+    evr: 1.0-1
+    sourcerpm: test-common-1.0-1.src.rpm
+  - url: http://localhost:PORT/test-repo/test-not-aarch64-1.0-1.noarch.rpm
+    repoid: test-repo
+    size: 50836
+    checksum: sha256:3046fe25e2f92d0a514caf3947917fd55f227eb8f024ae635da9f2a8a25042cc
+    name: test-not-aarch64
+    evr: 1.0-1
+    sourcerpm: test-not-aarch64-1.0-1.src.rpm
+  - url: http://localhost:PORT/test-repo/test-x86-only-1.0-1.noarch.rpm
+    repoid: test-repo
+    size: 21449
+    checksum: sha256:06afa5c5d23c80153a6ef5db268c7d1758e627b9e18cbef25acc291167a991a1
+    name: test-x86-only
+    evr: 1.0-1
+    sourcerpm: test-x86-only-1.0-1.src.rpm
+  source:
+  - url: http://localhost:PORT/test-repo/test-common-1.0-1.src.rpm
+    repoid: test-repo
+    size: 17508
+    checksum: sha256:f2dff9061e5b23158b3cd4e2aae77f235abd6f127e6227935d3be9f0d9e0b5c4
+    name: test-common
+    evr: 1.0-1
+  - url: http://localhost:PORT/test-repo/test-not-aarch64-1.0-1.src.rpm
+    repoid: test-repo
+    size: 12605
+    checksum: sha256:fd49b5bba9fab84858efac5dab5f4b4a45ce51705a19187754316ca99f81db65
+    name: test-not-aarch64
+    evr: 1.0-1
+  - url: http://localhost:PORT/test-repo/test-x86-only-1.0-1.src.rpm
+    repoid: test-repo
+    size: 6732
+    checksum: sha256:7ac5991d586afd7c7cec8080baf22c34e4c9987a410e99746587757bc3c1e664
+    name: test-x86-only
+    evr: 1.0-1
+  module_metadata: []

--- a/tests/integration/data/success/multi-arch/repos/test-repo.yaml
+++ b/tests/integration/data/success/multi-arch/repos/test-repo.yaml
@@ -1,0 +1,6 @@
+packages:
+  - nvr: test-common-1.0-1
+
+  - nvr: test-x86-only-1.0-1
+
+  - nvr: test-not-aarch64-1.0-1

--- a/tests/integration/data/success/multi-arch/rpms.in.yaml
+++ b/tests/integration/data/success/multi-arch/rpms.in.yaml
@@ -1,0 +1,19 @@
+contentOrigin:
+  repos:
+    - repoid: test-repo
+      baseurl: http://localhost:PORT/test-repo
+packages:
+  - test-common
+  - name: test-x86-only
+    arches:
+      only:
+        - x86_64
+  - name: test-not-aarch64
+    arches:
+      not:
+        - aarch64
+arches:
+  - x86_64
+  - aarch64
+context:
+  bare: true

--- a/tests/integration/data/success/multi-repo/expected.lock.yaml
+++ b/tests/integration/data/success/multi-repo/expected.lock.yaml
@@ -1,0 +1,60 @@
+---
+lockfileVersion: 1
+lockfileVendor: redhat
+arches:
+- arch: x86_64
+  packages:
+  - url: http://localhost:PORT/main-repo/test-app-1.0-1.x86_64.rpm
+    repoid: main-repo
+    size: 46466
+    checksum: sha256:c21072f7d6fdd53e1392028e10d754746d098ded0e0955d257fde886419d2f4a
+    name: test-app
+    evr: 1.0-1
+    sourcerpm: test-app-1.0-1.src.rpm
+  - url: http://localhost:PORT/main-repo/test-base-1.0-1.noarch.rpm
+    repoid: main-repo
+    size: 17899
+    checksum: sha256:e3ca3c340759b02d09400e29a1c739e1f2c2bf8c793b2baf7bcebc3f44da5c53
+    name: test-base
+    evr: 1.0-1
+    sourcerpm: test-base-1.0-1.src.rpm
+  - url: http://localhost:PORT/main-repo/test-lib-1.0-1.x86_64.rpm
+    repoid: main-repo
+    size: 2054
+    checksum: sha256:64f404a4cf4500918adb216317bf9433b44be32dee9dc516adfeebde286e2ba6
+    name: test-lib
+    evr: 1.0-1
+    sourcerpm: test-lib-1.0-1.src.rpm
+  - url: http://localhost:PORT/secondary-repo/test-optional-1.0-1.noarch.rpm
+    repoid: secondary-repo
+    size: 25902
+    checksum: sha256:8d9619306f7c356ca9ef8d54db44f0d30b9f94da8a0a6029afc221e170cef15e
+    name: test-optional
+    evr: 1.0-1
+    sourcerpm: test-optional-1.0-1.src.rpm
+  source:
+  - url: http://localhost:PORT/main-repo/test-app-1.0-1.src.rpm
+    repoid: main-repo
+    size: 6803
+    checksum: sha256:ee8a029197f249dd51b673fb93d8d7ac5ed496ee11d5b31d0ab3d452ef4208fb
+    name: test-app
+    evr: 1.0-1
+  - url: http://localhost:PORT/main-repo/test-base-1.0-1.src.rpm
+    repoid: main-repo
+    size: 2327
+    checksum: sha256:6a3850963dc1c535e77b51fcbad730f392c4dad235c1c690a77044e418243fbf
+    name: test-base
+    evr: 1.0-1
+  - url: http://localhost:PORT/main-repo/test-lib-1.0-1.src.rpm
+    repoid: main-repo
+    size: 77461
+    checksum: sha256:3ed0c333cf83998369b53e08e2a69ef9be9ff71d4a6137a1cf0eb8e585cb84bd
+    name: test-lib
+    evr: 1.0-1
+  - url: http://localhost:PORT/secondary-repo/test-optional-1.0-1.src.rpm
+    repoid: secondary-repo
+    size: 99688
+    checksum: sha256:bbe00c0383b406fad721afbbf52941477c97e6b9dfce0009aa96e892f25c7920
+    name: test-optional
+    evr: 1.0-1
+  module_metadata: []

--- a/tests/integration/data/success/multi-repo/repos/main-repo.yaml
+++ b/tests/integration/data/success/multi-repo/repos/main-repo.yaml
@@ -1,0 +1,17 @@
+packages:
+  - nvr: test-base-1.0-1
+
+  - nvr: test-lib-1.0-1
+    arch: x86_64
+    provides:
+      - libtest
+
+  - nvr: test-app-1.0-1
+    arch: x86_64
+    requires:
+      - test-lib
+      - test-base
+    recommends:
+      - test-optional
+
+  - nvr: test-unrelated-1.0-1

--- a/tests/integration/data/success/multi-repo/repos/secondary-repo.yaml
+++ b/tests/integration/data/success/multi-repo/repos/secondary-repo.yaml
@@ -1,0 +1,2 @@
+packages:
+  - nvr: test-optional-1.0-1

--- a/tests/integration/data/success/multi-repo/rpms.in.yaml
+++ b/tests/integration/data/success/multi-repo/rpms.in.yaml
@@ -1,0 +1,13 @@
+contentOrigin:
+  repos:
+    - repoid: main-repo
+      baseurl: http://localhost:PORT/main-repo
+    - repoid: secondary-repo
+      baseurl: http://localhost:PORT/secondary-repo
+packages:
+  - test-app
+arches:
+  - x86_64
+context:
+  bare: true
+installWeakDeps: true

--- a/tests/integration/data/success/multiple-packages/expected.lock.yaml
+++ b/tests/integration/data/success/multiple-packages/expected.lock.yaml
@@ -1,0 +1,34 @@
+---
+lockfileVersion: 1
+lockfileVendor: redhat
+arches:
+- arch: x86_64
+  packages:
+  - url: http://localhost:PORT/test-repo/test-base-1.0-1.noarch.rpm
+    repoid: test-repo
+    size: 17899
+    checksum: sha256:e3ca3c340759b02d09400e29a1c739e1f2c2bf8c793b2baf7bcebc3f44da5c53
+    name: test-base
+    evr: 1.0-1
+    sourcerpm: test-base-1.0-1.src.rpm
+  - url: http://localhost:PORT/test-repo/test-optional-1.0-1.noarch.rpm
+    repoid: test-repo
+    size: 25902
+    checksum: sha256:8d9619306f7c356ca9ef8d54db44f0d30b9f94da8a0a6029afc221e170cef15e
+    name: test-optional
+    evr: 1.0-1
+    sourcerpm: test-optional-1.0-1.src.rpm
+  source:
+  - url: http://localhost:PORT/test-repo/test-base-1.0-1.src.rpm
+    repoid: test-repo
+    size: 2327
+    checksum: sha256:6a3850963dc1c535e77b51fcbad730f392c4dad235c1c690a77044e418243fbf
+    name: test-base
+    evr: 1.0-1
+  - url: http://localhost:PORT/test-repo/test-optional-1.0-1.src.rpm
+    repoid: test-repo
+    size: 99688
+    checksum: sha256:bbe00c0383b406fad721afbbf52941477c97e6b9dfce0009aa96e892f25c7920
+    name: test-optional
+    evr: 1.0-1
+  module_metadata: []

--- a/tests/integration/data/success/multiple-packages/repos/test-repo.yaml
+++ b/tests/integration/data/success/multiple-packages/repos/test-repo.yaml
@@ -1,0 +1,6 @@
+packages:
+  - nvr: test-base-1.0-1
+
+  - nvr: test-optional-1.0-1
+
+  - nvr: test-decoy-1.0-1

--- a/tests/integration/data/success/multiple-packages/rpms.in.yaml
+++ b/tests/integration/data/success/multiple-packages/rpms.in.yaml
@@ -1,0 +1,11 @@
+contentOrigin:
+  repos:
+    - repoid: test-repo
+      baseurl: http://localhost:PORT/test-repo
+packages:
+  - test-base
+  - test-optional
+arches:
+  - x86_64
+context:
+  bare: true

--- a/tests/integration/data/success/no-sources/expected.lock.yaml
+++ b/tests/integration/data/success/no-sources/expected.lock.yaml
@@ -1,0 +1,15 @@
+---
+lockfileVersion: 1
+lockfileVendor: redhat
+arches:
+- arch: x86_64
+  packages:
+  - url: http://localhost:PORT/test-repo/test-base-1.0-1.noarch.rpm
+    repoid: test-repo
+    size: 17899
+    checksum: sha256:e3ca3c340759b02d09400e29a1c739e1f2c2bf8c793b2baf7bcebc3f44da5c53
+    name: test-base
+    evr: 1.0-1
+    sourcerpm: test-base-1.0-1.src.rpm
+  source: []
+  module_metadata: []

--- a/tests/integration/data/success/no-sources/repos/test-repo.yaml
+++ b/tests/integration/data/success/no-sources/repos/test-repo.yaml
@@ -1,0 +1,2 @@
+packages:
+  - nvr: test-base-1.0-1

--- a/tests/integration/data/success/no-sources/rpms.in.yaml
+++ b/tests/integration/data/success/no-sources/rpms.in.yaml
@@ -1,0 +1,11 @@
+contentOrigin:
+  repos:
+    - repoid: test-repo
+      baseurl: http://localhost:PORT/test-repo
+packages:
+  - test-base
+arches:
+  - x86_64
+context:
+  bare: true
+noSources: true

--- a/tests/integration/data/success/pfc-additive/Dockerfile
+++ b/tests/integration/data/success/pfc-additive/Dockerfile
@@ -1,0 +1,2 @@
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+RUN microdnf install -y test-from-containerfile && microdnf clean all

--- a/tests/integration/data/success/pfc-additive/expected.lock.yaml
+++ b/tests/integration/data/success/pfc-additive/expected.lock.yaml
@@ -1,0 +1,34 @@
+---
+lockfileVersion: 1
+lockfileVendor: redhat
+arches:
+- arch: x86_64
+  packages:
+  - url: http://localhost:PORT/test-repo/test-from-config-1.0-1.noarch.rpm
+    repoid: test-repo
+    size: 8198
+    checksum: sha256:f1785ebfb42296899e9a37dcb1d3e53e35ba7420616a09a146bdb9498c684f6e
+    name: test-from-config
+    evr: 1.0-1
+    sourcerpm: test-from-config-1.0-1.src.rpm
+  - url: http://localhost:PORT/test-repo/test-from-containerfile-1.0-1.noarch.rpm
+    repoid: test-repo
+    size: 50989
+    checksum: sha256:8469bc890daecdb6208cc1c9dc05e0934145abced1fe4c00c17a81dc8cc91ff5
+    name: test-from-containerfile
+    evr: 1.0-1
+    sourcerpm: test-from-containerfile-1.0-1.src.rpm
+  source:
+  - url: http://localhost:PORT/test-repo/test-from-config-1.0-1.src.rpm
+    repoid: test-repo
+    size: 70528
+    checksum: sha256:a2103836df7996e251498f9717fe060b16738e4bb67ffa58338c9c080f7a1c98
+    name: test-from-config
+    evr: 1.0-1
+  - url: http://localhost:PORT/test-repo/test-from-containerfile-1.0-1.src.rpm
+    repoid: test-repo
+    size: 26234
+    checksum: sha256:f572c1873cff7d77306adcff24f6f49bef3740c66c77d7a4e8ead5648eac9fc2
+    name: test-from-containerfile
+    evr: 1.0-1
+  module_metadata: []

--- a/tests/integration/data/success/pfc-additive/repos/test-repo.yaml
+++ b/tests/integration/data/success/pfc-additive/repos/test-repo.yaml
@@ -1,0 +1,6 @@
+packages:
+  - nvr: test-from-config-1.0-1
+
+  - nvr: test-from-containerfile-1.0-1
+
+  - nvr: test-decoy-1.0-1

--- a/tests/integration/data/success/pfc-additive/rpms.in.yaml
+++ b/tests/integration/data/success/pfc-additive/rpms.in.yaml
@@ -1,0 +1,11 @@
+contentOrigin:
+  repos:
+    - repoid: test-repo
+      baseurl: http://localhost:PORT/test-repo
+packages:
+  - test-from-config
+packagesFromContainerfile: Dockerfile
+arches:
+  - x86_64
+context:
+  containerfile: Dockerfile

--- a/tests/integration/data/success/pfc-arch-file-install/Dockerfile
+++ b/tests/integration/data/success/pfc-arch-file-install/Dockerfile
@@ -1,0 +1,3 @@
+FROM registry.access.redhat.com/ubi9/ubi:latest
+COPY packages-x86_64.txt packages-aarch64.txt /tmp/
+RUN xargs dnf install -y < /tmp/packages-$(arch).txt

--- a/tests/integration/data/success/pfc-arch-file-install/expected.lock.yaml
+++ b/tests/integration/data/success/pfc-arch-file-install/expected.lock.yaml
@@ -1,0 +1,38 @@
+---
+lockfileVersion: 1
+lockfileVendor: redhat
+arches:
+- arch: aarch64
+  packages:
+  - url: http://localhost:PORT/test-repo/test-aarch64-from-file-1.0-1.noarch.rpm
+    repoid: test-repo
+    size: 14412
+    checksum: sha256:05bc55a20176954d85438e7c9f0658f4042c5909075ba6246e02f97e0628e2f4
+    name: test-aarch64-from-file
+    evr: 1.0-1
+    sourcerpm: test-aarch64-from-file-1.0-1.src.rpm
+  source:
+  - url: http://localhost:PORT/test-repo/test-aarch64-from-file-1.0-1.src.rpm
+    repoid: test-repo
+    size: 83050
+    checksum: sha256:430144f224049408ea81d21845632e7b4845fd04279d89265fb7a337f56a6e42
+    name: test-aarch64-from-file
+    evr: 1.0-1
+  module_metadata: []
+- arch: x86_64
+  packages:
+  - url: http://localhost:PORT/test-repo/test-x86-from-file-1.0-1.noarch.rpm
+    repoid: test-repo
+    size: 5743
+    checksum: sha256:3fe4e455960bb079ec7d2cdf4ce17ea891b658439e06f60321d9b5d86e2d326f
+    name: test-x86-from-file
+    evr: 1.0-1
+    sourcerpm: test-x86-from-file-1.0-1.src.rpm
+  source:
+  - url: http://localhost:PORT/test-repo/test-x86-from-file-1.0-1.src.rpm
+    repoid: test-repo
+    size: 74060
+    checksum: sha256:43b3ea2a2cb0d7bf7cff51eaae5c3b2ffaa3e27a497f6c92bcad357ab5262054
+    name: test-x86-from-file
+    evr: 1.0-1
+  module_metadata: []

--- a/tests/integration/data/success/pfc-arch-file-install/packages-aarch64.txt
+++ b/tests/integration/data/success/pfc-arch-file-install/packages-aarch64.txt
@@ -1,0 +1,1 @@
+test-aarch64-from-file

--- a/tests/integration/data/success/pfc-arch-file-install/packages-x86_64.txt
+++ b/tests/integration/data/success/pfc-arch-file-install/packages-x86_64.txt
@@ -1,0 +1,1 @@
+test-x86-from-file

--- a/tests/integration/data/success/pfc-arch-file-install/repos/test-repo.yaml
+++ b/tests/integration/data/success/pfc-arch-file-install/repos/test-repo.yaml
@@ -1,0 +1,6 @@
+packages:
+  - nvr: test-x86-from-file-1.0-1
+
+  - nvr: test-aarch64-from-file-1.0-1
+
+  - nvr: test-decoy-1.0-1

--- a/tests/integration/data/success/pfc-arch-file-install/rpms.in.yaml
+++ b/tests/integration/data/success/pfc-arch-file-install/rpms.in.yaml
@@ -1,0 +1,10 @@
+contentOrigin:
+  repos:
+    - repoid: test-repo
+      baseurl: http://localhost:PORT/test-repo
+packagesFromContainerfile: Dockerfile
+arches:
+  - x86_64
+  - aarch64
+context:
+  bare: true

--- a/tests/integration/data/success/pfc-arch-packages/Dockerfile
+++ b/tests/integration/data/success/pfc-arch-packages/Dockerfile
@@ -1,0 +1,4 @@
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+RUN microdnf install -y test-common && \
+    if [ $(arch) = x86_64 ]; then microdnf install -y test-x86-only; fi && \
+    if [ $(arch) = aarch64 ]; then microdnf install -y test-aarch64-only; fi

--- a/tests/integration/data/success/pfc-arch-packages/expected.lock.yaml
+++ b/tests/integration/data/success/pfc-arch-packages/expected.lock.yaml
@@ -1,0 +1,64 @@
+---
+lockfileVersion: 1
+lockfileVendor: redhat
+arches:
+- arch: aarch64
+  packages:
+  - url: http://localhost:PORT/test-repo/test-aarch64-only-1.0-1.noarch.rpm
+    repoid: test-repo
+    size: 37590
+    checksum: sha256:cbe3bcefb2bba1d42b975906c7812a9c7b126f202f14d644bbed9eca7b4ffede
+    name: test-aarch64-only
+    evr: 1.0-1
+    sourcerpm: test-aarch64-only-1.0-1.src.rpm
+  - url: http://localhost:PORT/test-repo/test-common-1.0-1.noarch.rpm
+    repoid: test-repo
+    size: 33488
+    checksum: sha256:f744da761b44ab0c00f94f391f3386dee075a81c12c9db4bc1ed6f6e4bf23ed8
+    name: test-common
+    evr: 1.0-1
+    sourcerpm: test-common-1.0-1.src.rpm
+  source:
+  - url: http://localhost:PORT/test-repo/test-aarch64-only-1.0-1.src.rpm
+    repoid: test-repo
+    size: 62964
+    checksum: sha256:66ab8abbb8269707905ee7c874ee750b006a083802dbd7b0f2dfea64e0791e54
+    name: test-aarch64-only
+    evr: 1.0-1
+  - url: http://localhost:PORT/test-repo/test-common-1.0-1.src.rpm
+    repoid: test-repo
+    size: 17508
+    checksum: sha256:f2dff9061e5b23158b3cd4e2aae77f235abd6f127e6227935d3be9f0d9e0b5c4
+    name: test-common
+    evr: 1.0-1
+  module_metadata: []
+- arch: x86_64
+  packages:
+  - url: http://localhost:PORT/test-repo/test-common-1.0-1.noarch.rpm
+    repoid: test-repo
+    size: 33488
+    checksum: sha256:f744da761b44ab0c00f94f391f3386dee075a81c12c9db4bc1ed6f6e4bf23ed8
+    name: test-common
+    evr: 1.0-1
+    sourcerpm: test-common-1.0-1.src.rpm
+  - url: http://localhost:PORT/test-repo/test-x86-only-1.0-1.noarch.rpm
+    repoid: test-repo
+    size: 21449
+    checksum: sha256:06afa5c5d23c80153a6ef5db268c7d1758e627b9e18cbef25acc291167a991a1
+    name: test-x86-only
+    evr: 1.0-1
+    sourcerpm: test-x86-only-1.0-1.src.rpm
+  source:
+  - url: http://localhost:PORT/test-repo/test-common-1.0-1.src.rpm
+    repoid: test-repo
+    size: 17508
+    checksum: sha256:f2dff9061e5b23158b3cd4e2aae77f235abd6f127e6227935d3be9f0d9e0b5c4
+    name: test-common
+    evr: 1.0-1
+  - url: http://localhost:PORT/test-repo/test-x86-only-1.0-1.src.rpm
+    repoid: test-repo
+    size: 6732
+    checksum: sha256:7ac5991d586afd7c7cec8080baf22c34e4c9987a410e99746587757bc3c1e664
+    name: test-x86-only
+    evr: 1.0-1
+  module_metadata: []

--- a/tests/integration/data/success/pfc-arch-packages/repos/test-repo.yaml
+++ b/tests/integration/data/success/pfc-arch-packages/repos/test-repo.yaml
@@ -1,0 +1,6 @@
+packages:
+  - nvr: test-common-1.0-1
+
+  - nvr: test-x86-only-1.0-1
+
+  - nvr: test-aarch64-only-1.0-1

--- a/tests/integration/data/success/pfc-arch-packages/rpms.in.yaml
+++ b/tests/integration/data/success/pfc-arch-packages/rpms.in.yaml
@@ -1,0 +1,10 @@
+contentOrigin:
+  repos:
+    - repoid: test-repo
+      baseurl: http://localhost:PORT/test-repo
+packagesFromContainerfile: Dockerfile
+arches:
+  - x86_64
+  - aarch64
+context:
+  bare: true

--- a/tests/integration/data/success/pfc-arg-expansion/Dockerfile
+++ b/tests/integration/data/success/pfc-arg-expansion/Dockerfile
@@ -1,0 +1,5 @@
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+
+ARG EXTRA_PKG=test-from-arg
+
+RUN microdnf install -y test-base $EXTRA_PKG

--- a/tests/integration/data/success/pfc-arg-expansion/expected.lock.yaml
+++ b/tests/integration/data/success/pfc-arg-expansion/expected.lock.yaml
@@ -1,0 +1,34 @@
+---
+lockfileVersion: 1
+lockfileVendor: redhat
+arches:
+- arch: x86_64
+  packages:
+  - url: http://localhost:PORT/test-repo/test-base-1.0-1.noarch.rpm
+    repoid: test-repo
+    size: 17899
+    checksum: sha256:e3ca3c340759b02d09400e29a1c739e1f2c2bf8c793b2baf7bcebc3f44da5c53
+    name: test-base
+    evr: 1.0-1
+    sourcerpm: test-base-1.0-1.src.rpm
+  - url: http://localhost:PORT/test-repo/test-from-arg-1.0-1.noarch.rpm
+    repoid: test-repo
+    size: 91629
+    checksum: sha256:0ec74d92de9a134e95f8e50423682304559eb939bd636ce488af52b6f2c3d50d
+    name: test-from-arg
+    evr: 1.0-1
+    sourcerpm: test-from-arg-1.0-1.src.rpm
+  source:
+  - url: http://localhost:PORT/test-repo/test-base-1.0-1.src.rpm
+    repoid: test-repo
+    size: 2327
+    checksum: sha256:6a3850963dc1c535e77b51fcbad730f392c4dad235c1c690a77044e418243fbf
+    name: test-base
+    evr: 1.0-1
+  - url: http://localhost:PORT/test-repo/test-from-arg-1.0-1.src.rpm
+    repoid: test-repo
+    size: 52669
+    checksum: sha256:64fb0740f19af519bf8c1ba05d5f6886506faef07a4f55efc1d5752b077cdd55
+    name: test-from-arg
+    evr: 1.0-1
+  module_metadata: []

--- a/tests/integration/data/success/pfc-arg-expansion/repos/test-repo.yaml
+++ b/tests/integration/data/success/pfc-arg-expansion/repos/test-repo.yaml
@@ -1,0 +1,6 @@
+packages:
+  - nvr: test-base-1.0-1
+
+  - nvr: test-from-arg-1.0-1
+
+  - nvr: test-decoy-1.0-1

--- a/tests/integration/data/success/pfc-arg-expansion/rpms.in.yaml
+++ b/tests/integration/data/success/pfc-arg-expansion/rpms.in.yaml
@@ -1,0 +1,9 @@
+contentOrigin:
+  repos:
+    - repoid: test-repo
+      baseurl: http://localhost:PORT/test-repo
+packagesFromContainerfile: Dockerfile
+arches:
+  - x86_64
+context:
+  bare: true

--- a/tests/integration/data/success/pfc-bare-script-name/Dockerfile
+++ b/tests/integration/data/success/pfc-bare-script-name/Dockerfile
@@ -1,0 +1,3 @@
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+COPY setup.sh /opt/scripts/
+RUN setup.sh

--- a/tests/integration/data/success/pfc-bare-script-name/expected.lock.yaml
+++ b/tests/integration/data/success/pfc-bare-script-name/expected.lock.yaml
@@ -1,0 +1,21 @@
+---
+lockfileVersion: 1
+lockfileVendor: redhat
+arches:
+- arch: x86_64
+  packages:
+  - url: http://localhost:PORT/test-repo/test-from-bare-name-1.0-1.noarch.rpm
+    repoid: test-repo
+    size: 34464
+    checksum: sha256:fab0f6f07bbc411903dc59026438a3fe8d07ca8bf89ce0fe95c67e55d4871fe8
+    name: test-from-bare-name
+    evr: 1.0-1
+    sourcerpm: test-from-bare-name-1.0-1.src.rpm
+  source:
+  - url: http://localhost:PORT/test-repo/test-from-bare-name-1.0-1.src.rpm
+    repoid: test-repo
+    size: 46263
+    checksum: sha256:15bc66a2d7ba369ba3a9f340ba3cf5c149c33775c079c49dbb6abcbbc6af8ff7
+    name: test-from-bare-name
+    evr: 1.0-1
+  module_metadata: []

--- a/tests/integration/data/success/pfc-bare-script-name/repos/test-repo.yaml
+++ b/tests/integration/data/success/pfc-bare-script-name/repos/test-repo.yaml
@@ -1,0 +1,4 @@
+packages:
+  - nvr: test-from-bare-name-1.0-1
+
+  - nvr: test-decoy-1.0-1

--- a/tests/integration/data/success/pfc-bare-script-name/rpms.in.yaml
+++ b/tests/integration/data/success/pfc-bare-script-name/rpms.in.yaml
@@ -1,0 +1,9 @@
+contentOrigin:
+  repos:
+    - repoid: test-repo
+      baseurl: http://localhost:PORT/test-repo
+packagesFromContainerfile: Dockerfile
+arches:
+  - x86_64
+context:
+  bare: true

--- a/tests/integration/data/success/pfc-bare-script-name/setup.sh
+++ b/tests/integration/data/success/pfc-bare-script-name/setup.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+set -ex
+microdnf install -y test-from-bare-name

--- a/tests/integration/data/success/pfc-bare/Dockerfile
+++ b/tests/integration/data/success/pfc-bare/Dockerfile
@@ -1,0 +1,2 @@
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+RUN microdnf install -y test-base && microdnf clean all

--- a/tests/integration/data/success/pfc-bare/expected.lock.yaml
+++ b/tests/integration/data/success/pfc-bare/expected.lock.yaml
@@ -1,0 +1,21 @@
+---
+lockfileVersion: 1
+lockfileVendor: redhat
+arches:
+- arch: x86_64
+  packages:
+  - url: http://localhost:PORT/test-repo/test-base-1.0-1.noarch.rpm
+    repoid: test-repo
+    size: 17899
+    checksum: sha256:e3ca3c340759b02d09400e29a1c739e1f2c2bf8c793b2baf7bcebc3f44da5c53
+    name: test-base
+    evr: 1.0-1
+    sourcerpm: test-base-1.0-1.src.rpm
+  source:
+  - url: http://localhost:PORT/test-repo/test-base-1.0-1.src.rpm
+    repoid: test-repo
+    size: 2327
+    checksum: sha256:6a3850963dc1c535e77b51fcbad730f392c4dad235c1c690a77044e418243fbf
+    name: test-base
+    evr: 1.0-1
+  module_metadata: []

--- a/tests/integration/data/success/pfc-bare/repos/test-repo.yaml
+++ b/tests/integration/data/success/pfc-bare/repos/test-repo.yaml
@@ -1,0 +1,4 @@
+packages:
+  - nvr: test-base-1.0-1
+
+  - nvr: test-decoy-1.0-1

--- a/tests/integration/data/success/pfc-bare/rpms.in.yaml
+++ b/tests/integration/data/success/pfc-bare/rpms.in.yaml
@@ -1,0 +1,9 @@
+contentOrigin:
+  repos:
+    - repoid: test-repo
+      baseurl: http://localhost:PORT/test-repo
+packagesFromContainerfile: Dockerfile
+arches:
+  - x86_64
+context:
+  bare: true

--- a/tests/integration/data/success/pfc-bash-interpreter-script/Dockerfile
+++ b/tests/integration/data/success/pfc-bash-interpreter-script/Dockerfile
@@ -1,0 +1,3 @@
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+COPY setup.sh /tmp/
+RUN bash /tmp/setup.sh

--- a/tests/integration/data/success/pfc-bash-interpreter-script/expected.lock.yaml
+++ b/tests/integration/data/success/pfc-bash-interpreter-script/expected.lock.yaml
@@ -1,0 +1,21 @@
+---
+lockfileVersion: 1
+lockfileVendor: redhat
+arches:
+- arch: x86_64
+  packages:
+  - url: http://localhost:PORT/test-repo/test-from-bash-script-1.0-1.noarch.rpm
+    repoid: test-repo
+    size: 26005
+    checksum: sha256:9f3b5494cc776e24168e751f9f9823f72f49359ad13fee784097b338d3eb195d
+    name: test-from-bash-script
+    evr: 1.0-1
+    sourcerpm: test-from-bash-script-1.0-1.src.rpm
+  source:
+  - url: http://localhost:PORT/test-repo/test-from-bash-script-1.0-1.src.rpm
+    repoid: test-repo
+    size: 82605
+    checksum: sha256:3804cfb040a3f35e921d8748eb8225fc8514c6933a71f2be6acfdfad0de9a9ed
+    name: test-from-bash-script
+    evr: 1.0-1
+  module_metadata: []

--- a/tests/integration/data/success/pfc-bash-interpreter-script/repos/test-repo.yaml
+++ b/tests/integration/data/success/pfc-bash-interpreter-script/repos/test-repo.yaml
@@ -1,0 +1,4 @@
+packages:
+  - nvr: test-from-bash-script-1.0-1
+
+  - nvr: test-decoy-1.0-1

--- a/tests/integration/data/success/pfc-bash-interpreter-script/rpms.in.yaml
+++ b/tests/integration/data/success/pfc-bash-interpreter-script/rpms.in.yaml
@@ -1,0 +1,9 @@
+contentOrigin:
+  repos:
+    - repoid: test-repo
+      baseurl: http://localhost:PORT/test-repo
+packagesFromContainerfile: Dockerfile
+arches:
+  - x86_64
+context:
+  bare: true

--- a/tests/integration/data/success/pfc-bash-interpreter-script/setup.sh
+++ b/tests/integration/data/success/pfc-bash-interpreter-script/setup.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+set -ex
+microdnf install -y test-from-bash-script

--- a/tests/integration/data/success/pfc-chained-commands/Dockerfile
+++ b/tests/integration/data/success/pfc-chained-commands/Dockerfile
@@ -1,0 +1,4 @@
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+RUN microdnf install -y test-first && \
+    microdnf install -y test-second && \
+    microdnf clean all

--- a/tests/integration/data/success/pfc-chained-commands/expected.lock.yaml
+++ b/tests/integration/data/success/pfc-chained-commands/expected.lock.yaml
@@ -1,0 +1,34 @@
+---
+lockfileVersion: 1
+lockfileVendor: redhat
+arches:
+- arch: x86_64
+  packages:
+  - url: http://localhost:PORT/test-repo/test-first-1.0-1.noarch.rpm
+    repoid: test-repo
+    size: 64940
+    checksum: sha256:d6b736b486ad0135b9a6cbb9d391fd64d8b1db28ca0b00c5c95837ef14e3e5cc
+    name: test-first
+    evr: 1.0-1
+    sourcerpm: test-first-1.0-1.src.rpm
+  - url: http://localhost:PORT/test-repo/test-second-1.0-1.noarch.rpm
+    repoid: test-repo
+    size: 24751
+    checksum: sha256:94879f24295fc715e99f41d9a2b0855c7eb6913dfc201537e4cea23994cb8eaf
+    name: test-second
+    evr: 1.0-1
+    sourcerpm: test-second-1.0-1.src.rpm
+  source:
+  - url: http://localhost:PORT/test-repo/test-first-1.0-1.src.rpm
+    repoid: test-repo
+    size: 88732
+    checksum: sha256:0ac36af6e1ddb1fce41f952991529f576e8cf87ceea88ab1127072e5e851ed5c
+    name: test-first
+    evr: 1.0-1
+  - url: http://localhost:PORT/test-repo/test-second-1.0-1.src.rpm
+    repoid: test-repo
+    size: 3733
+    checksum: sha256:26ad65744bedf7af62ccb9951cfec9863df7b08f1f8f8a6cb8f3786050d84c65
+    name: test-second
+    evr: 1.0-1
+  module_metadata: []

--- a/tests/integration/data/success/pfc-chained-commands/repos/test-repo.yaml
+++ b/tests/integration/data/success/pfc-chained-commands/repos/test-repo.yaml
@@ -1,0 +1,6 @@
+packages:
+  - nvr: test-first-1.0-1
+
+  - nvr: test-second-1.0-1
+
+  - nvr: test-decoy-1.0-1

--- a/tests/integration/data/success/pfc-chained-commands/rpms.in.yaml
+++ b/tests/integration/data/success/pfc-chained-commands/rpms.in.yaml
@@ -1,0 +1,9 @@
+contentOrigin:
+  repos:
+    - repoid: test-repo
+      baseurl: http://localhost:PORT/test-repo
+packagesFromContainerfile: Dockerfile
+arches:
+  - x86_64
+context:
+  bare: true

--- a/tests/integration/data/success/pfc-dnf-install/Dockerfile
+++ b/tests/integration/data/success/pfc-dnf-install/Dockerfile
@@ -1,0 +1,2 @@
+FROM registry.access.redhat.com/ubi9/ubi:latest
+RUN dnf install -y test-from-dnf && dnf clean all

--- a/tests/integration/data/success/pfc-dnf-install/expected.lock.yaml
+++ b/tests/integration/data/success/pfc-dnf-install/expected.lock.yaml
@@ -1,0 +1,21 @@
+---
+lockfileVersion: 1
+lockfileVendor: redhat
+arches:
+- arch: x86_64
+  packages:
+  - url: http://localhost:PORT/test-repo/test-from-dnf-1.0-1.noarch.rpm
+    repoid: test-repo
+    size: 18477
+    checksum: sha256:2054434bcd7b02d67b49c436f29aea47f522545eb6802c6d3af3e960cca44745
+    name: test-from-dnf
+    evr: 1.0-1
+    sourcerpm: test-from-dnf-1.0-1.src.rpm
+  source:
+  - url: http://localhost:PORT/test-repo/test-from-dnf-1.0-1.src.rpm
+    repoid: test-repo
+    size: 13470
+    checksum: sha256:998ffb65c10f19ebaf1d013f1576bced92cfd0363e214b35129c3ff8a05c41b6
+    name: test-from-dnf
+    evr: 1.0-1
+  module_metadata: []

--- a/tests/integration/data/success/pfc-dnf-install/repos/test-repo.yaml
+++ b/tests/integration/data/success/pfc-dnf-install/repos/test-repo.yaml
@@ -1,0 +1,4 @@
+packages:
+  - nvr: test-from-dnf-1.0-1
+
+  - nvr: test-decoy-1.0-1

--- a/tests/integration/data/success/pfc-dnf-install/rpms.in.yaml
+++ b/tests/integration/data/success/pfc-dnf-install/rpms.in.yaml
@@ -1,0 +1,9 @@
+contentOrigin:
+  repos:
+    - repoid: test-repo
+      baseurl: http://localhost:PORT/test-repo
+packagesFromContainerfile: Dockerfile
+arches:
+  - x86_64
+context:
+  bare: true

--- a/tests/integration/data/success/pfc-env-expansion/Dockerfile
+++ b/tests/integration/data/success/pfc-env-expansion/Dockerfile
@@ -1,0 +1,5 @@
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+
+ENV PKG_NAME=test-from-env
+
+RUN microdnf install -y $PKG_NAME

--- a/tests/integration/data/success/pfc-env-expansion/expected.lock.yaml
+++ b/tests/integration/data/success/pfc-env-expansion/expected.lock.yaml
@@ -1,0 +1,21 @@
+---
+lockfileVersion: 1
+lockfileVendor: redhat
+arches:
+- arch: x86_64
+  packages:
+  - url: http://localhost:PORT/test-repo/test-from-env-1.0-1.noarch.rpm
+    repoid: test-repo
+    size: 54120
+    checksum: sha256:fe9cafc9fa006be52605d379305c63db4cf9fe47e26f19511debe75ca16b0e08
+    name: test-from-env
+    evr: 1.0-1
+    sourcerpm: test-from-env-1.0-1.src.rpm
+  source:
+  - url: http://localhost:PORT/test-repo/test-from-env-1.0-1.src.rpm
+    repoid: test-repo
+    size: 23908
+    checksum: sha256:cf90e0b49e1d85808598d99ea98030a82bb1d46f8c0936528a38080d6e30fd1c
+    name: test-from-env
+    evr: 1.0-1
+  module_metadata: []

--- a/tests/integration/data/success/pfc-env-expansion/repos/test-repo.yaml
+++ b/tests/integration/data/success/pfc-env-expansion/repos/test-repo.yaml
@@ -1,0 +1,4 @@
+packages:
+  - nvr: test-from-env-1.0-1
+
+  - nvr: test-decoy-1.0-1

--- a/tests/integration/data/success/pfc-env-expansion/rpms.in.yaml
+++ b/tests/integration/data/success/pfc-env-expansion/rpms.in.yaml
@@ -1,0 +1,9 @@
+contentOrigin:
+  repos:
+    - repoid: test-repo
+      baseurl: http://localhost:PORT/test-repo
+packagesFromContainerfile: Dockerfile
+arches:
+  - x86_64
+context:
+  bare: true

--- a/tests/integration/data/success/pfc-explicit/Dockerfile
+++ b/tests/integration/data/success/pfc-explicit/Dockerfile
@@ -1,0 +1,2 @@
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+RUN microdnf install -y test-base && microdnf clean all

--- a/tests/integration/data/success/pfc-explicit/expected.lock.yaml
+++ b/tests/integration/data/success/pfc-explicit/expected.lock.yaml
@@ -1,0 +1,21 @@
+---
+lockfileVersion: 1
+lockfileVendor: redhat
+arches:
+- arch: x86_64
+  packages:
+  - url: http://localhost:PORT/test-repo/test-base-1.0-1.noarch.rpm
+    repoid: test-repo
+    size: 17899
+    checksum: sha256:e3ca3c340759b02d09400e29a1c739e1f2c2bf8c793b2baf7bcebc3f44da5c53
+    name: test-base
+    evr: 1.0-1
+    sourcerpm: test-base-1.0-1.src.rpm
+  source:
+  - url: http://localhost:PORT/test-repo/test-base-1.0-1.src.rpm
+    repoid: test-repo
+    size: 2327
+    checksum: sha256:6a3850963dc1c535e77b51fcbad730f392c4dad235c1c690a77044e418243fbf
+    name: test-base
+    evr: 1.0-1
+  module_metadata: []

--- a/tests/integration/data/success/pfc-explicit/repos/test-repo.yaml
+++ b/tests/integration/data/success/pfc-explicit/repos/test-repo.yaml
@@ -1,0 +1,4 @@
+packages:
+  - nvr: test-base-1.0-1
+
+  - nvr: test-not-in-containerfile-1.0-1

--- a/tests/integration/data/success/pfc-explicit/rpms.in.yaml
+++ b/tests/integration/data/success/pfc-explicit/rpms.in.yaml
@@ -1,0 +1,9 @@
+contentOrigin:
+  repos:
+    - repoid: test-repo
+      baseurl: http://localhost:PORT/test-repo
+packagesFromContainerfile: Dockerfile
+arches:
+  - x86_64
+context:
+  containerfile: Dockerfile

--- a/tests/integration/data/success/pfc-file-install-basename/Dockerfile
+++ b/tests/integration/data/success/pfc-file-install-basename/Dockerfile
@@ -1,0 +1,3 @@
+FROM registry.access.redhat.com/ubi9/ubi:latest
+COPY deps.txt /opt/config/
+RUN xargs dnf install -y < /var/tmp/deps.txt

--- a/tests/integration/data/success/pfc-file-install-basename/deps.txt
+++ b/tests/integration/data/success/pfc-file-install-basename/deps.txt
@@ -1,0 +1,1 @@
+test-from-basename

--- a/tests/integration/data/success/pfc-file-install-basename/expected.lock.yaml
+++ b/tests/integration/data/success/pfc-file-install-basename/expected.lock.yaml
@@ -1,0 +1,21 @@
+---
+lockfileVersion: 1
+lockfileVendor: redhat
+arches:
+- arch: x86_64
+  packages:
+  - url: http://localhost:PORT/test-repo/test-from-basename-1.0-1.noarch.rpm
+    repoid: test-repo
+    size: 25935
+    checksum: sha256:7c73efb07f461a5130c33e6e4bef9211d5540b4e4c0096c36ba68164f682bac7
+    name: test-from-basename
+    evr: 1.0-1
+    sourcerpm: test-from-basename-1.0-1.src.rpm
+  source:
+  - url: http://localhost:PORT/test-repo/test-from-basename-1.0-1.src.rpm
+    repoid: test-repo
+    size: 67784
+    checksum: sha256:fb1ab36c9061a29631c7d962c24150b90c21e8cb6cbf02db2bfc987a328da1b8
+    name: test-from-basename
+    evr: 1.0-1
+  module_metadata: []

--- a/tests/integration/data/success/pfc-file-install-basename/repos/test-repo.yaml
+++ b/tests/integration/data/success/pfc-file-install-basename/repos/test-repo.yaml
@@ -1,0 +1,4 @@
+packages:
+  - nvr: test-from-basename-1.0-1
+
+  - nvr: test-decoy-1.0-1

--- a/tests/integration/data/success/pfc-file-install-basename/rpms.in.yaml
+++ b/tests/integration/data/success/pfc-file-install-basename/rpms.in.yaml
@@ -1,0 +1,9 @@
+contentOrigin:
+  repos:
+    - repoid: test-repo
+      baseurl: http://localhost:PORT/test-repo
+packagesFromContainerfile: Dockerfile
+arches:
+  - x86_64
+context:
+  bare: true

--- a/tests/integration/data/success/pfc-file-install-no-copy/Dockerfile
+++ b/tests/integration/data/success/pfc-file-install-no-copy/Dockerfile
@@ -1,0 +1,2 @@
+FROM registry.access.redhat.com/ubi9/ubi:latest
+RUN xargs dnf install -y < /tmp/pkglist.txt

--- a/tests/integration/data/success/pfc-file-install-no-copy/expected.lock.yaml
+++ b/tests/integration/data/success/pfc-file-install-no-copy/expected.lock.yaml
@@ -1,0 +1,21 @@
+---
+lockfileVersion: 1
+lockfileVendor: redhat
+arches:
+- arch: x86_64
+  packages:
+  - url: http://localhost:PORT/test-repo/test-from-nocopy-1.0-1.noarch.rpm
+    repoid: test-repo
+    size: 77756
+    checksum: sha256:6b82ad3d25e1129ee51d89b17935f2ee755ab8303d0c443c76d3441e0130b234
+    name: test-from-nocopy
+    evr: 1.0-1
+    sourcerpm: test-from-nocopy-1.0-1.src.rpm
+  source:
+  - url: http://localhost:PORT/test-repo/test-from-nocopy-1.0-1.src.rpm
+    repoid: test-repo
+    size: 23363
+    checksum: sha256:264eed8c86075e97d69e78a425cd5f42040bff30c4aada07346cb8192a5e5df3
+    name: test-from-nocopy
+    evr: 1.0-1
+  module_metadata: []

--- a/tests/integration/data/success/pfc-file-install-no-copy/pkglist.txt
+++ b/tests/integration/data/success/pfc-file-install-no-copy/pkglist.txt
@@ -1,0 +1,1 @@
+test-from-nocopy

--- a/tests/integration/data/success/pfc-file-install-no-copy/repos/test-repo.yaml
+++ b/tests/integration/data/success/pfc-file-install-no-copy/repos/test-repo.yaml
@@ -1,0 +1,4 @@
+packages:
+  - nvr: test-from-nocopy-1.0-1
+
+  - nvr: test-decoy-1.0-1

--- a/tests/integration/data/success/pfc-file-install-no-copy/rpms.in.yaml
+++ b/tests/integration/data/success/pfc-file-install-no-copy/rpms.in.yaml
@@ -1,0 +1,9 @@
+contentOrigin:
+  repos:
+    - repoid: test-repo
+      baseurl: http://localhost:PORT/test-repo
+packagesFromContainerfile: Dockerfile
+arches:
+  - x86_64
+context:
+  bare: true

--- a/tests/integration/data/success/pfc-file-install/Dockerfile
+++ b/tests/integration/data/success/pfc-file-install/Dockerfile
@@ -1,0 +1,3 @@
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+COPY packages.txt /tmp/
+RUN xargs microdnf install -y < /tmp/packages.txt

--- a/tests/integration/data/success/pfc-file-install/expected.lock.yaml
+++ b/tests/integration/data/success/pfc-file-install/expected.lock.yaml
@@ -1,0 +1,21 @@
+---
+lockfileVersion: 1
+lockfileVendor: redhat
+arches:
+- arch: x86_64
+  packages:
+  - url: http://localhost:PORT/test-repo/test-from-file-1.0-1.noarch.rpm
+    repoid: test-repo
+    size: 93851
+    checksum: sha256:6b55b6f65d9c06ef7b078c5bce5d95737b305544e5f544ee91eb1356440a2a8b
+    name: test-from-file
+    evr: 1.0-1
+    sourcerpm: test-from-file-1.0-1.src.rpm
+  source:
+  - url: http://localhost:PORT/test-repo/test-from-file-1.0-1.src.rpm
+    repoid: test-repo
+    size: 40031
+    checksum: sha256:3473da2a7b1a79c55f014474f9b205a67abf577052601a93e307bbeb1734bfef
+    name: test-from-file
+    evr: 1.0-1
+  module_metadata: []

--- a/tests/integration/data/success/pfc-file-install/packages.txt
+++ b/tests/integration/data/success/pfc-file-install/packages.txt
@@ -1,0 +1,2 @@
+# Common packages
+test-from-file

--- a/tests/integration/data/success/pfc-file-install/repos/test-repo.yaml
+++ b/tests/integration/data/success/pfc-file-install/repos/test-repo.yaml
@@ -1,0 +1,4 @@
+packages:
+  - nvr: test-from-file-1.0-1
+
+  - nvr: test-decoy-1.0-1

--- a/tests/integration/data/success/pfc-file-install/rpms.in.yaml
+++ b/tests/integration/data/success/pfc-file-install/rpms.in.yaml
@@ -1,0 +1,9 @@
+contentOrigin:
+  repos:
+    - repoid: test-repo
+      baseurl: http://localhost:PORT/test-repo
+packagesFromContainerfile: Dockerfile
+arches:
+  - x86_64
+context:
+  bare: true

--- a/tests/integration/data/success/pfc-global-arg/Dockerfile
+++ b/tests/integration/data/success/pfc-global-arg/Dockerfile
@@ -1,0 +1,7 @@
+ARG PKG_SUFFIX=global
+
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+
+ARG PKG_SUFFIX
+
+RUN microdnf install -y test-from-$PKG_SUFFIX

--- a/tests/integration/data/success/pfc-global-arg/expected.lock.yaml
+++ b/tests/integration/data/success/pfc-global-arg/expected.lock.yaml
@@ -1,0 +1,21 @@
+---
+lockfileVersion: 1
+lockfileVendor: redhat
+arches:
+- arch: x86_64
+  packages:
+  - url: http://localhost:PORT/test-repo/test-from-global-1.0-1.noarch.rpm
+    repoid: test-repo
+    size: 48668
+    checksum: sha256:dec2afb0ce0cd5e67776898fe72ae8cd33f6d718cb9148735dabae2c05395bd4
+    name: test-from-global
+    evr: 1.0-1
+    sourcerpm: test-from-global-1.0-1.src.rpm
+  source:
+  - url: http://localhost:PORT/test-repo/test-from-global-1.0-1.src.rpm
+    repoid: test-repo
+    size: 4200
+    checksum: sha256:6223598edb50faf12786507f1c0a5ed419da8fdc58a3bd414ae2f9613356b890
+    name: test-from-global
+    evr: 1.0-1
+  module_metadata: []

--- a/tests/integration/data/success/pfc-global-arg/repos/test-repo.yaml
+++ b/tests/integration/data/success/pfc-global-arg/repos/test-repo.yaml
@@ -1,0 +1,4 @@
+packages:
+  - nvr: test-from-global-1.0-1
+
+  - nvr: test-decoy-1.0-1

--- a/tests/integration/data/success/pfc-global-arg/rpms.in.yaml
+++ b/tests/integration/data/success/pfc-global-arg/rpms.in.yaml
@@ -1,0 +1,9 @@
+contentOrigin:
+  repos:
+    - repoid: test-repo
+      baseurl: http://localhost:PORT/test-repo
+packagesFromContainerfile: Dockerfile
+arches:
+  - x86_64
+context:
+  bare: true

--- a/tests/integration/data/success/pfc-if-else-install/Dockerfile
+++ b/tests/integration/data/success/pfc-if-else-install/Dockerfile
@@ -1,0 +1,6 @@
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+RUN if [ $(arch) = x86_64 ]; then \
+        microdnf install -y test-x86-branch; \
+    else \
+        microdnf install -y test-else-branch; \
+    fi

--- a/tests/integration/data/success/pfc-if-else-install/expected.lock.yaml
+++ b/tests/integration/data/success/pfc-if-else-install/expected.lock.yaml
@@ -1,0 +1,51 @@
+---
+lockfileVersion: 1
+lockfileVendor: redhat
+arches:
+- arch: aarch64
+  packages:
+  - url: http://localhost:PORT/test-repo/test-else-branch-1.0-1.noarch.rpm
+    repoid: test-repo
+    size: 97013
+    checksum: sha256:abf4a1cedd438c64304defef0ac383a1c43e8c8e3dbac9d92377ae81caf884bd
+    name: test-else-branch
+    evr: 1.0-1
+    sourcerpm: test-else-branch-1.0-1.src.rpm
+  source:
+  - url: http://localhost:PORT/test-repo/test-else-branch-1.0-1.src.rpm
+    repoid: test-repo
+    size: 4642
+    checksum: sha256:7d513a86ec9ebfb3677017dd1a78a5a12bae38ed3b7a68aa83458ebda3d9c65a
+    name: test-else-branch
+    evr: 1.0-1
+  module_metadata: []
+- arch: x86_64
+  packages:
+  - url: http://localhost:PORT/test-repo/test-else-branch-1.0-1.noarch.rpm
+    repoid: test-repo
+    size: 97013
+    checksum: sha256:abf4a1cedd438c64304defef0ac383a1c43e8c8e3dbac9d92377ae81caf884bd
+    name: test-else-branch
+    evr: 1.0-1
+    sourcerpm: test-else-branch-1.0-1.src.rpm
+  - url: http://localhost:PORT/test-repo/test-x86-branch-1.0-1.noarch.rpm
+    repoid: test-repo
+    size: 3481
+    checksum: sha256:e799c21ba607a353f86824fd557356fe72847db94d3c04289721327b96cf93c1
+    name: test-x86-branch
+    evr: 1.0-1
+    sourcerpm: test-x86-branch-1.0-1.src.rpm
+  source:
+  - url: http://localhost:PORT/test-repo/test-else-branch-1.0-1.src.rpm
+    repoid: test-repo
+    size: 4642
+    checksum: sha256:7d513a86ec9ebfb3677017dd1a78a5a12bae38ed3b7a68aa83458ebda3d9c65a
+    name: test-else-branch
+    evr: 1.0-1
+  - url: http://localhost:PORT/test-repo/test-x86-branch-1.0-1.src.rpm
+    repoid: test-repo
+    size: 65378
+    checksum: sha256:753ac182c8d0bfa6a345b1cbc38eb4db39909fac39f992fba6ea19193f56508a
+    name: test-x86-branch
+    evr: 1.0-1
+  module_metadata: []

--- a/tests/integration/data/success/pfc-if-else-install/repos/test-repo.yaml
+++ b/tests/integration/data/success/pfc-if-else-install/repos/test-repo.yaml
@@ -1,0 +1,4 @@
+packages:
+  - nvr: test-x86-branch-1.0-1
+
+  - nvr: test-else-branch-1.0-1

--- a/tests/integration/data/success/pfc-if-else-install/rpms.in.yaml
+++ b/tests/integration/data/success/pfc-if-else-install/rpms.in.yaml
@@ -1,0 +1,10 @@
+contentOrigin:
+  repos:
+    - repoid: test-repo
+      baseurl: http://localhost:PORT/test-repo
+packagesFromContainerfile: Dockerfile
+arches:
+  - x86_64
+  - aarch64
+context:
+  bare: true

--- a/tests/integration/data/success/pfc-image-pattern-select/Dockerfile
+++ b/tests/integration/data/success/pfc-image-pattern-select/Dockerfile
@@ -1,0 +1,5 @@
+FROM registry.access.redhat.com/ubi9/ubi:latest AS builder
+RUN dnf install -y test-builder-only
+
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest AS runtime
+RUN microdnf install -y test-runtime-only

--- a/tests/integration/data/success/pfc-image-pattern-select/expected.lock.yaml
+++ b/tests/integration/data/success/pfc-image-pattern-select/expected.lock.yaml
@@ -1,0 +1,21 @@
+---
+lockfileVersion: 1
+lockfileVendor: redhat
+arches:
+- arch: x86_64
+  packages:
+  - url: http://localhost:PORT/test-repo/test-runtime-only-1.0-1.noarch.rpm
+    repoid: test-repo
+    size: 65757
+    checksum: sha256:33764a85df51e5d1df229c82c5f718111a543d90a617fdb973a466194ee6e605
+    name: test-runtime-only
+    evr: 1.0-1
+    sourcerpm: test-runtime-only-1.0-1.src.rpm
+  source:
+  - url: http://localhost:PORT/test-repo/test-runtime-only-1.0-1.src.rpm
+    repoid: test-repo
+    size: 81930
+    checksum: sha256:31aad7c9381775b0a08257dc64e4ab8e6cc728cf57cc968cd83b9582c277df32
+    name: test-runtime-only
+    evr: 1.0-1
+  module_metadata: []

--- a/tests/integration/data/success/pfc-image-pattern-select/repos/test-repo.yaml
+++ b/tests/integration/data/success/pfc-image-pattern-select/repos/test-repo.yaml
@@ -1,0 +1,4 @@
+packages:
+  - nvr: test-builder-only-1.0-1
+
+  - nvr: test-runtime-only-1.0-1

--- a/tests/integration/data/success/pfc-image-pattern-select/rpms.in.yaml
+++ b/tests/integration/data/success/pfc-image-pattern-select/rpms.in.yaml
@@ -1,0 +1,11 @@
+contentOrigin:
+  repos:
+    - repoid: test-repo
+      baseurl: http://localhost:PORT/test-repo
+packagesFromContainerfile:
+  file: Dockerfile
+  imagePattern: ubi-minimal
+arches:
+  - x86_64
+context:
+  bare: true

--- a/tests/integration/data/success/pfc-list-arch-cond/Dockerfile
+++ b/tests/integration/data/success/pfc-list-arch-cond/Dockerfile
@@ -1,0 +1,4 @@
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+RUN microdnf install -y test-common && \
+    [ $(arch) != x86_64 ] || microdnf install -y test-x86-only && \
+    [ $(arch) = aarch64 ] && microdnf install -y test-aarch64-only || true

--- a/tests/integration/data/success/pfc-list-arch-cond/expected.lock.yaml
+++ b/tests/integration/data/success/pfc-list-arch-cond/expected.lock.yaml
@@ -1,0 +1,64 @@
+---
+lockfileVersion: 1
+lockfileVendor: redhat
+arches:
+- arch: aarch64
+  packages:
+  - url: http://localhost:PORT/test-repo/test-aarch64-only-1.0-1.noarch.rpm
+    repoid: test-repo
+    size: 37590
+    checksum: sha256:cbe3bcefb2bba1d42b975906c7812a9c7b126f202f14d644bbed9eca7b4ffede
+    name: test-aarch64-only
+    evr: 1.0-1
+    sourcerpm: test-aarch64-only-1.0-1.src.rpm
+  - url: http://localhost:PORT/test-repo/test-common-1.0-1.noarch.rpm
+    repoid: test-repo
+    size: 33488
+    checksum: sha256:f744da761b44ab0c00f94f391f3386dee075a81c12c9db4bc1ed6f6e4bf23ed8
+    name: test-common
+    evr: 1.0-1
+    sourcerpm: test-common-1.0-1.src.rpm
+  source:
+  - url: http://localhost:PORT/test-repo/test-aarch64-only-1.0-1.src.rpm
+    repoid: test-repo
+    size: 62964
+    checksum: sha256:66ab8abbb8269707905ee7c874ee750b006a083802dbd7b0f2dfea64e0791e54
+    name: test-aarch64-only
+    evr: 1.0-1
+  - url: http://localhost:PORT/test-repo/test-common-1.0-1.src.rpm
+    repoid: test-repo
+    size: 17508
+    checksum: sha256:f2dff9061e5b23158b3cd4e2aae77f235abd6f127e6227935d3be9f0d9e0b5c4
+    name: test-common
+    evr: 1.0-1
+  module_metadata: []
+- arch: x86_64
+  packages:
+  - url: http://localhost:PORT/test-repo/test-common-1.0-1.noarch.rpm
+    repoid: test-repo
+    size: 33488
+    checksum: sha256:f744da761b44ab0c00f94f391f3386dee075a81c12c9db4bc1ed6f6e4bf23ed8
+    name: test-common
+    evr: 1.0-1
+    sourcerpm: test-common-1.0-1.src.rpm
+  - url: http://localhost:PORT/test-repo/test-x86-only-1.0-1.noarch.rpm
+    repoid: test-repo
+    size: 21449
+    checksum: sha256:06afa5c5d23c80153a6ef5db268c7d1758e627b9e18cbef25acc291167a991a1
+    name: test-x86-only
+    evr: 1.0-1
+    sourcerpm: test-x86-only-1.0-1.src.rpm
+  source:
+  - url: http://localhost:PORT/test-repo/test-common-1.0-1.src.rpm
+    repoid: test-repo
+    size: 17508
+    checksum: sha256:f2dff9061e5b23158b3cd4e2aae77f235abd6f127e6227935d3be9f0d9e0b5c4
+    name: test-common
+    evr: 1.0-1
+  - url: http://localhost:PORT/test-repo/test-x86-only-1.0-1.src.rpm
+    repoid: test-repo
+    size: 6732
+    checksum: sha256:7ac5991d586afd7c7cec8080baf22c34e4c9987a410e99746587757bc3c1e664
+    name: test-x86-only
+    evr: 1.0-1
+  module_metadata: []

--- a/tests/integration/data/success/pfc-list-arch-cond/repos/test-repo.yaml
+++ b/tests/integration/data/success/pfc-list-arch-cond/repos/test-repo.yaml
@@ -1,0 +1,6 @@
+packages:
+  - nvr: test-common-1.0-1
+
+  - nvr: test-x86-only-1.0-1
+
+  - nvr: test-aarch64-only-1.0-1

--- a/tests/integration/data/success/pfc-list-arch-cond/rpms.in.yaml
+++ b/tests/integration/data/success/pfc-list-arch-cond/rpms.in.yaml
@@ -1,0 +1,10 @@
+contentOrigin:
+  repos:
+    - repoid: test-repo
+      baseurl: http://localhost:PORT/test-repo
+packagesFromContainerfile: Dockerfile
+arches:
+  - x86_64
+  - aarch64
+context:
+  bare: true

--- a/tests/integration/data/success/pfc-multi-stage/Dockerfile
+++ b/tests/integration/data/success/pfc-multi-stage/Dockerfile
@@ -1,0 +1,8 @@
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest AS builder
+RUN microdnf install -y test-builder-only
+
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest AS middleware
+RUN microdnf install -y test-middleware-only
+
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest AS final
+RUN microdnf install -y test-final-only

--- a/tests/integration/data/success/pfc-multi-stage/expected.lock.yaml
+++ b/tests/integration/data/success/pfc-multi-stage/expected.lock.yaml
@@ -1,0 +1,21 @@
+---
+lockfileVersion: 1
+lockfileVendor: redhat
+arches:
+- arch: x86_64
+  packages:
+  - url: http://localhost:PORT/test-repo/test-middleware-only-1.0-1.noarch.rpm
+    repoid: test-repo
+    size: 32398
+    checksum: sha256:b7c83dcf03b1c12ec91b4243d3bbef0566f1946c40f349a5010bd88c0e78d52e
+    name: test-middleware-only
+    evr: 1.0-1
+    sourcerpm: test-middleware-only-1.0-1.src.rpm
+  source:
+  - url: http://localhost:PORT/test-repo/test-middleware-only-1.0-1.src.rpm
+    repoid: test-repo
+    size: 80376
+    checksum: sha256:416264947a01f24b4fcc7323e5edaf8b86adf95da71123a3af3aa6292a18a8e8
+    name: test-middleware-only
+    evr: 1.0-1
+  module_metadata: []

--- a/tests/integration/data/success/pfc-multi-stage/repos/test-repo.yaml
+++ b/tests/integration/data/success/pfc-multi-stage/repos/test-repo.yaml
@@ -1,0 +1,6 @@
+packages:
+  - nvr: test-builder-only-1.0-1
+
+  - nvr: test-middleware-only-1.0-1
+
+  - nvr: test-final-only-1.0-1

--- a/tests/integration/data/success/pfc-multi-stage/rpms.in.yaml
+++ b/tests/integration/data/success/pfc-multi-stage/rpms.in.yaml
@@ -1,0 +1,11 @@
+contentOrigin:
+  repos:
+    - repoid: test-repo
+      baseurl: http://localhost:PORT/test-repo
+packagesFromContainerfile:
+  file: Dockerfile
+  stageNum: 2
+arches:
+  - x86_64
+context:
+  bare: true

--- a/tests/integration/data/success/pfc-multiple-run/Dockerfile
+++ b/tests/integration/data/success/pfc-multiple-run/Dockerfile
@@ -1,0 +1,7 @@
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+
+RUN microdnf install -y test-first-run
+
+RUN microdnf install -y test-second-run
+
+RUN microdnf install -y test-third-run && microdnf clean all

--- a/tests/integration/data/success/pfc-multiple-run/expected.lock.yaml
+++ b/tests/integration/data/success/pfc-multiple-run/expected.lock.yaml
@@ -1,0 +1,47 @@
+---
+lockfileVersion: 1
+lockfileVendor: redhat
+arches:
+- arch: x86_64
+  packages:
+  - url: http://localhost:PORT/test-repo/test-first-run-1.0-1.noarch.rpm
+    repoid: test-repo
+    size: 54546
+    checksum: sha256:d83d100d564937cb54a94d582702fe01a9f288ab705e027f4de759af92f1e21a
+    name: test-first-run
+    evr: 1.0-1
+    sourcerpm: test-first-run-1.0-1.src.rpm
+  - url: http://localhost:PORT/test-repo/test-second-run-1.0-1.noarch.rpm
+    repoid: test-repo
+    size: 14614
+    checksum: sha256:7a6ae410fbc4562acaa431a8ab424527db37cf4531886b32fac84f94742cabd6
+    name: test-second-run
+    evr: 1.0-1
+    sourcerpm: test-second-run-1.0-1.src.rpm
+  - url: http://localhost:PORT/test-repo/test-third-run-1.0-1.noarch.rpm
+    repoid: test-repo
+    size: 82688
+    checksum: sha256:9a59787ee43333a2d5f43f5b73817a82478ce78a281f36390fbba7701fe22da0
+    name: test-third-run
+    evr: 1.0-1
+    sourcerpm: test-third-run-1.0-1.src.rpm
+  source:
+  - url: http://localhost:PORT/test-repo/test-first-run-1.0-1.src.rpm
+    repoid: test-repo
+    size: 80354
+    checksum: sha256:abfdf62d1444f4c30495d4518b3bf2030f674b795fb71e902f5318c1d1d97b42
+    name: test-first-run
+    evr: 1.0-1
+  - url: http://localhost:PORT/test-repo/test-second-run-1.0-1.src.rpm
+    repoid: test-repo
+    size: 8283
+    checksum: sha256:51a790556d1027442bc1f41e24ecda69e51eb79de1ac341b608a845ee5b831bb
+    name: test-second-run
+    evr: 1.0-1
+  - url: http://localhost:PORT/test-repo/test-third-run-1.0-1.src.rpm
+    repoid: test-repo
+    size: 37213
+    checksum: sha256:7100ed80879aad02592ac5b2ddb7d3b0110fbb8ba0a7ffa948b87ab4848aa13d
+    name: test-third-run
+    evr: 1.0-1
+  module_metadata: []

--- a/tests/integration/data/success/pfc-multiple-run/repos/test-repo.yaml
+++ b/tests/integration/data/success/pfc-multiple-run/repos/test-repo.yaml
@@ -1,0 +1,8 @@
+packages:
+  - nvr: test-first-run-1.0-1
+
+  - nvr: test-second-run-1.0-1
+
+  - nvr: test-third-run-1.0-1
+
+  - nvr: test-decoy-1.0-1

--- a/tests/integration/data/success/pfc-multiple-run/rpms.in.yaml
+++ b/tests/integration/data/success/pfc-multiple-run/rpms.in.yaml
@@ -1,0 +1,9 @@
+contentOrigin:
+  repos:
+    - repoid: test-repo
+      baseurl: http://localhost:PORT/test-repo
+packagesFromContainerfile: Dockerfile
+arches:
+  - x86_64
+context:
+  bare: true

--- a/tests/integration/data/success/pfc-pipe-file-install/Dockerfile
+++ b/tests/integration/data/success/pfc-pipe-file-install/Dockerfile
@@ -1,0 +1,3 @@
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+COPY packages.txt /tmp/
+RUN cat /tmp/packages.txt | xargs dnf install -y

--- a/tests/integration/data/success/pfc-pipe-file-install/expected.lock.yaml
+++ b/tests/integration/data/success/pfc-pipe-file-install/expected.lock.yaml
@@ -1,0 +1,21 @@
+---
+lockfileVersion: 1
+lockfileVendor: redhat
+arches:
+- arch: x86_64
+  packages:
+  - url: http://localhost:PORT/test-repo/test-from-pipe-1.0-1.noarch.rpm
+    repoid: test-repo
+    size: 74474
+    checksum: sha256:ec64e0dbff270c4e2b41c90174889bbcf384a5dca239d1ecddc17699139663c2
+    name: test-from-pipe
+    evr: 1.0-1
+    sourcerpm: test-from-pipe-1.0-1.src.rpm
+  source:
+  - url: http://localhost:PORT/test-repo/test-from-pipe-1.0-1.src.rpm
+    repoid: test-repo
+    size: 56960
+    checksum: sha256:0f8e24b7c25877a4d4b9091501557a4f8aa22e14086c45f690016ffd08d94078
+    name: test-from-pipe
+    evr: 1.0-1
+  module_metadata: []

--- a/tests/integration/data/success/pfc-pipe-file-install/packages.txt
+++ b/tests/integration/data/success/pfc-pipe-file-install/packages.txt
@@ -1,0 +1,1 @@
+test-from-pipe

--- a/tests/integration/data/success/pfc-pipe-file-install/repos/test-repo.yaml
+++ b/tests/integration/data/success/pfc-pipe-file-install/repos/test-repo.yaml
@@ -1,0 +1,4 @@
+packages:
+  - nvr: test-from-pipe-1.0-1
+
+  - nvr: test-decoy-1.0-1

--- a/tests/integration/data/success/pfc-pipe-file-install/rpms.in.yaml
+++ b/tests/integration/data/success/pfc-pipe-file-install/rpms.in.yaml
@@ -1,0 +1,9 @@
+contentOrigin:
+  repos:
+    - repoid: test-repo
+      baseurl: http://localhost:PORT/test-repo
+packagesFromContainerfile: Dockerfile
+arches:
+  - x86_64
+context:
+  bare: true

--- a/tests/integration/data/success/pfc-relative-script/Dockerfile
+++ b/tests/integration/data/success/pfc-relative-script/Dockerfile
@@ -1,0 +1,3 @@
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+COPY install.sh /tmp/
+RUN ./install.sh

--- a/tests/integration/data/success/pfc-relative-script/expected.lock.yaml
+++ b/tests/integration/data/success/pfc-relative-script/expected.lock.yaml
@@ -1,0 +1,21 @@
+---
+lockfileVersion: 1
+lockfileVendor: redhat
+arches:
+- arch: x86_64
+  packages:
+  - url: http://localhost:PORT/test-repo/test-from-relative-1.0-1.noarch.rpm
+    repoid: test-repo
+    size: 57484
+    checksum: sha256:2b20805523598ceb6c76d0e9c2ee9cc0b91bd205cd6d9fd617088343aa72fd14
+    name: test-from-relative
+    evr: 1.0-1
+    sourcerpm: test-from-relative-1.0-1.src.rpm
+  source:
+  - url: http://localhost:PORT/test-repo/test-from-relative-1.0-1.src.rpm
+    repoid: test-repo
+    size: 80006
+    checksum: sha256:a1010ed71de52909d01aebe87cc4c3024dbea60dd3578362e393585b2fb21f8e
+    name: test-from-relative
+    evr: 1.0-1
+  module_metadata: []

--- a/tests/integration/data/success/pfc-relative-script/install.sh
+++ b/tests/integration/data/success/pfc-relative-script/install.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+set -ex
+microdnf install -y test-from-relative

--- a/tests/integration/data/success/pfc-relative-script/repos/test-repo.yaml
+++ b/tests/integration/data/success/pfc-relative-script/repos/test-repo.yaml
@@ -1,0 +1,4 @@
+packages:
+  - nvr: test-from-relative-1.0-1
+
+  - nvr: test-decoy-1.0-1

--- a/tests/integration/data/success/pfc-relative-script/rpms.in.yaml
+++ b/tests/integration/data/success/pfc-relative-script/rpms.in.yaml
@@ -1,0 +1,9 @@
+contentOrigin:
+  repos:
+    - repoid: test-repo
+      baseurl: http://localhost:PORT/test-repo
+packagesFromContainerfile: Dockerfile
+arches:
+  - x86_64
+context:
+  bare: true

--- a/tests/integration/data/success/pfc-script-arch-packages/Dockerfile
+++ b/tests/integration/data/success/pfc-script-arch-packages/Dockerfile
@@ -1,0 +1,3 @@
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+COPY install-deps.sh /tmp/
+RUN /tmp/install-deps.sh

--- a/tests/integration/data/success/pfc-script-arch-packages/expected.lock.yaml
+++ b/tests/integration/data/success/pfc-script-arch-packages/expected.lock.yaml
@@ -1,0 +1,51 @@
+---
+lockfileVersion: 1
+lockfileVendor: redhat
+arches:
+- arch: aarch64
+  packages:
+  - url: http://localhost:PORT/test-repo/test-script-common-1.0-1.noarch.rpm
+    repoid: test-repo
+    size: 20856
+    checksum: sha256:f14f01347d77701ba5bae1828ba5e63eb08c0e38084001fcd86253b5a5890e08
+    name: test-script-common
+    evr: 1.0-1
+    sourcerpm: test-script-common-1.0-1.src.rpm
+  source:
+  - url: http://localhost:PORT/test-repo/test-script-common-1.0-1.src.rpm
+    repoid: test-repo
+    size: 62031
+    checksum: sha256:b46a5695ad72081201c27cfc93a3ae3334e8d0fd678246e075ab641d0d0259df
+    name: test-script-common
+    evr: 1.0-1
+  module_metadata: []
+- arch: x86_64
+  packages:
+  - url: http://localhost:PORT/test-repo/test-script-common-1.0-1.noarch.rpm
+    repoid: test-repo
+    size: 20856
+    checksum: sha256:f14f01347d77701ba5bae1828ba5e63eb08c0e38084001fcd86253b5a5890e08
+    name: test-script-common
+    evr: 1.0-1
+    sourcerpm: test-script-common-1.0-1.src.rpm
+  - url: http://localhost:PORT/test-repo/test-script-x86-1.0-1.noarch.rpm
+    repoid: test-repo
+    size: 67658
+    checksum: sha256:2e9b0865597483646af4f5056b235870f140ae49772b85aa3111da0b6a7b55c2
+    name: test-script-x86
+    evr: 1.0-1
+    sourcerpm: test-script-x86-1.0-1.src.rpm
+  source:
+  - url: http://localhost:PORT/test-repo/test-script-common-1.0-1.src.rpm
+    repoid: test-repo
+    size: 62031
+    checksum: sha256:b46a5695ad72081201c27cfc93a3ae3334e8d0fd678246e075ab641d0d0259df
+    name: test-script-common
+    evr: 1.0-1
+  - url: http://localhost:PORT/test-repo/test-script-x86-1.0-1.src.rpm
+    repoid: test-repo
+    size: 76925
+    checksum: sha256:395bfb002b3a81d7cffaf6212b15fea9c3a279db2b167c768a16c7964eeb6d0d
+    name: test-script-x86
+    evr: 1.0-1
+  module_metadata: []

--- a/tests/integration/data/success/pfc-script-arch-packages/install-deps.sh
+++ b/tests/integration/data/success/pfc-script-arch-packages/install-deps.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -ex
+microdnf install -y test-script-common
+if [ $(arch) = x86_64 ]; then
+    microdnf install -y test-script-x86
+fi

--- a/tests/integration/data/success/pfc-script-arch-packages/repos/test-repo.yaml
+++ b/tests/integration/data/success/pfc-script-arch-packages/repos/test-repo.yaml
@@ -1,0 +1,6 @@
+packages:
+  - nvr: test-script-common-1.0-1
+
+  - nvr: test-script-x86-1.0-1
+
+  - nvr: test-decoy-1.0-1

--- a/tests/integration/data/success/pfc-script-arch-packages/rpms.in.yaml
+++ b/tests/integration/data/success/pfc-script-arch-packages/rpms.in.yaml
@@ -1,0 +1,10 @@
+contentOrigin:
+  repos:
+    - repoid: test-repo
+      baseurl: http://localhost:PORT/test-repo
+packagesFromContainerfile: Dockerfile
+arches:
+  - x86_64
+  - aarch64
+context:
+  bare: true

--- a/tests/integration/data/success/pfc-script-line-continuation/Dockerfile
+++ b/tests/integration/data/success/pfc-script-line-continuation/Dockerfile
@@ -1,0 +1,3 @@
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+COPY install-deps.sh /tmp/
+RUN /tmp/install-deps.sh

--- a/tests/integration/data/success/pfc-script-line-continuation/expected.lock.yaml
+++ b/tests/integration/data/success/pfc-script-line-continuation/expected.lock.yaml
@@ -1,0 +1,34 @@
+---
+lockfileVersion: 1
+lockfileVendor: redhat
+arches:
+- arch: x86_64
+  packages:
+  - url: http://localhost:PORT/test-repo/test-continued-a-1.0-1.noarch.rpm
+    repoid: test-repo
+    size: 86879
+    checksum: sha256:ba1c4b592aa920573e37f9fc74886949f0e8a510bf6a91de2d5820de0a4050d7
+    name: test-continued-a
+    evr: 1.0-1
+    sourcerpm: test-continued-a-1.0-1.src.rpm
+  - url: http://localhost:PORT/test-repo/test-continued-b-1.0-1.noarch.rpm
+    repoid: test-repo
+    size: 11311
+    checksum: sha256:d512ae4ab2a4c77a1879330751f335deeb8c32ab5932cee13ed4490efb197a07
+    name: test-continued-b
+    evr: 1.0-1
+    sourcerpm: test-continued-b-1.0-1.src.rpm
+  source:
+  - url: http://localhost:PORT/test-repo/test-continued-a-1.0-1.src.rpm
+    repoid: test-repo
+    size: 43078
+    checksum: sha256:838889f2e42f3a2bb5ceca6d8a0699cec46a71948451a65a4cf77a2ddb07995e
+    name: test-continued-a
+    evr: 1.0-1
+  - url: http://localhost:PORT/test-repo/test-continued-b-1.0-1.src.rpm
+    repoid: test-repo
+    size: 77088
+    checksum: sha256:720f60962baeeef175b538b18e3e490f3c1c8bd29e5bc8130b1b0bbf86af8750
+    name: test-continued-b
+    evr: 1.0-1
+  module_metadata: []

--- a/tests/integration/data/success/pfc-script-line-continuation/install-deps.sh
+++ b/tests/integration/data/success/pfc-script-line-continuation/install-deps.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -ex
+microdnf install -y \
+    test-continued-a \
+    test-continued-b

--- a/tests/integration/data/success/pfc-script-line-continuation/repos/test-repo.yaml
+++ b/tests/integration/data/success/pfc-script-line-continuation/repos/test-repo.yaml
@@ -1,0 +1,6 @@
+packages:
+  - nvr: test-continued-a-1.0-1
+
+  - nvr: test-continued-b-1.0-1
+
+  - nvr: test-decoy-1.0-1

--- a/tests/integration/data/success/pfc-script-line-continuation/rpms.in.yaml
+++ b/tests/integration/data/success/pfc-script-line-continuation/rpms.in.yaml
@@ -1,0 +1,9 @@
+contentOrigin:
+  repos:
+    - repoid: test-repo
+      baseurl: http://localhost:PORT/test-repo
+packagesFromContainerfile: Dockerfile
+arches:
+  - x86_64
+context:
+  bare: true

--- a/tests/integration/data/success/pfc-script-packages/Dockerfile
+++ b/tests/integration/data/success/pfc-script-packages/Dockerfile
@@ -1,0 +1,3 @@
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+COPY install-deps.sh /tmp/
+RUN /tmp/install-deps.sh

--- a/tests/integration/data/success/pfc-script-packages/expected.lock.yaml
+++ b/tests/integration/data/success/pfc-script-packages/expected.lock.yaml
@@ -1,0 +1,21 @@
+---
+lockfileVersion: 1
+lockfileVendor: redhat
+arches:
+- arch: x86_64
+  packages:
+  - url: http://localhost:PORT/test-repo/test-from-script-1.0-1.noarch.rpm
+    repoid: test-repo
+    size: 12491
+    checksum: sha256:2ab79f31c4d1b25155ade3549733d28b4148a2ba4fe24bfee58014ca6f9bb3ab
+    name: test-from-script
+    evr: 1.0-1
+    sourcerpm: test-from-script-1.0-1.src.rpm
+  source:
+  - url: http://localhost:PORT/test-repo/test-from-script-1.0-1.src.rpm
+    repoid: test-repo
+    size: 83793
+    checksum: sha256:528aa42629845f4ba2fb5d2442f12c9f597b9a6b5a7aac0e2ed2c5fbdf697ff1
+    name: test-from-script
+    evr: 1.0-1
+  module_metadata: []

--- a/tests/integration/data/success/pfc-script-packages/install-deps.sh
+++ b/tests/integration/data/success/pfc-script-packages/install-deps.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+set -ex
+microdnf install -y test-from-script

--- a/tests/integration/data/success/pfc-script-packages/repos/test-repo.yaml
+++ b/tests/integration/data/success/pfc-script-packages/repos/test-repo.yaml
@@ -1,0 +1,4 @@
+packages:
+  - nvr: test-from-script-1.0-1
+
+  - nvr: test-not-in-script-1.0-1

--- a/tests/integration/data/success/pfc-script-packages/rpms.in.yaml
+++ b/tests/integration/data/success/pfc-script-packages/rpms.in.yaml
@@ -1,0 +1,9 @@
+contentOrigin:
+  repos:
+    - repoid: test-repo
+      baseurl: http://localhost:PORT/test-repo
+packagesFromContainerfile: Dockerfile
+arches:
+  - x86_64
+context:
+  bare: true

--- a/tests/integration/data/success/pfc-shell-var/Dockerfile
+++ b/tests/integration/data/success/pfc-shell-var/Dockerfile
@@ -1,0 +1,3 @@
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+RUN EXTRA_PKGS="test-from-shell-var" && \
+    microdnf install -y test-base $EXTRA_PKGS

--- a/tests/integration/data/success/pfc-shell-var/expected.lock.yaml
+++ b/tests/integration/data/success/pfc-shell-var/expected.lock.yaml
@@ -1,0 +1,34 @@
+---
+lockfileVersion: 1
+lockfileVendor: redhat
+arches:
+- arch: x86_64
+  packages:
+  - url: http://localhost:PORT/test-repo/test-base-1.0-1.noarch.rpm
+    repoid: test-repo
+    size: 17899
+    checksum: sha256:e3ca3c340759b02d09400e29a1c739e1f2c2bf8c793b2baf7bcebc3f44da5c53
+    name: test-base
+    evr: 1.0-1
+    sourcerpm: test-base-1.0-1.src.rpm
+  - url: http://localhost:PORT/test-repo/test-from-shell-var-1.0-1.noarch.rpm
+    repoid: test-repo
+    size: 36126
+    checksum: sha256:35c8df2f95f73211aba048c17a8af46af8bdcbfc78b875e919536a2a331d0296
+    name: test-from-shell-var
+    evr: 1.0-1
+    sourcerpm: test-from-shell-var-1.0-1.src.rpm
+  source:
+  - url: http://localhost:PORT/test-repo/test-base-1.0-1.src.rpm
+    repoid: test-repo
+    size: 2327
+    checksum: sha256:6a3850963dc1c535e77b51fcbad730f392c4dad235c1c690a77044e418243fbf
+    name: test-base
+    evr: 1.0-1
+  - url: http://localhost:PORT/test-repo/test-from-shell-var-1.0-1.src.rpm
+    repoid: test-repo
+    size: 71559
+    checksum: sha256:67b2a511e46a824d825fe2efc168316e0659aa1d6248954a11aa02c7b7fb10ef
+    name: test-from-shell-var
+    evr: 1.0-1
+  module_metadata: []

--- a/tests/integration/data/success/pfc-shell-var/repos/test-repo.yaml
+++ b/tests/integration/data/success/pfc-shell-var/repos/test-repo.yaml
@@ -1,0 +1,6 @@
+packages:
+  - nvr: test-base-1.0-1
+
+  - nvr: test-from-shell-var-1.0-1
+
+  - nvr: test-decoy-1.0-1

--- a/tests/integration/data/success/pfc-shell-var/rpms.in.yaml
+++ b/tests/integration/data/success/pfc-shell-var/rpms.in.yaml
@@ -1,0 +1,9 @@
+contentOrigin:
+  repos:
+    - repoid: test-repo
+      baseurl: http://localhost:PORT/test-repo
+packagesFromContainerfile: Dockerfile
+arches:
+  - x86_64
+context:
+  bare: true

--- a/tests/integration/data/success/pfc-src-script/Dockerfile
+++ b/tests/integration/data/success/pfc-src-script/Dockerfile
@@ -1,0 +1,2 @@
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+RUN /src/install.sh

--- a/tests/integration/data/success/pfc-src-script/expected.lock.yaml
+++ b/tests/integration/data/success/pfc-src-script/expected.lock.yaml
@@ -1,0 +1,21 @@
+---
+lockfileVersion: 1
+lockfileVendor: redhat
+arches:
+- arch: x86_64
+  packages:
+  - url: http://localhost:PORT/test-repo/test-from-src-1.0-1.noarch.rpm
+    repoid: test-repo
+    size: 73386
+    checksum: sha256:2e8a77a1d92dcf8fa6a50f0bee31e6d174c6b7de4c8c06e0e132a42d1a3fb012
+    name: test-from-src
+    evr: 1.0-1
+    sourcerpm: test-from-src-1.0-1.src.rpm
+  source:
+  - url: http://localhost:PORT/test-repo/test-from-src-1.0-1.src.rpm
+    repoid: test-repo
+    size: 99563
+    checksum: sha256:e66fba1f6e55242e8dba4a25621866d4c0b2bde520bd6ceca2742d54e1cd0b7b
+    name: test-from-src
+    evr: 1.0-1
+  module_metadata: []

--- a/tests/integration/data/success/pfc-src-script/install.sh
+++ b/tests/integration/data/success/pfc-src-script/install.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+set -ex
+microdnf install -y test-from-src

--- a/tests/integration/data/success/pfc-src-script/repos/test-repo.yaml
+++ b/tests/integration/data/success/pfc-src-script/repos/test-repo.yaml
@@ -1,0 +1,4 @@
+packages:
+  - nvr: test-from-src-1.0-1
+
+  - nvr: test-decoy-1.0-1

--- a/tests/integration/data/success/pfc-src-script/rpms.in.yaml
+++ b/tests/integration/data/success/pfc-src-script/rpms.in.yaml
@@ -1,0 +1,9 @@
+contentOrigin:
+  repos:
+    - repoid: test-repo
+      baseurl: http://localhost:PORT/test-repo
+packagesFromContainerfile: Dockerfile
+arches:
+  - x86_64
+context:
+  bare: true

--- a/tests/integration/data/success/pfc-stage-select/Dockerfile
+++ b/tests/integration/data/success/pfc-stage-select/Dockerfile
@@ -1,0 +1,5 @@
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest AS builder
+RUN microdnf install -y test-builder-only
+
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest AS runtime
+RUN microdnf install -y test-runtime-only

--- a/tests/integration/data/success/pfc-stage-select/expected.lock.yaml
+++ b/tests/integration/data/success/pfc-stage-select/expected.lock.yaml
@@ -1,0 +1,21 @@
+---
+lockfileVersion: 1
+lockfileVendor: redhat
+arches:
+- arch: x86_64
+  packages:
+  - url: http://localhost:PORT/test-repo/test-runtime-only-1.0-1.noarch.rpm
+    repoid: test-repo
+    size: 65757
+    checksum: sha256:33764a85df51e5d1df229c82c5f718111a543d90a617fdb973a466194ee6e605
+    name: test-runtime-only
+    evr: 1.0-1
+    sourcerpm: test-runtime-only-1.0-1.src.rpm
+  source:
+  - url: http://localhost:PORT/test-repo/test-runtime-only-1.0-1.src.rpm
+    repoid: test-repo
+    size: 81930
+    checksum: sha256:31aad7c9381775b0a08257dc64e4ab8e6cc728cf57cc968cd83b9582c277df32
+    name: test-runtime-only
+    evr: 1.0-1
+  module_metadata: []

--- a/tests/integration/data/success/pfc-stage-select/repos/test-repo.yaml
+++ b/tests/integration/data/success/pfc-stage-select/repos/test-repo.yaml
@@ -1,0 +1,4 @@
+packages:
+  - nvr: test-builder-only-1.0-1
+
+  - nvr: test-runtime-only-1.0-1

--- a/tests/integration/data/success/pfc-stage-select/rpms.in.yaml
+++ b/tests/integration/data/success/pfc-stage-select/rpms.in.yaml
@@ -1,0 +1,11 @@
+contentOrigin:
+  repos:
+    - repoid: test-repo
+      baseurl: http://localhost:PORT/test-repo
+packagesFromContainerfile:
+  file: Dockerfile
+  stageName: runtime
+arches:
+  - x86_64
+context:
+  bare: true

--- a/tests/integration/data/success/pfc-subshell-arch-var/Dockerfile
+++ b/tests/integration/data/success/pfc-subshell-arch-var/Dockerfile
@@ -1,0 +1,3 @@
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+RUN EXTRA=$(if [ "$(uname -m)" != "aarch64" ]; then echo -n test-not-aarch64; fi) && \
+    microdnf install -y test-common $EXTRA

--- a/tests/integration/data/success/pfc-subshell-arch-var/expected.lock.yaml
+++ b/tests/integration/data/success/pfc-subshell-arch-var/expected.lock.yaml
@@ -1,0 +1,51 @@
+---
+lockfileVersion: 1
+lockfileVendor: redhat
+arches:
+- arch: aarch64
+  packages:
+  - url: http://localhost:PORT/test-repo/test-common-1.0-1.noarch.rpm
+    repoid: test-repo
+    size: 33488
+    checksum: sha256:f744da761b44ab0c00f94f391f3386dee075a81c12c9db4bc1ed6f6e4bf23ed8
+    name: test-common
+    evr: 1.0-1
+    sourcerpm: test-common-1.0-1.src.rpm
+  source:
+  - url: http://localhost:PORT/test-repo/test-common-1.0-1.src.rpm
+    repoid: test-repo
+    size: 17508
+    checksum: sha256:f2dff9061e5b23158b3cd4e2aae77f235abd6f127e6227935d3be9f0d9e0b5c4
+    name: test-common
+    evr: 1.0-1
+  module_metadata: []
+- arch: x86_64
+  packages:
+  - url: http://localhost:PORT/test-repo/test-common-1.0-1.noarch.rpm
+    repoid: test-repo
+    size: 33488
+    checksum: sha256:f744da761b44ab0c00f94f391f3386dee075a81c12c9db4bc1ed6f6e4bf23ed8
+    name: test-common
+    evr: 1.0-1
+    sourcerpm: test-common-1.0-1.src.rpm
+  - url: http://localhost:PORT/test-repo/test-not-aarch64-1.0-1.noarch.rpm
+    repoid: test-repo
+    size: 50836
+    checksum: sha256:3046fe25e2f92d0a514caf3947917fd55f227eb8f024ae635da9f2a8a25042cc
+    name: test-not-aarch64
+    evr: 1.0-1
+    sourcerpm: test-not-aarch64-1.0-1.src.rpm
+  source:
+  - url: http://localhost:PORT/test-repo/test-common-1.0-1.src.rpm
+    repoid: test-repo
+    size: 17508
+    checksum: sha256:f2dff9061e5b23158b3cd4e2aae77f235abd6f127e6227935d3be9f0d9e0b5c4
+    name: test-common
+    evr: 1.0-1
+  - url: http://localhost:PORT/test-repo/test-not-aarch64-1.0-1.src.rpm
+    repoid: test-repo
+    size: 12605
+    checksum: sha256:fd49b5bba9fab84858efac5dab5f4b4a45ce51705a19187754316ca99f81db65
+    name: test-not-aarch64
+    evr: 1.0-1
+  module_metadata: []

--- a/tests/integration/data/success/pfc-subshell-arch-var/repos/test-repo.yaml
+++ b/tests/integration/data/success/pfc-subshell-arch-var/repos/test-repo.yaml
@@ -1,0 +1,4 @@
+packages:
+  - nvr: test-common-1.0-1
+
+  - nvr: test-not-aarch64-1.0-1

--- a/tests/integration/data/success/pfc-subshell-arch-var/rpms.in.yaml
+++ b/tests/integration/data/success/pfc-subshell-arch-var/rpms.in.yaml
@@ -1,0 +1,10 @@
+contentOrigin:
+  repos:
+    - repoid: test-repo
+      baseurl: http://localhost:PORT/test-repo
+packagesFromContainerfile: Dockerfile
+arches:
+  - x86_64
+  - aarch64
+context:
+  bare: true

--- a/tests/integration/data/success/pfc-yum-install/Dockerfile
+++ b/tests/integration/data/success/pfc-yum-install/Dockerfile
@@ -1,0 +1,2 @@
+FROM registry.access.redhat.com/ubi9/ubi:latest
+RUN yum install -y test-from-yum && yum clean all

--- a/tests/integration/data/success/pfc-yum-install/expected.lock.yaml
+++ b/tests/integration/data/success/pfc-yum-install/expected.lock.yaml
@@ -1,0 +1,21 @@
+---
+lockfileVersion: 1
+lockfileVendor: redhat
+arches:
+- arch: x86_64
+  packages:
+  - url: http://localhost:PORT/test-repo/test-from-yum-1.0-1.noarch.rpm
+    repoid: test-repo
+    size: 37777
+    checksum: sha256:ca3498ff970fbd58a7b94032704b2051ce3344c67e76a9db59e511b76bdaf059
+    name: test-from-yum
+    evr: 1.0-1
+    sourcerpm: test-from-yum-1.0-1.src.rpm
+  source:
+  - url: http://localhost:PORT/test-repo/test-from-yum-1.0-1.src.rpm
+    repoid: test-repo
+    size: 32019
+    checksum: sha256:24171d56d0abebd9b5c0d69d116c62d17157786d78428fe3f2240279f697275b
+    name: test-from-yum
+    evr: 1.0-1
+  module_metadata: []

--- a/tests/integration/data/success/pfc-yum-install/repos/test-repo.yaml
+++ b/tests/integration/data/success/pfc-yum-install/repos/test-repo.yaml
@@ -1,0 +1,4 @@
+packages:
+  - nvr: test-from-yum-1.0-1
+
+  - nvr: test-decoy-1.0-1

--- a/tests/integration/data/success/pfc-yum-install/rpms.in.yaml
+++ b/tests/integration/data/success/pfc-yum-install/rpms.in.yaml
@@ -1,0 +1,9 @@
+contentOrigin:
+  repos:
+    - repoid: test-repo
+      baseurl: http://localhost:PORT/test-repo
+packagesFromContainerfile: Dockerfile
+arches:
+  - x86_64
+context:
+  bare: true

--- a/tests/integration/data/success/reinstall-not-installed/expected.lock.yaml
+++ b/tests/integration/data/success/reinstall-not-installed/expected.lock.yaml
@@ -1,0 +1,8 @@
+---
+lockfileVersion: 1
+lockfileVendor: redhat
+arches:
+- arch: x86_64
+  packages: []
+  source: []
+  module_metadata: []

--- a/tests/integration/data/success/reinstall-not-installed/expected.stdout
+++ b/tests/integration/data/success/reinstall-not-installed/expected.stdout
@@ -1,0 +1,2 @@
+# Reinstalling a package that is not in the base image should warn
+Can not reinstall

--- a/tests/integration/data/success/reinstall-not-installed/repos/test-repo.yaml
+++ b/tests/integration/data/success/reinstall-not-installed/repos/test-repo.yaml
@@ -1,0 +1,2 @@
+packages:
+  - nvr: test-not-in-image-1.0-1

--- a/tests/integration/data/success/reinstall-not-installed/rpms.in.yaml
+++ b/tests/integration/data/success/reinstall-not-installed/rpms.in.yaml
@@ -1,0 +1,11 @@
+contentOrigin:
+  repos:
+    - repoid: test-repo
+      baseurl: http://localhost:PORT/test-repo
+packages: []
+reinstallPackages:
+  - test-not-in-image
+arches:
+  - x86_64
+context:
+  image: registry.access.redhat.com/ubi9/ubi-minimal@sha256:062c52ff973065752b0965787649db2bcf551a6c727a00e95a3eb42cebadbdab

--- a/tests/integration/data/success/reinstall-packages/expected.lock.yaml
+++ b/tests/integration/data/success/reinstall-packages/expected.lock.yaml
@@ -1,0 +1,21 @@
+---
+lockfileVersion: 1
+lockfileVendor: redhat
+arches:
+- arch: x86_64
+  packages:
+  - url: http://localhost:PORT/test-repo/findutils-4.8.0-7.el9.x86_64.rpm
+    repoid: test-repo
+    size: 37555
+    checksum: sha256:4ce7ae7bfa1c4f55db25dc904a271a8ff9854caefc5f51592dd79991a8b59a1b
+    name: findutils
+    evr: 1:4.8.0-7.el9
+    sourcerpm: findutils-4.8.0-7.el9.src.rpm
+  source:
+  - url: http://localhost:PORT/test-repo/findutils-4.8.0-7.el9.src.rpm
+    repoid: test-repo
+    size: 79943
+    checksum: sha256:777d139a1e2f952d008ce6a95165db75afb1d61614730b1a2836b2a5721ce9bf
+    name: findutils
+    evr: 4.8.0-7.el9
+  module_metadata: []

--- a/tests/integration/data/success/reinstall-packages/repos/test-repo.yaml
+++ b/tests/integration/data/success/reinstall-packages/repos/test-repo.yaml
@@ -1,0 +1,5 @@
+packages:
+  - nvr: findutils-1:4.8.0-7.el9
+    arch: x86_64
+
+  - nvr: test-decoy-1.0-1

--- a/tests/integration/data/success/reinstall-packages/rpms.in.yaml
+++ b/tests/integration/data/success/reinstall-packages/rpms.in.yaml
@@ -1,0 +1,11 @@
+contentOrigin:
+  repos:
+    - repoid: test-repo
+      baseurl: http://localhost:PORT/test-repo
+packages: []
+reinstallPackages:
+  - findutils
+arches:
+  - x86_64
+context:
+  image: registry.access.redhat.com/ubi9/ubi-minimal@sha256:062c52ff973065752b0965787649db2bcf551a6c727a00e95a3eb42cebadbdab

--- a/tests/integration/data/success/reinstall-with-upgrade/expected.lock.yaml
+++ b/tests/integration/data/success/reinstall-with-upgrade/expected.lock.yaml
@@ -1,0 +1,21 @@
+---
+lockfileVersion: 1
+lockfileVendor: redhat
+arches:
+- arch: x86_64
+  packages:
+  - url: http://localhost:PORT/test-repo/findutils-99.0-1.x86_64.rpm
+    repoid: test-repo
+    size: 41761
+    checksum: sha256:f16dc7e1623df6fa9421adf3d55a8fb2b43d7c8cab0f3f8a005b2c91387dd889
+    name: findutils
+    evr: 1:99.0-1
+    sourcerpm: findutils-99.0-1.src.rpm
+  source:
+  - url: http://localhost:PORT/test-repo/findutils-99.0-1.src.rpm
+    repoid: test-repo
+    size: 35999
+    checksum: sha256:9480bc1636fd7dc5a2d2ad4b6278db7d44747a30b43d3f1a01cc66d654d3be07
+    name: findutils
+    evr: 99.0-1
+  module_metadata: []

--- a/tests/integration/data/success/reinstall-with-upgrade/repos/test-repo.yaml
+++ b/tests/integration/data/success/reinstall-with-upgrade/repos/test-repo.yaml
@@ -1,0 +1,5 @@
+packages:
+  - nvr: findutils-1:99.0-1
+    arch: x86_64
+
+  - nvr: test-decoy-1.0-1

--- a/tests/integration/data/success/reinstall-with-upgrade/rpms.in.yaml
+++ b/tests/integration/data/success/reinstall-with-upgrade/rpms.in.yaml
@@ -1,0 +1,13 @@
+contentOrigin:
+  repos:
+    - repoid: test-repo
+      baseurl: http://localhost:PORT/test-repo
+packages: []
+reinstallPackages:
+  - findutils
+upgradePackages:
+  - findutils
+arches:
+  - x86_64
+context:
+  image: registry.access.redhat.com/ubi9/ubi-minimal@sha256:062c52ff973065752b0965787649db2bcf551a6c727a00e95a3eb42cebadbdab

--- a/tests/integration/data/success/releasever-from-image/expected.lock.yaml
+++ b/tests/integration/data/success/releasever-from-image/expected.lock.yaml
@@ -1,0 +1,21 @@
+---
+lockfileVersion: 1
+lockfileVendor: redhat
+arches:
+- arch: x86_64
+  packages:
+  - url: http://localhost:PORT/test-repo/9/test-base-1.0-1.noarch.rpm
+    repoid: test-repo
+    size: 17899
+    checksum: sha256:e3ca3c340759b02d09400e29a1c739e1f2c2bf8c793b2baf7bcebc3f44da5c53
+    name: test-base
+    evr: 1.0-1
+    sourcerpm: test-base-1.0-1.src.rpm
+  source:
+  - url: http://localhost:PORT/test-repo/9/test-base-1.0-1.src.rpm
+    repoid: test-repo
+    size: 2327
+    checksum: sha256:6a3850963dc1c535e77b51fcbad730f392c4dad235c1c690a77044e418243fbf
+    name: test-base
+    evr: 1.0-1
+  module_metadata: []

--- a/tests/integration/data/success/releasever-from-image/repos/test-repo/9.yaml
+++ b/tests/integration/data/success/releasever-from-image/repos/test-repo/9.yaml
@@ -1,0 +1,4 @@
+packages:
+  - nvr: test-base-1.0-1
+
+  - nvr: test-decoy-1.0-1

--- a/tests/integration/data/success/releasever-from-image/rpms.in.yaml
+++ b/tests/integration/data/success/releasever-from-image/rpms.in.yaml
@@ -1,0 +1,10 @@
+contentOrigin:
+  repos:
+    - repoid: test-repo
+      baseurl: http://localhost:PORT/test-repo/$releasever
+packages:
+  - test-base
+arches:
+  - x86_64
+context:
+  image: registry.access.redhat.com/ubi9/ubi-minimal:latest

--- a/tests/integration/data/success/releasever-substitution/expected.lock.yaml
+++ b/tests/integration/data/success/releasever-substitution/expected.lock.yaml
@@ -1,0 +1,21 @@
+---
+lockfileVersion: 1
+lockfileVendor: redhat
+arches:
+- arch: x86_64
+  packages:
+  - url: http://localhost:PORT/test-repo/unknown/test-base-1.0-1.noarch.rpm
+    repoid: test-repo
+    size: 17899
+    checksum: sha256:e3ca3c340759b02d09400e29a1c739e1f2c2bf8c793b2baf7bcebc3f44da5c53
+    name: test-base
+    evr: 1.0-1
+    sourcerpm: test-base-1.0-1.src.rpm
+  source:
+  - url: http://localhost:PORT/test-repo/unknown/test-base-1.0-1.src.rpm
+    repoid: test-repo
+    size: 2327
+    checksum: sha256:6a3850963dc1c535e77b51fcbad730f392c4dad235c1c690a77044e418243fbf
+    name: test-base
+    evr: 1.0-1
+  module_metadata: []

--- a/tests/integration/data/success/releasever-substitution/repos/test-repo/unknown.yaml
+++ b/tests/integration/data/success/releasever-substitution/repos/test-repo/unknown.yaml
@@ -1,0 +1,4 @@
+packages:
+  - nvr: test-base-1.0-1
+
+  - nvr: test-decoy-1.0-1

--- a/tests/integration/data/success/releasever-substitution/rpms.in.yaml
+++ b/tests/integration/data/success/releasever-substitution/rpms.in.yaml
@@ -1,0 +1,10 @@
+contentOrigin:
+  repos:
+    - repoid: test-repo
+      baseurl: http://localhost:PORT/test-repo/$releasever
+packages:
+  - test-base
+arches:
+  - x86_64
+context:
+  bare: true

--- a/tests/integration/data/success/repofile-disabled-repo/expected.lock.yaml
+++ b/tests/integration/data/success/repofile-disabled-repo/expected.lock.yaml
@@ -1,0 +1,21 @@
+---
+lockfileVersion: 1
+lockfileVendor: redhat
+arches:
+- arch: x86_64
+  packages:
+  - url: http://localhost:PORT/enabled-repo/test-base-1.0-1.noarch.rpm
+    repoid: enabled-repo
+    size: 17899
+    checksum: sha256:e3ca3c340759b02d09400e29a1c739e1f2c2bf8c793b2baf7bcebc3f44da5c53
+    name: test-base
+    evr: 1.0-1
+    sourcerpm: test-base-1.0-1.src.rpm
+  source:
+  - url: http://localhost:PORT/enabled-repo/test-base-1.0-1.src.rpm
+    repoid: enabled-repo
+    size: 2327
+    checksum: sha256:6a3850963dc1c535e77b51fcbad730f392c4dad235c1c690a77044e418243fbf
+    name: test-base
+    evr: 1.0-1
+  module_metadata: []

--- a/tests/integration/data/success/repofile-disabled-repo/repos/enabled-repo.yaml
+++ b/tests/integration/data/success/repofile-disabled-repo/repos/enabled-repo.yaml
@@ -1,0 +1,4 @@
+packages:
+  - nvr: test-base-1.0-1
+
+  - nvr: test-decoy-1.0-1

--- a/tests/integration/data/success/repofile-disabled-repo/rpms.in.yaml
+++ b/tests/integration/data/success/repofile-disabled-repo/rpms.in.yaml
@@ -1,0 +1,9 @@
+contentOrigin:
+  repofiles:
+    - test.repo
+packages:
+  - test-base
+arches:
+  - x86_64
+context:
+  bare: true

--- a/tests/integration/data/success/repofile-disabled-repo/test.repo
+++ b/tests/integration/data/success/repofile-disabled-repo/test.repo
@@ -1,0 +1,11 @@
+[enabled-repo]
+name=Enabled Repo
+baseurl=http://localhost:PORT/enabled-repo
+gpgcheck=0
+enabled=1
+
+[disabled-repo]
+name=Disabled Repo
+baseurl=http://localhost:PORT/disabled-repo
+gpgcheck=0
+enabled=0

--- a/tests/integration/data/success/repofile-http/expected.lock.yaml
+++ b/tests/integration/data/success/repofile-http/expected.lock.yaml
@@ -1,0 +1,21 @@
+---
+lockfileVersion: 1
+lockfileVendor: redhat
+arches:
+- arch: x86_64
+  packages:
+  - url: http://localhost:PORT/test-repo/test-base-1.0-1.noarch.rpm
+    repoid: test-repo
+    size: 17899
+    checksum: sha256:e3ca3c340759b02d09400e29a1c739e1f2c2bf8c793b2baf7bcebc3f44da5c53
+    name: test-base
+    evr: 1.0-1
+    sourcerpm: test-base-1.0-1.src.rpm
+  source:
+  - url: http://localhost:PORT/test-repo/test-base-1.0-1.src.rpm
+    repoid: test-repo
+    size: 2327
+    checksum: sha256:6a3850963dc1c535e77b51fcbad730f392c4dad235c1c690a77044e418243fbf
+    name: test-base
+    evr: 1.0-1
+  module_metadata: []

--- a/tests/integration/data/success/repofile-http/repos/test-repo.yaml
+++ b/tests/integration/data/success/repofile-http/repos/test-repo.yaml
@@ -1,0 +1,4 @@
+packages:
+  - nvr: test-base-1.0-1
+
+  - nvr: test-decoy-1.0-1

--- a/tests/integration/data/success/repofile-http/rpms.in.yaml
+++ b/tests/integration/data/success/repofile-http/rpms.in.yaml
@@ -1,0 +1,9 @@
+contentOrigin:
+  repofiles:
+    - location: http://localhost:PORT/test.repo
+packages:
+  - test-base
+arches:
+  - x86_64
+context:
+  bare: true

--- a/tests/integration/data/success/repofile-http/test.repo
+++ b/tests/integration/data/success/repofile-http/test.repo
@@ -1,0 +1,4 @@
+[test-repo]
+name=Test Repo
+baseurl=http://localhost:PORT/test-repo
+gpgcheck=0

--- a/tests/integration/data/success/repofile-local/expected.lock.yaml
+++ b/tests/integration/data/success/repofile-local/expected.lock.yaml
@@ -1,0 +1,21 @@
+---
+lockfileVersion: 1
+lockfileVendor: redhat
+arches:
+- arch: x86_64
+  packages:
+  - url: http://localhost:PORT/test-repo/test-base-1.0-1.noarch.rpm
+    repoid: test-repo
+    size: 17899
+    checksum: sha256:e3ca3c340759b02d09400e29a1c739e1f2c2bf8c793b2baf7bcebc3f44da5c53
+    name: test-base
+    evr: 1.0-1
+    sourcerpm: test-base-1.0-1.src.rpm
+  source:
+  - url: http://localhost:PORT/test-repo/test-base-1.0-1.src.rpm
+    repoid: test-repo
+    size: 2327
+    checksum: sha256:6a3850963dc1c535e77b51fcbad730f392c4dad235c1c690a77044e418243fbf
+    name: test-base
+    evr: 1.0-1
+  module_metadata: []

--- a/tests/integration/data/success/repofile-local/repos/test-repo.yaml
+++ b/tests/integration/data/success/repofile-local/repos/test-repo.yaml
@@ -1,0 +1,4 @@
+packages:
+  - nvr: test-base-1.0-1
+
+  - nvr: test-decoy-1.0-1

--- a/tests/integration/data/success/repofile-local/rpms.in.yaml
+++ b/tests/integration/data/success/repofile-local/rpms.in.yaml
@@ -1,0 +1,9 @@
+contentOrigin:
+  repofiles:
+    - test.repo
+packages:
+  - test-base
+arches:
+  - x86_64
+context:
+  bare: true

--- a/tests/integration/data/success/repofile-local/test.repo
+++ b/tests/integration/data/success/repofile-local/test.repo
@@ -1,0 +1,4 @@
+[test-repo]
+name=Test Repo
+baseurl=http://localhost:PORT/test-repo
+gpgcheck=0

--- a/tests/integration/data/success/repofile-multiple-repos/expected.lock.yaml
+++ b/tests/integration/data/success/repofile-multiple-repos/expected.lock.yaml
@@ -1,0 +1,60 @@
+---
+lockfileVersion: 1
+lockfileVendor: redhat
+arches:
+- arch: x86_64
+  packages:
+  - url: http://localhost:PORT/extras-repo/test-optional-1.0-1.noarch.rpm
+    repoid: extras-repo
+    size: 25902
+    checksum: sha256:8d9619306f7c356ca9ef8d54db44f0d30b9f94da8a0a6029afc221e170cef15e
+    name: test-optional
+    evr: 1.0-1
+    sourcerpm: test-optional-1.0-1.src.rpm
+  - url: http://localhost:PORT/main-repo/test-app-1.0-1.x86_64.rpm
+    repoid: main-repo
+    size: 46466
+    checksum: sha256:c21072f7d6fdd53e1392028e10d754746d098ded0e0955d257fde886419d2f4a
+    name: test-app
+    evr: 1.0-1
+    sourcerpm: test-app-1.0-1.src.rpm
+  - url: http://localhost:PORT/main-repo/test-base-1.0-1.noarch.rpm
+    repoid: main-repo
+    size: 17899
+    checksum: sha256:e3ca3c340759b02d09400e29a1c739e1f2c2bf8c793b2baf7bcebc3f44da5c53
+    name: test-base
+    evr: 1.0-1
+    sourcerpm: test-base-1.0-1.src.rpm
+  - url: http://localhost:PORT/main-repo/test-lib-1.0-1.x86_64.rpm
+    repoid: main-repo
+    size: 2054
+    checksum: sha256:64f404a4cf4500918adb216317bf9433b44be32dee9dc516adfeebde286e2ba6
+    name: test-lib
+    evr: 1.0-1
+    sourcerpm: test-lib-1.0-1.src.rpm
+  source:
+  - url: http://localhost:PORT/extras-repo/test-optional-1.0-1.src.rpm
+    repoid: extras-repo
+    size: 99688
+    checksum: sha256:bbe00c0383b406fad721afbbf52941477c97e6b9dfce0009aa96e892f25c7920
+    name: test-optional
+    evr: 1.0-1
+  - url: http://localhost:PORT/main-repo/test-app-1.0-1.src.rpm
+    repoid: main-repo
+    size: 6803
+    checksum: sha256:ee8a029197f249dd51b673fb93d8d7ac5ed496ee11d5b31d0ab3d452ef4208fb
+    name: test-app
+    evr: 1.0-1
+  - url: http://localhost:PORT/main-repo/test-base-1.0-1.src.rpm
+    repoid: main-repo
+    size: 2327
+    checksum: sha256:6a3850963dc1c535e77b51fcbad730f392c4dad235c1c690a77044e418243fbf
+    name: test-base
+    evr: 1.0-1
+  - url: http://localhost:PORT/main-repo/test-lib-1.0-1.src.rpm
+    repoid: main-repo
+    size: 77461
+    checksum: sha256:3ed0c333cf83998369b53e08e2a69ef9be9ff71d4a6137a1cf0eb8e585cb84bd
+    name: test-lib
+    evr: 1.0-1
+  module_metadata: []

--- a/tests/integration/data/success/repofile-multiple-repos/repos/extras-repo.yaml
+++ b/tests/integration/data/success/repofile-multiple-repos/repos/extras-repo.yaml
@@ -1,0 +1,4 @@
+packages:
+  - nvr: test-optional-1.0-1
+
+  - nvr: test-decoy-1.0-1

--- a/tests/integration/data/success/repofile-multiple-repos/repos/main-repo.yaml
+++ b/tests/integration/data/success/repofile-multiple-repos/repos/main-repo.yaml
@@ -1,0 +1,15 @@
+packages:
+  - nvr: test-base-1.0-1
+
+  - nvr: test-lib-1.0-1
+    arch: x86_64
+    provides:
+      - libtest
+
+  - nvr: test-app-1.0-1
+    arch: x86_64
+    requires:
+      - test-lib
+      - test-base
+    recommends:
+      - test-optional

--- a/tests/integration/data/success/repofile-multiple-repos/rpms.in.yaml
+++ b/tests/integration/data/success/repofile-multiple-repos/rpms.in.yaml
@@ -1,0 +1,10 @@
+contentOrigin:
+  repofiles:
+    - test.repo
+packages:
+  - test-app
+arches:
+  - x86_64
+context:
+  bare: true
+installWeakDeps: true

--- a/tests/integration/data/success/repofile-multiple-repos/test.repo
+++ b/tests/integration/data/success/repofile-multiple-repos/test.repo
@@ -1,0 +1,9 @@
+[main-repo]
+name=Main Repo
+baseurl=http://localhost:PORT/main-repo
+gpgcheck=0
+
+[extras-repo]
+name=Extras Repo
+baseurl=http://localhost:PORT/extras-repo
+gpgcheck=0

--- a/tests/integration/data/success/single-package/expected.lock.yaml
+++ b/tests/integration/data/success/single-package/expected.lock.yaml
@@ -1,0 +1,21 @@
+---
+lockfileVersion: 1
+lockfileVendor: redhat
+arches:
+- arch: x86_64
+  packages:
+  - url: http://localhost:PORT/test-repo/test-base-1.0-1.noarch.rpm
+    repoid: test-repo
+    size: 17899
+    checksum: sha256:e3ca3c340759b02d09400e29a1c739e1f2c2bf8c793b2baf7bcebc3f44da5c53
+    name: test-base
+    evr: 1.0-1
+    sourcerpm: test-base-1.0-1.src.rpm
+  source:
+  - url: http://localhost:PORT/test-repo/test-base-1.0-1.src.rpm
+    repoid: test-repo
+    size: 2327
+    checksum: sha256:6a3850963dc1c535e77b51fcbad730f392c4dad235c1c690a77044e418243fbf
+    name: test-base
+    evr: 1.0-1
+  module_metadata: []

--- a/tests/integration/data/success/single-package/repos/test-repo.yaml
+++ b/tests/integration/data/success/single-package/repos/test-repo.yaml
@@ -1,0 +1,4 @@
+packages:
+  - nvr: test-base-1.0-1
+
+  - nvr: test-decoy-1.0-1

--- a/tests/integration/data/success/single-package/rpms.in.yaml
+++ b/tests/integration/data/success/single-package/rpms.in.yaml
@@ -1,0 +1,10 @@
+contentOrigin:
+  repos:
+    - repoid: test-repo
+      baseurl: http://localhost:PORT/test-repo
+packages:
+  - test-base
+arches:
+  - x86_64
+context:
+  bare: true

--- a/tests/integration/data/success/treefile-arch-include/aarch64-packages.yaml
+++ b/tests/integration/data/success/treefile-arch-include/aarch64-packages.yaml
@@ -1,0 +1,2 @@
+packages:
+  - test-aarch64-only

--- a/tests/integration/data/success/treefile-arch-include/expected.lock.yaml
+++ b/tests/integration/data/success/treefile-arch-include/expected.lock.yaml
@@ -1,0 +1,64 @@
+---
+lockfileVersion: 1
+lockfileVendor: redhat
+arches:
+- arch: aarch64
+  packages:
+  - url: http://localhost:PORT/test-repo/test-aarch64-only-1.0-1.noarch.rpm
+    repoid: test-repo
+    size: 37590
+    checksum: sha256:cbe3bcefb2bba1d42b975906c7812a9c7b126f202f14d644bbed9eca7b4ffede
+    name: test-aarch64-only
+    evr: 1.0-1
+    sourcerpm: test-aarch64-only-1.0-1.src.rpm
+  - url: http://localhost:PORT/test-repo/test-common-1.0-1.noarch.rpm
+    repoid: test-repo
+    size: 33488
+    checksum: sha256:f744da761b44ab0c00f94f391f3386dee075a81c12c9db4bc1ed6f6e4bf23ed8
+    name: test-common
+    evr: 1.0-1
+    sourcerpm: test-common-1.0-1.src.rpm
+  source:
+  - url: http://localhost:PORT/test-repo/test-aarch64-only-1.0-1.src.rpm
+    repoid: test-repo
+    size: 62964
+    checksum: sha256:66ab8abbb8269707905ee7c874ee750b006a083802dbd7b0f2dfea64e0791e54
+    name: test-aarch64-only
+    evr: 1.0-1
+  - url: http://localhost:PORT/test-repo/test-common-1.0-1.src.rpm
+    repoid: test-repo
+    size: 17508
+    checksum: sha256:f2dff9061e5b23158b3cd4e2aae77f235abd6f127e6227935d3be9f0d9e0b5c4
+    name: test-common
+    evr: 1.0-1
+  module_metadata: []
+- arch: x86_64
+  packages:
+  - url: http://localhost:PORT/test-repo/test-common-1.0-1.noarch.rpm
+    repoid: test-repo
+    size: 33488
+    checksum: sha256:f744da761b44ab0c00f94f391f3386dee075a81c12c9db4bc1ed6f6e4bf23ed8
+    name: test-common
+    evr: 1.0-1
+    sourcerpm: test-common-1.0-1.src.rpm
+  - url: http://localhost:PORT/test-repo/test-x86-only-1.0-1.noarch.rpm
+    repoid: test-repo
+    size: 21449
+    checksum: sha256:06afa5c5d23c80153a6ef5db268c7d1758e627b9e18cbef25acc291167a991a1
+    name: test-x86-only
+    evr: 1.0-1
+    sourcerpm: test-x86-only-1.0-1.src.rpm
+  source:
+  - url: http://localhost:PORT/test-repo/test-common-1.0-1.src.rpm
+    repoid: test-repo
+    size: 17508
+    checksum: sha256:f2dff9061e5b23158b3cd4e2aae77f235abd6f127e6227935d3be9f0d9e0b5c4
+    name: test-common
+    evr: 1.0-1
+  - url: http://localhost:PORT/test-repo/test-x86-only-1.0-1.src.rpm
+    repoid: test-repo
+    size: 6732
+    checksum: sha256:7ac5991d586afd7c7cec8080baf22c34e4c9987a410e99746587757bc3c1e664
+    name: test-x86-only
+    evr: 1.0-1
+  module_metadata: []

--- a/tests/integration/data/success/treefile-arch-include/repos/test-repo.yaml
+++ b/tests/integration/data/success/treefile-arch-include/repos/test-repo.yaml
@@ -1,0 +1,6 @@
+packages:
+  - nvr: test-common-1.0-1
+
+  - nvr: test-x86-only-1.0-1
+
+  - nvr: test-aarch64-only-1.0-1

--- a/tests/integration/data/success/treefile-arch-include/rpms.in.yaml
+++ b/tests/integration/data/success/treefile-arch-include/rpms.in.yaml
@@ -1,0 +1,10 @@
+contentOrigin:
+  repos:
+    - repoid: test-repo
+      baseurl: http://localhost:PORT/test-repo
+packages: []
+arches:
+  - x86_64
+  - aarch64
+context:
+  rpmOstreeTreefile: treefile.yaml

--- a/tests/integration/data/success/treefile-arch-include/treefile.yaml
+++ b/tests/integration/data/success/treefile-arch-include/treefile.yaml
@@ -1,0 +1,5 @@
+packages:
+  - test-common
+arch-include:
+  x86_64: x86_64-packages.yaml
+  aarch64: aarch64-packages.yaml

--- a/tests/integration/data/success/treefile-arch-include/x86_64-packages.yaml
+++ b/tests/integration/data/success/treefile-arch-include/x86_64-packages.yaml
@@ -1,0 +1,2 @@
+packages:
+  - test-x86-only

--- a/tests/integration/data/success/treefile/base-treefile.yaml
+++ b/tests/integration/data/success/treefile/base-treefile.yaml
@@ -1,0 +1,2 @@
+packages:
+  - test-base

--- a/tests/integration/data/success/treefile/expected.lock.yaml
+++ b/tests/integration/data/success/treefile/expected.lock.yaml
@@ -1,0 +1,60 @@
+---
+lockfileVersion: 1
+lockfileVendor: redhat
+arches:
+- arch: x86_64
+  packages:
+  - url: http://localhost:PORT/test-repo/test-app-1.0-1.noarch.rpm
+    repoid: test-repo
+    size: 32658
+    checksum: sha256:6d69d191e63688e2ca93f8c0d6114cf73affc3a7b864291f93cb4f4d03476a72
+    name: test-app
+    evr: 1.0-1
+    sourcerpm: test-app-1.0-1.src.rpm
+  - url: http://localhost:PORT/test-repo/test-arch-specific-1.0-1.noarch.rpm
+    repoid: test-repo
+    size: 82372
+    checksum: sha256:e44f049f63f1a1fdfe696d499ca52b239b6c157119c26344a49b64ca188bf4fc
+    name: test-arch-specific
+    evr: 1.0-1
+    sourcerpm: test-arch-specific-1.0-1.src.rpm
+  - url: http://localhost:PORT/test-repo/test-base-1.0-1.noarch.rpm
+    repoid: test-repo
+    size: 17899
+    checksum: sha256:e3ca3c340759b02d09400e29a1c739e1f2c2bf8c793b2baf7bcebc3f44da5c53
+    name: test-base
+    evr: 1.0-1
+    sourcerpm: test-base-1.0-1.src.rpm
+  - url: http://localhost:PORT/test-repo/test-from-repo-packages-1.0-1.noarch.rpm
+    repoid: test-repo
+    size: 2034
+    checksum: sha256:289f9a1fa39d2bd9a4bd63dbc8a0625b88627ddf834af2436e8b7b76b611f992
+    name: test-from-repo-packages
+    evr: 1.0-1
+    sourcerpm: test-from-repo-packages-1.0-1.src.rpm
+  source:
+  - url: http://localhost:PORT/test-repo/test-app-1.0-1.src.rpm
+    repoid: test-repo
+    size: 6803
+    checksum: sha256:ee8a029197f249dd51b673fb93d8d7ac5ed496ee11d5b31d0ab3d452ef4208fb
+    name: test-app
+    evr: 1.0-1
+  - url: http://localhost:PORT/test-repo/test-arch-specific-1.0-1.src.rpm
+    repoid: test-repo
+    size: 74729
+    checksum: sha256:d93fafc97e52fec7d7e328a477a69dcb99e7649f52b358460635189dcc1a4d89
+    name: test-arch-specific
+    evr: 1.0-1
+  - url: http://localhost:PORT/test-repo/test-base-1.0-1.src.rpm
+    repoid: test-repo
+    size: 2327
+    checksum: sha256:6a3850963dc1c535e77b51fcbad730f392c4dad235c1c690a77044e418243fbf
+    name: test-base
+    evr: 1.0-1
+  - url: http://localhost:PORT/test-repo/test-from-repo-packages-1.0-1.src.rpm
+    repoid: test-repo
+    size: 67041
+    checksum: sha256:6798b8c07f31ff2672456d31a869b6c12346717247155b4d5c83aa4eba899df9
+    name: test-from-repo-packages
+    evr: 1.0-1
+  module_metadata: []

--- a/tests/integration/data/success/treefile/repos/test-repo.yaml
+++ b/tests/integration/data/success/treefile/repos/test-repo.yaml
@@ -1,0 +1,10 @@
+packages:
+  - nvr: test-base-1.0-1
+
+  - nvr: test-app-1.0-1
+
+  - nvr: test-arch-specific-1.0-1
+
+  - nvr: test-from-repo-packages-1.0-1
+
+  - nvr: test-not-in-treefile-1.0-1

--- a/tests/integration/data/success/treefile/rpms.in.yaml
+++ b/tests/integration/data/success/treefile/rpms.in.yaml
@@ -1,0 +1,9 @@
+contentOrigin:
+  repos:
+    - repoid: test-repo
+      baseurl: http://localhost:PORT/test-repo
+packages: []
+arches:
+  - x86_64
+context:
+  rpmOstreeTreefile: treefile.yaml

--- a/tests/integration/data/success/treefile/treefile.yaml
+++ b/tests/integration/data/success/treefile/treefile.yaml
@@ -1,0 +1,10 @@
+include:
+  - base-treefile.yaml
+packages:
+  - test-app
+packages-x86_64:
+  - test-arch-specific
+repo-packages:
+  - repo: test-repo
+    packages:
+      - test-from-repo-packages

--- a/tests/integration/data/success/upgrade-packages/expected.lock.yaml
+++ b/tests/integration/data/success/upgrade-packages/expected.lock.yaml
@@ -1,0 +1,21 @@
+---
+lockfileVersion: 1
+lockfileVendor: redhat
+arches:
+- arch: x86_64
+  packages:
+  - url: http://localhost:PORT/test-repo/findutils-99.0-1.x86_64.rpm
+    repoid: test-repo
+    size: 41761
+    checksum: sha256:f16dc7e1623df6fa9421adf3d55a8fb2b43d7c8cab0f3f8a005b2c91387dd889
+    name: findutils
+    evr: 1:99.0-1
+    sourcerpm: findutils-99.0-1.src.rpm
+  source:
+  - url: http://localhost:PORT/test-repo/findutils-99.0-1.src.rpm
+    repoid: test-repo
+    size: 35999
+    checksum: sha256:9480bc1636fd7dc5a2d2ad4b6278db7d44747a30b43d3f1a01cc66d654d3be07
+    name: findutils
+    evr: 99.0-1
+  module_metadata: []

--- a/tests/integration/data/success/upgrade-packages/repos/test-repo.yaml
+++ b/tests/integration/data/success/upgrade-packages/repos/test-repo.yaml
@@ -1,0 +1,5 @@
+packages:
+  - nvr: findutils-1:99.0-1
+    arch: x86_64
+
+  - nvr: test-decoy-1.0-1

--- a/tests/integration/data/success/upgrade-packages/rpms.in.yaml
+++ b/tests/integration/data/success/upgrade-packages/rpms.in.yaml
@@ -1,0 +1,11 @@
+contentOrigin:
+  repos:
+    - repoid: test-repo
+      baseurl: http://localhost:PORT/test-repo
+packages: []
+upgradePackages:
+  - findutils
+arches:
+  - x86_64
+context:
+  image: registry.access.redhat.com/ubi9/ubi-minimal@sha256:062c52ff973065752b0965787649db2bcf551a6c727a00e95a3eb42cebadbdab

--- a/tests/integration/data/success/variable-substitution/expected.lock.yaml
+++ b/tests/integration/data/success/variable-substitution/expected.lock.yaml
@@ -1,0 +1,34 @@
+---
+lockfileVersion: 1
+lockfileVendor: redhat
+arches:
+- arch: x86_64
+  packages:
+  - url: http://localhost:PORT/test-repo/packages/test-from-file-1.0-1.noarch.rpm
+    repoid: test-repo
+    size: 93851
+    checksum: sha256:6b55b6f65d9c06ef7b078c5bce5d95737b305544e5f544ee91eb1356440a2a8b
+    name: test-from-file
+    evr: 1.0-1
+    sourcerpm: test-from-file-1.0-1.src.rpm
+  - url: http://localhost:PORT/test-repo/packages/test-from-inline-1.0-1.noarch.rpm
+    repoid: test-repo
+    size: 78480
+    checksum: sha256:406f65b3d190a90de4d390ffcf5fd09678aba23268d44e511bab943e0288bf20
+    name: test-from-inline
+    evr: 1.0-1
+    sourcerpm: test-from-inline-1.0-1.src.rpm
+  source:
+  - url: http://localhost:PORT/test-repo/packages/test-from-file-1.0-1.src.rpm
+    repoid: test-repo
+    size: 40031
+    checksum: sha256:3473da2a7b1a79c55f014474f9b205a67abf577052601a93e307bbeb1734bfef
+    name: test-from-file
+    evr: 1.0-1
+  - url: http://localhost:PORT/test-repo/packages/test-from-inline-1.0-1.src.rpm
+    repoid: test-repo
+    size: 61323
+    checksum: sha256:181e90d84d655530c650b3381691b63049bd7f8f1898e5afcc8b8e3525b601a3
+    name: test-from-inline
+    evr: 1.0-1
+  module_metadata: []

--- a/tests/integration/data/success/variable-substitution/repos/test-repo/packages.yaml
+++ b/tests/integration/data/success/variable-substitution/repos/test-repo/packages.yaml
@@ -1,0 +1,6 @@
+packages:
+  - nvr: test-from-file-1.0-1
+
+  - nvr: test-from-inline-1.0-1
+
+  - nvr: test-decoy-1.0-1

--- a/tests/integration/data/success/variable-substitution/rpms.in.yaml
+++ b/tests/integration/data/success/variable-substitution/rpms.in.yaml
@@ -1,0 +1,15 @@
+variables:
+  - file: vars.env
+  - inline:
+      INLINE_PKG: test-from-inline
+contentOrigin:
+  repos:
+    - repoid: test-repo
+      baseurl: http://localhost:PORT/test-repo/{REPO_SUFFIX}
+packages:
+  - "{FILE_PKG}"
+  - "{INLINE_PKG}"
+arches:
+  - x86_64
+context:
+  bare: true

--- a/tests/integration/data/success/variable-substitution/vars.env
+++ b/tests/integration/data/success/variable-substitution/vars.env
@@ -1,0 +1,2 @@
+FILE_PKG=test-from-file
+REPO_SUFFIX=packages

--- a/tests/integration/data/success/vars-from-image/expected.lock.yaml
+++ b/tests/integration/data/success/vars-from-image/expected.lock.yaml
@@ -1,0 +1,21 @@
+---
+lockfileVersion: 1
+lockfileVendor: redhat
+arches:
+- arch: x86_64
+  packages:
+  - url: http://localhost:PORT/test-repo/9.8/test-base-1.0-1.noarch.rpm
+    repoid: test-repo
+    size: 17899
+    checksum: sha256:e3ca3c340759b02d09400e29a1c739e1f2c2bf8c793b2baf7bcebc3f44da5c53
+    name: test-base
+    evr: 1.0-1
+    sourcerpm: test-base-1.0-1.src.rpm
+  source:
+  - url: http://localhost:PORT/test-repo/9.8/test-base-1.0-1.src.rpm
+    repoid: test-repo
+    size: 2327
+    checksum: sha256:6a3850963dc1c535e77b51fcbad730f392c4dad235c1c690a77044e418243fbf
+    name: test-base
+    evr: 1.0-1
+  module_metadata: []

--- a/tests/integration/data/success/vars-from-image/repos/test-repo/9.8.yaml
+++ b/tests/integration/data/success/vars-from-image/repos/test-repo/9.8.yaml
@@ -1,0 +1,4 @@
+packages:
+  - nvr: test-base-1.0-1
+
+  - nvr: test-decoy-1.0-1

--- a/tests/integration/data/success/vars-from-image/rpms.in.yaml
+++ b/tests/integration/data/success/vars-from-image/rpms.in.yaml
@@ -1,0 +1,11 @@
+contentOrigin:
+  repos:
+    - repoid: test-repo
+      baseurl: http://localhost:PORT/test-repo/{version}
+      varsFromImage: registry.access.redhat.com/ubi9/ubi-minimal@sha256:062c52ff973065752b0965787649db2bcf551a6c727a00e95a3eb42cebadbdab
+packages:
+  - test-base
+arches:
+  - x86_64
+context:
+  bare: true

--- a/tests/integration/data/success/weak-deps-disabled/expected.lock.yaml
+++ b/tests/integration/data/success/weak-deps-disabled/expected.lock.yaml
@@ -1,0 +1,47 @@
+---
+lockfileVersion: 1
+lockfileVendor: redhat
+arches:
+- arch: x86_64
+  packages:
+  - url: http://localhost:PORT/test-repo/test-app-1.0-1.x86_64.rpm
+    repoid: test-repo
+    size: 46466
+    checksum: sha256:c21072f7d6fdd53e1392028e10d754746d098ded0e0955d257fde886419d2f4a
+    name: test-app
+    evr: 1.0-1
+    sourcerpm: test-app-1.0-1.src.rpm
+  - url: http://localhost:PORT/test-repo/test-base-1.0-1.noarch.rpm
+    repoid: test-repo
+    size: 17899
+    checksum: sha256:e3ca3c340759b02d09400e29a1c739e1f2c2bf8c793b2baf7bcebc3f44da5c53
+    name: test-base
+    evr: 1.0-1
+    sourcerpm: test-base-1.0-1.src.rpm
+  - url: http://localhost:PORT/test-repo/test-lib-1.0-1.x86_64.rpm
+    repoid: test-repo
+    size: 2054
+    checksum: sha256:64f404a4cf4500918adb216317bf9433b44be32dee9dc516adfeebde286e2ba6
+    name: test-lib
+    evr: 1.0-1
+    sourcerpm: test-lib-1.0-1.src.rpm
+  source:
+  - url: http://localhost:PORT/test-repo/test-app-1.0-1.src.rpm
+    repoid: test-repo
+    size: 6803
+    checksum: sha256:ee8a029197f249dd51b673fb93d8d7ac5ed496ee11d5b31d0ab3d452ef4208fb
+    name: test-app
+    evr: 1.0-1
+  - url: http://localhost:PORT/test-repo/test-base-1.0-1.src.rpm
+    repoid: test-repo
+    size: 2327
+    checksum: sha256:6a3850963dc1c535e77b51fcbad730f392c4dad235c1c690a77044e418243fbf
+    name: test-base
+    evr: 1.0-1
+  - url: http://localhost:PORT/test-repo/test-lib-1.0-1.src.rpm
+    repoid: test-repo
+    size: 77461
+    checksum: sha256:3ed0c333cf83998369b53e08e2a69ef9be9ff71d4a6137a1cf0eb8e585cb84bd
+    name: test-lib
+    evr: 1.0-1
+  module_metadata: []

--- a/tests/integration/data/success/weak-deps-disabled/repos/test-repo.yaml
+++ b/tests/integration/data/success/weak-deps-disabled/repos/test-repo.yaml
@@ -1,0 +1,17 @@
+packages:
+  - nvr: test-base-1.0-1
+
+  - nvr: test-lib-1.0-1
+    arch: x86_64
+    provides:
+      - libtest
+
+  - nvr: test-app-1.0-1
+    arch: x86_64
+    requires:
+      - test-lib
+      - test-base
+    recommends:
+      - test-optional
+
+  - nvr: test-optional-1.0-1

--- a/tests/integration/data/success/weak-deps-disabled/rpms.in.yaml
+++ b/tests/integration/data/success/weak-deps-disabled/rpms.in.yaml
@@ -1,0 +1,11 @@
+contentOrigin:
+  repos:
+    - repoid: test-repo
+      baseurl: http://localhost:PORT/test-repo
+packages:
+  - test-app
+arches:
+  - x86_64
+context:
+  bare: true
+installWeakDeps: false

--- a/tests/integration/data/success/weak-deps-enabled/expected.lock.yaml
+++ b/tests/integration/data/success/weak-deps-enabled/expected.lock.yaml
@@ -1,0 +1,60 @@
+---
+lockfileVersion: 1
+lockfileVendor: redhat
+arches:
+- arch: x86_64
+  packages:
+  - url: http://localhost:PORT/test-repo/test-app-1.0-1.x86_64.rpm
+    repoid: test-repo
+    size: 46466
+    checksum: sha256:c21072f7d6fdd53e1392028e10d754746d098ded0e0955d257fde886419d2f4a
+    name: test-app
+    evr: 1.0-1
+    sourcerpm: test-app-1.0-1.src.rpm
+  - url: http://localhost:PORT/test-repo/test-base-1.0-1.noarch.rpm
+    repoid: test-repo
+    size: 17899
+    checksum: sha256:e3ca3c340759b02d09400e29a1c739e1f2c2bf8c793b2baf7bcebc3f44da5c53
+    name: test-base
+    evr: 1.0-1
+    sourcerpm: test-base-1.0-1.src.rpm
+  - url: http://localhost:PORT/test-repo/test-lib-1.0-1.x86_64.rpm
+    repoid: test-repo
+    size: 2054
+    checksum: sha256:64f404a4cf4500918adb216317bf9433b44be32dee9dc516adfeebde286e2ba6
+    name: test-lib
+    evr: 1.0-1
+    sourcerpm: test-lib-1.0-1.src.rpm
+  - url: http://localhost:PORT/test-repo/test-optional-1.0-1.noarch.rpm
+    repoid: test-repo
+    size: 25902
+    checksum: sha256:8d9619306f7c356ca9ef8d54db44f0d30b9f94da8a0a6029afc221e170cef15e
+    name: test-optional
+    evr: 1.0-1
+    sourcerpm: test-optional-1.0-1.src.rpm
+  source:
+  - url: http://localhost:PORT/test-repo/test-app-1.0-1.src.rpm
+    repoid: test-repo
+    size: 6803
+    checksum: sha256:ee8a029197f249dd51b673fb93d8d7ac5ed496ee11d5b31d0ab3d452ef4208fb
+    name: test-app
+    evr: 1.0-1
+  - url: http://localhost:PORT/test-repo/test-base-1.0-1.src.rpm
+    repoid: test-repo
+    size: 2327
+    checksum: sha256:6a3850963dc1c535e77b51fcbad730f392c4dad235c1c690a77044e418243fbf
+    name: test-base
+    evr: 1.0-1
+  - url: http://localhost:PORT/test-repo/test-lib-1.0-1.src.rpm
+    repoid: test-repo
+    size: 77461
+    checksum: sha256:3ed0c333cf83998369b53e08e2a69ef9be9ff71d4a6137a1cf0eb8e585cb84bd
+    name: test-lib
+    evr: 1.0-1
+  - url: http://localhost:PORT/test-repo/test-optional-1.0-1.src.rpm
+    repoid: test-repo
+    size: 99688
+    checksum: sha256:bbe00c0383b406fad721afbbf52941477c97e6b9dfce0009aa96e892f25c7920
+    name: test-optional
+    evr: 1.0-1
+  module_metadata: []

--- a/tests/integration/data/success/weak-deps-enabled/repos/test-repo.yaml
+++ b/tests/integration/data/success/weak-deps-enabled/repos/test-repo.yaml
@@ -1,0 +1,19 @@
+packages:
+  - nvr: test-base-1.0-1
+
+  - nvr: test-lib-1.0-1
+    arch: x86_64
+    provides:
+      - libtest
+
+  - nvr: test-app-1.0-1
+    arch: x86_64
+    requires:
+      - test-lib
+      - test-base
+    recommends:
+      - test-optional
+
+  - nvr: test-optional-1.0-1
+
+  - nvr: test-decoy-1.0-1

--- a/tests/integration/data/success/weak-deps-enabled/rpms.in.yaml
+++ b/tests/integration/data/success/weak-deps-enabled/rpms.in.yaml
@@ -1,0 +1,11 @@
+contentOrigin:
+  repos:
+    - repoid: test-repo
+      baseurl: http://localhost:PORT/test-repo
+packages:
+  - test-app
+arches:
+  - x86_64
+context:
+  bare: true
+installWeakDeps: true

--- a/tests/integration/data/success/with-dependencies/expected.lock.yaml
+++ b/tests/integration/data/success/with-dependencies/expected.lock.yaml
@@ -1,0 +1,60 @@
+---
+lockfileVersion: 1
+lockfileVendor: redhat
+arches:
+- arch: x86_64
+  packages:
+  - url: http://localhost:PORT/test-repo/test-app-1.0-1.x86_64.rpm
+    repoid: test-repo
+    size: 46466
+    checksum: sha256:c21072f7d6fdd53e1392028e10d754746d098ded0e0955d257fde886419d2f4a
+    name: test-app
+    evr: 1.0-1
+    sourcerpm: test-app-1.0-1.src.rpm
+  - url: http://localhost:PORT/test-repo/test-base-1.0-1.noarch.rpm
+    repoid: test-repo
+    size: 17899
+    checksum: sha256:e3ca3c340759b02d09400e29a1c739e1f2c2bf8c793b2baf7bcebc3f44da5c53
+    name: test-base
+    evr: 1.0-1
+    sourcerpm: test-base-1.0-1.src.rpm
+  - url: http://localhost:PORT/test-repo/test-lib-1.0-1.x86_64.rpm
+    repoid: test-repo
+    size: 2054
+    checksum: sha256:64f404a4cf4500918adb216317bf9433b44be32dee9dc516adfeebde286e2ba6
+    name: test-lib
+    evr: 1.0-1
+    sourcerpm: test-lib-1.0-1.src.rpm
+  - url: http://localhost:PORT/test-repo/test-optional-1.0-1.noarch.rpm
+    repoid: test-repo
+    size: 25902
+    checksum: sha256:8d9619306f7c356ca9ef8d54db44f0d30b9f94da8a0a6029afc221e170cef15e
+    name: test-optional
+    evr: 1.0-1
+    sourcerpm: test-optional-1.0-1.src.rpm
+  source:
+  - url: http://localhost:PORT/test-repo/test-app-1.0-1.src.rpm
+    repoid: test-repo
+    size: 6803
+    checksum: sha256:ee8a029197f249dd51b673fb93d8d7ac5ed496ee11d5b31d0ab3d452ef4208fb
+    name: test-app
+    evr: 1.0-1
+  - url: http://localhost:PORT/test-repo/test-base-1.0-1.src.rpm
+    repoid: test-repo
+    size: 2327
+    checksum: sha256:6a3850963dc1c535e77b51fcbad730f392c4dad235c1c690a77044e418243fbf
+    name: test-base
+    evr: 1.0-1
+  - url: http://localhost:PORT/test-repo/test-lib-1.0-1.src.rpm
+    repoid: test-repo
+    size: 77461
+    checksum: sha256:3ed0c333cf83998369b53e08e2a69ef9be9ff71d4a6137a1cf0eb8e585cb84bd
+    name: test-lib
+    evr: 1.0-1
+  - url: http://localhost:PORT/test-repo/test-optional-1.0-1.src.rpm
+    repoid: test-repo
+    size: 99688
+    checksum: sha256:bbe00c0383b406fad721afbbf52941477c97e6b9dfce0009aa96e892f25c7920
+    name: test-optional
+    evr: 1.0-1
+  module_metadata: []

--- a/tests/integration/data/success/with-dependencies/repos/test-repo.yaml
+++ b/tests/integration/data/success/with-dependencies/repos/test-repo.yaml
@@ -1,0 +1,19 @@
+packages:
+  - nvr: test-base-1.0-1
+
+  - nvr: test-lib-1.0-1
+    arch: x86_64
+    provides:
+      - libtest
+
+  - nvr: test-app-1.0-1
+    arch: x86_64
+    requires:
+      - test-lib
+      - test-base
+    recommends:
+      - test-optional
+
+  - nvr: test-optional-1.0-1
+
+  - nvr: test-unrelated-1.0-1

--- a/tests/integration/data/success/with-dependencies/rpms.in.yaml
+++ b/tests/integration/data/success/with-dependencies/rpms.in.yaml
@@ -1,0 +1,10 @@
+contentOrigin:
+  repos:
+    - repoid: test-repo
+      baseurl: http://localhost:PORT/test-repo
+packages:
+  - test-app
+arches:
+  - x86_64
+context:
+  bare: true

--- a/tests/integration/generate-expected
+++ b/tests/integration/generate-expected
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""Generate an expected.lock.yaml skeleton for a test case.
+
+Reads all repos/*.yaml in the test case directory, computes the checksums
+and sizes for every package, and writes expected.lock.yaml with all packages
+included. Edit the file to remove packages that should not appear in the
+output.
+
+Usage:
+    tests/integration/generate-expected tests/integration/data/success/my-test
+"""
+
+import sys
+from pathlib import Path
+
+# Allow running from the repo root
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from tests.integration.repogen import _parse_nvr, _pkg_checksum, _pkg_size, _get_sourcerpm
+
+
+def main():
+    if len(sys.argv) != 2:
+        print(f"Usage: {sys.argv[0]} <test-case-dir>", file=sys.stderr)
+        sys.exit(1)
+
+    test_dir = Path(sys.argv[1])
+    if not test_dir.is_dir():
+        print(f"Not a directory: {test_dir}", file=sys.stderr)
+        sys.exit(1)
+
+    rpms_in = test_dir / "rpms.in.yaml"
+    if not rpms_in.exists():
+        print(f"No rpms.in.yaml found in {test_dir}", file=sys.stderr)
+        sys.exit(1)
+
+    # Read arches from rpms.in.yaml
+    import yaml
+
+    with open(rpms_in) as f:
+        config = yaml.safe_load(f)
+    arches = config.get("arches", ["x86_64"])
+
+    # Collect all packages from all repos, tracking each package's origin path.
+    # The relative path of the YAML file (minus extension) determines the URL
+    # prefix:
+    #   repos/test-repo.yaml         -> http://localhost:PORT/test-repo/
+    #   repos/test-repo/x86_64.yaml  -> http://localhost:PORT/test-repo/x86_64/
+    #   repos/test-repo/9.yaml       -> http://localhost:PORT/test-repo/9/
+    repos_dir = test_dir / "repos"
+    if not repos_dir.exists():
+        print(f"No repos/ directory in {test_dir}", file=sys.stderr)
+        sys.exit(1)
+
+    # List of (repo_name, url_prefix, pkg_dict) tuples
+    repo_packages = []
+    for repo_yaml in sorted(repos_dir.rglob("*.yaml")):
+        rel = repo_yaml.relative_to(repos_dir).with_suffix("")
+        rel_str = str(rel)
+        repo_name = rel_str.split("/")[0]
+        url_prefix = f"http://localhost:PORT/{rel_str}"
+        with open(repo_yaml) as f:
+            data = yaml.safe_load(f)
+        for pkg in data.get("packages", []):
+            repo_packages.append((repo_name, url_prefix, pkg))
+
+    # Build lockfile
+    lockfile_arches = []
+    for arch in arches:
+        packages = []
+        sources = []
+        seen_sources = set()
+
+        for repo_name, url_prefix, pkg in repo_packages:
+            name, epoch, version, release = _parse_nvr(pkg["nvr"])
+            pkg_arch = pkg.get("arch", "noarch")
+
+            # Skip src packages in the binary list
+            if pkg_arch == "src":
+                continue
+
+            nevra = f"{name}-{epoch}:{version}-{release}.{pkg_arch}"
+            checksum = _pkg_checksum(nevra)
+            size = _pkg_size(nevra)
+            evr = f"{epoch}:{version}-{release}" if epoch else f"{version}-{release}"
+            location = f"{name}-{version}-{release}.{pkg_arch}.rpm"
+
+            packages.append({
+                "url": f"{url_prefix}/{location}",
+                "repoid": repo_name,
+                "size": size,
+                "checksum": f"sha256:{checksum}",
+                "name": name,
+                "evr": evr,
+                "sourcerpm": _get_sourcerpm(pkg),
+            })
+
+            # Add source RPM
+            sourcerpm = _get_sourcerpm(pkg)
+            if sourcerpm and sourcerpm not in seen_sources:
+                seen_sources.add(sourcerpm)
+                src_nvr = sourcerpm[:-len(".src.rpm")]
+                src_name, src_epoch, src_version, src_release = _parse_nvr(src_nvr)
+                src_nevra = f"{src_name}-{src_epoch}:{src_version}-{src_release}.src"
+                src_checksum = _pkg_checksum(src_nevra)
+                src_size = _pkg_size(src_nevra)
+                src_evr = f"{src_epoch}:{src_version}-{src_release}" if src_epoch else f"{src_version}-{src_release}"
+
+                sources.append({
+                    "url": f"{url_prefix}/{sourcerpm}",
+                    "repoid": repo_name,
+                    "size": src_size,
+                    "checksum": f"sha256:{src_checksum}",
+                    "name": src_name,
+                    "evr": src_evr,
+                })
+
+        packages.sort(key=lambda p: p["name"])
+        sources.sort(key=lambda p: p["name"])
+
+        lockfile_arches.append({
+            "arch": arch,
+            "packages": packages,
+            "source": sources,
+            "module_metadata": [],
+        })
+
+    lockfile = {
+        "lockfileVersion": 1,
+        "lockfileVendor": "redhat",
+        "arches": lockfile_arches,
+    }
+
+    out_path = test_dir / "expected.lock.yaml"
+    with open(out_path, "w") as f:
+        yaml.dump(lockfile, f, sort_keys=False, explicit_start=True)
+
+    print(f"Wrote {out_path}")
+    print(f"Contains {sum(len(a['packages']) for a in lockfile_arches)} packages "
+          f"across {len(arches)} arch(es).")
+    print("Edit the file to remove packages that should not appear in the output.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integration/repogen.py
+++ b/tests/integration/repogen.py
@@ -1,0 +1,300 @@
+"""Generate DNF-compatible repodata from YAML package definitions.
+
+Reads a YAML file describing packages and produces repodata (primary.xml.gz,
+filelists.xml.gz, other.xml.gz, repomd.xml) that DNF can consume. No actual
+.rpm files are created -- DNF only needs the metadata for dependency resolution.
+
+The YAML format is:
+
+    packages:
+      - nvr: test-base-1.0-1
+        arch: x86_64          # default: noarch
+        requires:
+          - some-dep
+        provides:
+          - some-capability
+        recommends:
+          - optional-dep
+        sourcerpm: test-base-1.0-1.src.rpm
+"""
+
+import gzip
+import hashlib
+from pathlib import Path
+from xml.sax.saxutils import escape
+
+import yaml
+
+
+def _parse_nvr(nvr):
+    """Split NVR string into (name, epoch, version, release).
+
+    The NVR is split on the last two hyphens, and the version may contain
+    an epoch prefix (epoch:version):
+      test-app-1.0-1       -> ("test-app", 0, "1.0", "1")
+      foo-2.3.4-5          -> ("foo", 0, "2.3.4", "5")
+      findutils-1:99.0-1   -> ("findutils", 1, "99.0", "1")
+    """
+    parts = nvr.rsplit("-", 2)
+    if len(parts) != 3:
+        raise ValueError(f"Invalid NVR (expected name-version-release): {nvr}")
+    name, version, release = parts
+    epoch = 0
+    if ":" in version:
+        epoch_str, version = version.split(":", 1)
+        epoch = int(epoch_str)
+    return name, epoch, version, release
+
+
+def _pkg_size(nevra):
+    """Derive a unique non-zero package size from the NEVRA string.
+
+    Uses the hash to produce a size in the range 1000-99999, ensuring
+    different packages get different sizes.
+    """
+    h = int(hashlib.sha256(nevra.encode()).hexdigest(), 16)
+    return 1000 + (h % 99000)
+
+
+def _pkg_checksum(nevra):
+    """Derive a deterministic SHA-256 checksum from the NEVRA string."""
+    return hashlib.sha256(nevra.encode()).hexdigest()
+
+
+def _primary_xml(packages):
+    """Generate primary.xml content from a list of package dicts."""
+    parts = [
+        '<?xml version="1.0" encoding="UTF-8"?>\n'
+        '<metadata xmlns="http://linux.duke.edu/metadata/common"'
+        ' xmlns:rpm="http://linux.duke.edu/metadata/rpm"'
+        f' packages="{len(packages)}">\n'
+    ]
+
+    for pkg in packages:
+        name, epoch, version, release = _parse_nvr(pkg["nvr"])
+        arch = pkg.get("arch", "noarch")
+        nevra = f"{name}-{epoch}:{version}-{release}.{arch}"
+        checksum = _pkg_checksum(nevra)
+        size = _pkg_size(nevra)
+        installed_size = size * 2
+        archive_size = size + size // 2
+        location = f"{name}-{version}-{release}.{arch}.rpm"
+        # Default sourcerpm to <name>-<version>-<release>.src.rpm for binary
+        # packages (non-src arch). Source RPMs have no sourcerpm.
+        if arch == "src":
+            sourcerpm = ""
+        else:
+            sourcerpm = pkg.get(
+                "sourcerpm", f"{name}-{version}-{release}.src.rpm"
+            )
+        requires = pkg.get("requires", [])
+        provides = pkg.get("provides", [])
+        recommends = pkg.get("recommends", [])
+
+        escaped_name = escape(name)
+
+        parts.append(
+            f'<package type="rpm">\n'
+            f"  <name>{escaped_name}</name>\n"
+            f"  <arch>{arch}</arch>\n"
+            f'  <version epoch="{epoch}" ver="{escape(version)}"'
+            f' rel="{escape(release)}"/>\n'
+            f'  <checksum type="sha256" pkgid="YES">{checksum}</checksum>\n'
+            f"  <summary>Test package {escaped_name}</summary>\n"
+            f"  <description>Test package</description>\n"
+            f"  <packager/>\n"
+            f"  <url/>\n"
+            f'  <time file="0" build="0"/>\n'
+            f'  <size package="{size}" installed="{installed_size}"'
+            f' archive="{archive_size}"/>\n'
+            f'  <location href="{escape(location)}"/>\n'
+            f"  <format>\n"
+            f"    <rpm:license>MIT</rpm:license>\n"
+            f"    <rpm:group>Unspecified</rpm:group>\n"
+            f"    <rpm:buildhost>localhost</rpm:buildhost>\n"
+            f"    <rpm:sourcerpm>{escape(sourcerpm)}</rpm:sourcerpm>\n"
+        )
+
+        # Self-provide is always added
+        parts.append("    <rpm:provides>\n")
+        parts.append(
+            f'      <rpm:entry name="{escaped_name}" flags="EQ"'
+            f' epoch="{epoch}" ver="{escape(version)}" rel="{escape(release)}"/>\n'
+        )
+        for prov in provides:
+            parts.append(f'      <rpm:entry name="{escape(prov)}"/>\n')
+        parts.append("    </rpm:provides>\n")
+
+        if requires:
+            parts.append("    <rpm:requires>\n")
+            for req in requires:
+                parts.append(f'      <rpm:entry name="{escape(req)}"/>\n')
+            parts.append("    </rpm:requires>\n")
+
+        if recommends:
+            parts.append(
+                "    <rpm:recommends>\n"
+            )
+            for rec in recommends:
+                parts.append(f'      <rpm:entry name="{escape(rec)}"/>\n')
+            parts.append("    </rpm:recommends>\n")
+
+        parts.append("  </format>\n")
+        parts.append("</package>\n")
+
+    parts.append("</metadata>\n")
+    return "".join(parts)
+
+
+def _filelists_xml(packages):
+    """Generate filelists.xml content."""
+    parts = [
+        '<?xml version="1.0" encoding="UTF-8"?>\n'
+        '<filelists xmlns="http://linux.duke.edu/metadata/filelists"'
+        f' packages="{len(packages)}">\n'
+    ]
+    for pkg in packages:
+        name, epoch, version, release = _parse_nvr(pkg["nvr"])
+        arch = pkg.get("arch", "noarch")
+        nevra = f"{name}-{epoch}:{version}-{release}.{arch}"
+        checksum = _pkg_checksum(nevra)
+        files = pkg.get("files", [])
+        parts.append(
+            f'<package pkgid="{checksum}" name="{escape(name)}"'
+            f' arch="{arch}">\n'
+            f'  <version epoch="{epoch}" ver="{escape(version)}"'
+            f' rel="{escape(release)}"/>\n'
+        )
+        for filepath in files:
+            parts.append(f"  <file>{escape(filepath)}</file>\n")
+        parts.append("</package>\n")
+    parts.append("</filelists>\n")
+    return "".join(parts)
+
+
+def _other_xml(packages):
+    """Generate other.xml content."""
+    parts = [
+        '<?xml version="1.0" encoding="UTF-8"?>\n'
+        '<otherdata xmlns="http://linux.duke.edu/metadata/other"'
+        f' packages="{len(packages)}">\n'
+    ]
+    for pkg in packages:
+        name, epoch, version, release = _parse_nvr(pkg["nvr"])
+        arch = pkg.get("arch", "noarch")
+        nevra = f"{name}-{epoch}:{version}-{release}.{arch}"
+        checksum = _pkg_checksum(nevra)
+        parts.append(
+            f'<package pkgid="{checksum}" name="{escape(name)}"'
+            f' arch="{arch}">\n'
+            f'  <version epoch="{epoch}" ver="{escape(version)}"'
+            f' rel="{escape(release)}"/>\n'
+            f"</package>\n"
+        )
+    parts.append("</otherdata>\n")
+    return "".join(parts)
+
+
+def _write_gz(path, content):
+    """Write content as a gzip-compressed file. Returns (sha256, size)."""
+    data = content.encode("utf-8")
+    with gzip.GzipFile(path, "wb", mtime=0) as f:
+        f.write(data)
+    with open(path, "rb") as f:
+        compressed = f.read()
+    return hashlib.sha256(compressed).hexdigest(), len(compressed)
+
+
+def _repomd_xml(records):
+    """Generate repomd.xml content.
+
+    records is a list of (md_type, sha256, size, filename) tuples.
+    """
+    parts = [
+        '<?xml version="1.0" encoding="UTF-8"?>\n'
+        '<repomd xmlns="http://linux.duke.edu/metadata/repo">\n'
+    ]
+    for md_type, checksum, size, filename in records:
+        parts.append(
+            f'  <data type="{md_type}">\n'
+            f'    <checksum type="sha256">{checksum}</checksum>\n'
+            f'    <location href="repodata/{filename}"/>\n'
+            f"    <size>{size}</size>\n"
+            f"  </data>\n"
+        )
+    parts.append("</repomd>\n")
+    return "".join(parts)
+
+
+def create_repo(repo_dir, packages):
+    """Create repodata in repo_dir from a list of package dicts.
+
+    Each package dict should have at minimum an 'nvr' key.
+    Returns the repo_dir path.
+    """
+    repo_dir = Path(repo_dir)
+    repodata_dir = repo_dir / "repodata"
+    repodata_dir.mkdir(parents=True, exist_ok=True)
+
+    # Collect source packages from sourcerpm fields
+    source_packages = _collect_source_packages(packages)
+    all_packages = list(packages) + source_packages
+
+    records = []
+    for md_type, generator in [
+        ("primary", _primary_xml),
+        ("filelists", _filelists_xml),
+        ("other", _other_xml),
+    ]:
+        filename = f"{md_type}.xml.gz"
+        path = repodata_dir / filename
+        content = generator(all_packages)
+        checksum, size = _write_gz(str(path), content)
+        records.append((md_type, checksum, size, filename))
+
+    with open(repodata_dir / "repomd.xml", "w") as f:
+        f.write(_repomd_xml(records))
+
+    return str(repo_dir)
+
+
+def _get_sourcerpm(pkg):
+    """Get the sourcerpm for a package, applying the default if needed."""
+    arch = pkg.get("arch", "noarch")
+    if arch == "src":
+        return ""
+    name, epoch, version, release = _parse_nvr(pkg["nvr"])
+    return pkg.get("sourcerpm", f"{name}-{version}-{release}.src.rpm")
+
+
+def _collect_source_packages(packages):
+    """Create source package entries from sourcerpm fields.
+
+    For each binary package that has a sourcerpm, create a corresponding
+    source package entry (arch=src) if one doesn't already exist.
+    """
+    seen = set()
+    source_packages = []
+    for pkg in packages:
+        sourcerpm = _get_sourcerpm(pkg)
+        if not sourcerpm or sourcerpm in seen:
+            continue
+        seen.add(sourcerpm)
+        if not sourcerpm.endswith(".src.rpm"):
+            continue
+        nvr = sourcerpm[: -len(".src.rpm")]
+        source_packages.append({"nvr": nvr, "arch": "src"})
+    return source_packages
+
+
+def create_repo_from_yaml(yaml_path, repo_dir):
+    """Read package definitions from a YAML file and generate repodata.
+
+    Returns the repo_dir path.
+    """
+    yaml_path = Path(yaml_path)
+    with open(yaml_path) as f:
+        data = yaml.safe_load(f)
+
+    packages = data.get("packages", [])
+    return create_repo(repo_dir, packages)

--- a/tests/integration/skopeo-cache
+++ b/tests/integration/skopeo-cache
@@ -1,0 +1,113 @@
+#!/bin/bash
+# Caching wrapper for skopeo used in integration tests.
+#
+# Caches the results of `skopeo inspect` and `skopeo copy` commands in
+# $SKOPEO_CACHE_DIR. If the cache entry exists, the result is served from
+# cache without hitting the network. Otherwise, real skopeo is called and
+# the result is stored.
+#
+# Thread-safe: uses atomic moves (mv) to avoid corruption when multiple
+# workers write to the same cache concurrently.
+#
+# Set SKOPEO_CACHE_DIR to a persistent directory to avoid re-downloading
+# images across test runs. If not set, this wrapper is a no-op passthrough
+# to real skopeo.
+
+set -euo pipefail
+
+# Find the real skopeo (skip this script on PATH)
+REAL_SKOPEO=""
+SELF="$(realpath "$0")"
+IFS=: read -ra path_dirs <<< "$PATH"
+for dir in "${path_dirs[@]}"; do
+    candidate="$dir/skopeo"
+    if [[ -x "$candidate" ]] && [[ "$(realpath "$candidate")" != "$SELF" ]]; then
+        REAL_SKOPEO="$candidate"
+        break
+    fi
+done
+
+if [[ -z "$REAL_SKOPEO" ]]; then
+    echo "skopeo-cache: could not find real skopeo on PATH" >&2
+    exit 1
+fi
+
+# If no cache dir configured, just pass through
+if [[ -z "${SKOPEO_CACHE_DIR:-}" ]]; then
+    exec "$REAL_SKOPEO" "$@"
+fi
+
+# Detect the subcommand (inspect or copy) while accounting for
+# --override-arch and other flags before the subcommand.
+# Also collect the cache-relevant arguments (excluding the destination
+# path for copy, which changes every run).
+subcmd=""
+dest_dir=""
+cache_args=""
+args=("$@")
+for i in "${!args[@]}"; do
+    case "${args[$i]}" in
+        inspect)
+            subcmd="inspect"
+            # For inspect, all args are cache-relevant
+            cache_args="$*"
+            break
+            ;;
+        copy)
+            subcmd="copy"
+            # For copy, cache key is everything except the dir: destination
+            for j in "${!args[@]}"; do
+                if [[ "${args[$j]}" == dir:* ]]; then
+                    dest_dir="${args[$j]#dir:}"
+                else
+                    cache_args="$cache_args ${args[$j]}"
+                fi
+            done
+            break
+            ;;
+    esac
+done
+
+cache_key=$(echo "$cache_args" | sha256sum | cut -d' ' -f1)
+
+case "$subcmd" in
+    inspect)
+        cache_file="$SKOPEO_CACHE_DIR/inspect/$cache_key"
+        if [[ -f "$cache_file" ]]; then
+            cat "$cache_file"
+            exit 0
+        fi
+        mkdir -p "$SKOPEO_CACHE_DIR/inspect"
+        tmpfile=$(mktemp "$SKOPEO_CACHE_DIR/inspect/.tmp.XXXXXX")
+        trap 'rm -f "$tmpfile"' EXIT
+        "$REAL_SKOPEO" "$@" | tee "$tmpfile"
+        if mv "$tmpfile" "$cache_file" 2>/dev/null; then
+            trap - EXIT
+        fi
+        ;;
+    copy)
+        # Only cache dir: destinations; other transports are passed through.
+        if [[ -z "$dest_dir" ]]; then
+            exec "$REAL_SKOPEO" "$@"
+        fi
+        cache_entry="$SKOPEO_CACHE_DIR/copy/$cache_key"
+        if [[ -d "$cache_entry" ]]; then
+            mkdir -p "$dest_dir"
+            cp -a "$cache_entry/." "$dest_dir/"
+            exit 0
+        fi
+        # Run real skopeo
+        "$REAL_SKOPEO" "$@"
+        # Cache the result atomically
+        mkdir -p "$SKOPEO_CACHE_DIR/copy"
+        tmpdir=$(mktemp -d "$SKOPEO_CACHE_DIR/copy/.tmp.XXXXXX")
+        trap 'rm -rf "$tmpdir"' EXIT
+        cp -a "$dest_dir/." "$tmpdir/"
+        if mv "$tmpdir" "$cache_entry" 2>/dev/null; then
+            trap - EXIT
+        fi
+        ;;
+    *)
+        exec "$REAL_SKOPEO" "$@"
+        ;;
+esac

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -1,0 +1,65 @@
+"""Integration tests for rpm-lockfile-prototype.
+
+These tests invoke the tool as a subprocess and validate the output lockfile
+against committed expected lockfiles.
+
+Test cases are autodiscovered from the data/ directory:
+  - data/success/<name>/  -- expected to succeed, lockfile compared to expected.lock.yaml
+  - data/failure/<name>/  -- expected to fail with non-zero exit code
+
+If a test case directory contains expected.stdout or expected.stderr, each
+non-empty, non-comment line is checked as a substring that must appear
+somewhere in the corresponding output stream.
+"""
+
+import pytest
+
+from .conftest import (
+    FAILURE_DIR,
+    SUCCESS_DIR,
+    load_expected,
+    load_expected_stderr,
+    load_expected_stdout,
+    run_test_case,
+    run_test_case_ok,
+)
+
+SUCCESSFUL_CASES = sorted(d.name for d in SUCCESS_DIR.iterdir() if d.is_dir())
+FAILURE_CASES = sorted(d.name for d in FAILURE_DIR.iterdir() if d.is_dir())
+
+
+def _check_output(test_case, result):
+    """Check stdout and stderr against expected patterns if defined."""
+    for stream_name, loader in [("stdout", load_expected_stdout), ("stderr", load_expected_stderr)]:
+        patterns = loader(test_case)
+        if patterns is None:
+            continue
+        actual = getattr(result, stream_name)
+        for pattern in patterns:
+            assert pattern in actual, (
+                f"Expected pattern not found in {stream_name}: {pattern!r}\n"
+                f"Actual {stream_name}:\n{actual}"
+            )
+
+
+@pytest.mark.parametrize("test_case", SUCCESSFUL_CASES)
+def test_lockfile_matches_expected(
+    test_case, tmp_path, shared_cache, _skopeo_wrapper_dir, _skopeo_cache_dir
+):
+    result = run_test_case_ok(
+        test_case, tmp_path, shared_cache, _skopeo_wrapper_dir, _skopeo_cache_dir
+    )
+    expected = load_expected(test_case, result.port)
+    assert result.lockfile == expected
+    _check_output(test_case, result)
+
+
+@pytest.mark.parametrize("test_case", FAILURE_CASES)
+def test_expected_failure(
+    test_case, tmp_path, shared_cache, _skopeo_wrapper_dir, _skopeo_cache_dir
+):
+    result = run_test_case(
+        test_case, tmp_path, shared_cache, _skopeo_wrapper_dir, _skopeo_cache_dir
+    )
+    assert result.rc != 0
+    _check_output(test_case, result)


### PR DESCRIPTION
Black-box tests that invoke rpm-lockfile-prototype as a subprocess, feed it input files, and validate the output lockfile against committed expected lockfiles.

Test cases are self-contained directories under tests/integration/data/, autodiscovered at collection time:
  - data/success/<name>/ -- tool must exit 0, lockfile compared to expected.lock.yaml
  - data/failure/<name>/ -- tool must exit non-zero

Each test case defines its own repos via YAML package definitions. The repogen module generates DNF-compatible repodata from these definitions (no rpmbuild or createrepo_c needed). A per-test HTTP server on a random port serves the generated repos.

Test harness features:
  - Subprocess-only invocation (survives a tool rewrite to another lang)
  - Per-test HTTP server for repo hosting
  - Skopeo caching wrapper for faster image downloads
  - expected.stdout / expected.stderr for log message validation
  - generate-expected helper for authoring expected lockfiles
  - Coverage collection from subprocesses via pytest-cov

Includes tests for:
  - Basic dependency resolution, weak deps, multiple packages
  - $basearch and $releasever substitution
  - Multi-repo and multi-arch resolution
  - Filelists download (file-based dependencies)
  - Container image rpmdb extraction (UBI 9, UBI 10)
  - Dependency satisfied by / upgrade / reinstall base image packages
  - Containerfile stage selection (by name, number, image pattern)
  - Containerfile package extraction (install, upgrade, reinstall, ARG expansion, arch conditionals, script extraction)
  - packagesFromContainerfile (explicit, additive, bare)
  - Repofile content origin (local, HTTP, disabled repos, multi-repo)
  - rpm-ostree treefile (packages, arch-include, repo-packages, include)
  - container.yaml / flatpak package extraction with platform filtering
  - Variable substitution (inline, file, varsFromImage)
  - matchContextVersions version pinning
  - assumeProvides, noSources
  - Error cases (missing package, reinstall failures)