### PR TITLE
Refactor containerfile parsing

### DIFF
--- a/rpm_lockfile/__init__.py
+++ b/rpm_lockfile/__init__.py
@@ -491,8 +491,7 @@ def logging_setup(debug=False):
 
 @dataclass
 class ContainerfilePackages:
-    common: set[str] = field(default_factory=set)
-    arch_specific: dict[str, set[str]] = field(default_factory=dict)
+    packages: set[str] = field(default_factory=set)
     upgrade: set[str] = field(default_factory=set)
     reinstall: set[str] = field(default_factory=set)
     module_enable: set[str] = field(default_factory=set)
@@ -502,32 +501,27 @@ class ContainerfilePackages:
 def _extract_containerfile_packages(
     containerfile: str,
     context: dict,
-    arches: list[str] | None = None,
+    arch: str | None = None,
 ) -> ContainerfilePackages:
     result = ContainerfilePackages()
 
     cf_path = Path(containerfile)
     source_dir = cf_path.parent
-    stages = analyze_containerfile_stages(cf_path, source_dir=source_dir, arches=arches)
+    stages = analyze_containerfile_stages(cf_path, source_dir=source_dir, arch=arch)
     selected = select_stage(stages, **_get_containerfile_filters(context))
     if selected:
-        result.common.update(selected.packages)
-        for arch, pkgs in selected.arch_packages.items():
-            result.arch_specific.setdefault(arch, set()).update(pkgs)
+        result.packages.update(selected.packages)
         result.upgrade.update(selected.update_targets)
         result.reinstall.update(selected.reinstall_targets)
         result.module_enable.update(selected.module_specs)
         result.builddep = list(selected.builddep_packages)
-    if result.common or result.arch_specific:
+    if result.packages:
         logger.info(
-            "Extracted %d common and %d arch-specific packages from Containerfile",
-            len(result.common),
-            sum(len(v) for v in result.arch_specific.values()),
+            "Extracted %d packages from Containerfile for %s",
+            len(result.packages),
+            arch or "unknown arch",
         )
-        if result.common:
-            logger.debug("Containerfile packages: %s", sorted(result.common))
-        for arch, pkgs in sorted(result.arch_specific.items()):
-            logger.debug("Containerfile packages [%s]: %s", arch, sorted(pkgs))
+        logger.debug("Containerfile packages: %s", sorted(result.packages))
         if result.upgrade:
             logger.debug("Containerfile upgrade packages: %s", sorted(result.upgrade))
         if result.reinstall:
@@ -616,8 +610,6 @@ def main():
 
     repos = collect_content_origins(config_dir, config["contentOrigin"], variables)
 
-    cf_pkgs = ContainerfilePackages()
-
     # Determine rpmdb source — independent of package extraction.
     containerfile = None
     is_image_context = True
@@ -655,46 +647,22 @@ def main():
         )
 
     # Determine package extraction source — independent of rpmdb mode.
+    # The actual extraction runs per-arch inside the loop below.
     pfc_spec = config.get("packagesFromContainerfile")
+    cf_containerfile = None
+    cf_context = {}
 
     if pfc_spec:
-        pfc_context = {"containerfile": pfc_spec}
-        pfc_path = _get_containerfile_path(config_dir, pfc_context)
-        try:
-            cf_pkgs = _extract_containerfile_packages(pfc_path, pfc_context, arches)
-        except Exception:
-            logger.warning(
-                "Failed to extract packages from Containerfile %s; "
-                "falling back to explicitly listed packages only.",
-                pfc_path,
-                exc_info=True,
-            )
-
-        if cf_pkgs.builddep:
-            source_dir = Path(pfc_path).parent
-            builddep_resolved = resolve_builddep_packages(cf_pkgs.builddep, source_dir)
-            cf_pkgs.common |= builddep_resolved
-
+        cf_context = {"containerfile": pfc_spec}
+        cf_containerfile = _get_containerfile_path(config_dir, cf_context)
     elif containerfile and not config.get("packages"):
         logger.warning(
             "Implicit package extraction from Containerfile is deprecated. "
             "Add 'packagesFromContainerfile' with the Containerfile path "
             "to your config file to preserve this behavior."
         )
-        try:
-            cf_pkgs = _extract_containerfile_packages(containerfile, context, arches)
-        except Exception:
-            logger.warning(
-                "Failed to extract packages from Containerfile %s; "
-                "falling back to explicitly listed packages only.",
-                containerfile,
-                exc_info=True,
-            )
-
-        if cf_pkgs.builddep:
-            source_dir = Path(containerfile).parent
-            builddep_resolved = resolve_builddep_packages(cf_pkgs.builddep, source_dir)
-            cf_pkgs.common |= builddep_resolved
+        cf_containerfile = containerfile
+        cf_context = context
 
     if config.get("matchContextVersions") and not is_image_context:
         parser.error(
@@ -713,9 +681,29 @@ def main():
         elif args.flatpak or context.get("flatpak"):
             packages = read_packages_from_container_yaml(arch)
 
-        # Merge Containerfile-extracted packages
-        packages |= cf_pkgs.common
-        packages |= cf_pkgs.arch_specific.get(arch, set())
+        # Extract packages from Containerfile for this architecture
+        cf_pkgs = ContainerfilePackages()
+        if cf_containerfile:
+            try:
+                cf_pkgs = _extract_containerfile_packages(
+                    cf_containerfile, cf_context, arch
+                )
+            except Exception:
+                logger.warning(
+                    "Failed to extract packages from Containerfile %s; "
+                    "falling back to explicitly listed packages only.",
+                    cf_containerfile,
+                    exc_info=True,
+                )
+
+            if cf_pkgs.builddep:
+                source_dir = Path(cf_containerfile).parent
+                builddep_resolved = resolve_builddep_packages(
+                    cf_pkgs.builddep, source_dir
+                )
+                cf_pkgs.packages |= builddep_resolved
+
+        packages |= cf_pkgs.packages
 
         data["arches"].append(
             process_arch(

--- a/rpm_lockfile/containerfile_packages.py
+++ b/rpm_lockfile/containerfile_packages.py
@@ -38,7 +38,6 @@ class StagePackages:
     stage_name: str = ""
     packages: list[str] = field(default_factory=list)
     has_update: bool = False
-    arch_packages: dict[str, list[str]] = field(default_factory=dict)
     update_targets: list[str] = field(default_factory=list)
     reinstall_targets: list[str] = field(default_factory=list)
     builddep_packages: list[str] = field(default_factory=list)
@@ -49,17 +48,11 @@ class StagePackages:
         Merge another StagePackages into this one, combining packages
         and update targets.
         """
-        merged_arch = dict(self.arch_packages)
-        for arch, pkgs in other.arch_packages.items():
-            existing = set(merged_arch.get(arch, []))
-            existing.update(pkgs)
-            merged_arch[arch] = sorted(existing)
         return StagePackages(
             base_image=self.base_image or other.base_image,
             stage_name=self.stage_name or other.stage_name,
             packages=sorted(set(self.packages + other.packages)),
             has_update=self.has_update or other.has_update,
-            arch_packages=merged_arch,
             update_targets=sorted(set(self.update_targets + other.update_targets)),
             reinstall_targets=sorted(
                 set(self.reinstall_targets + other.reinstall_targets)
@@ -230,8 +223,8 @@ def extract_packages_from_file_installs(
     copy_map: dict[str, str],
     source_dir: Path,
     env_vars: dict[str, str] | None = None,
-    arches: list[str] | None = None,
-) -> tuple[list[str], dict[str, list[str]]]:
+    arch: str | None = None,
+) -> list[str]:
     """
     Extract package names from install commands that read packages from
     a file via stdin redirect or pipe.
@@ -241,23 +234,19 @@ def extract_packages_from_file_installs(
         grep -vE '^(#|$)' /tmp/pkgs.txt | xargs dnf install -y
         cat /tmp/pkgs.txt | xargs dnf install -y
 
-    When the file path contains an arch keyword like $(arch), resolves
-    it per-architecture and returns arch-specific packages separately.
+    When the file path contains an arch keyword like $(arch), substitutes
+    the current architecture to resolve the correct file.
 
     Arg(s):
         run_values (list[str]): RUN command bodies or joined script lines.
         copy_map (dict[str, str]): Container path to source path mapping.
         source_dir (Path): Source tree root.
         env_vars (dict[str, str] | None): Variables for path resolution.
-        arches (list[str] | None): Architectures to resolve for arch-specific
-            file paths.
+        arch (str | None): Architecture being resolved.
     Return Value(s):
-        tuple[list[str], dict[str, list[str]]]:
-            - Sorted unique package names (common to all arches).
-            - Dict mapping arch to sorted unique package names for that arch only.
+        list[str]: Sorted unique package names.
     """
     variables = dict(env_vars or {})
-    arch_list = arches or []
     redirect_re = re.compile(
         r"""
         (?:xargs\s+(?:\S+\s+)*)?    # optional xargs with optional flags
@@ -279,7 +268,6 @@ def extract_packages_from_file_installs(
         re.VERBOSE,
     )
     packages: set[str] = set()
-    arch_packages: dict[str, set[str]] = {}
 
     for run_body in run_values:
         for cmd in re.split(r"&&|;", run_body):
@@ -301,24 +289,23 @@ def extract_packages_from_file_installs(
                 continue
 
             if has_arch_keyword:
-                for arch in arch_list:
-                    arch_path = resolved_path
-                    for kw in ARCH_SUBSHELL_KEYWORDS:
-                        arch_path = arch_path.replace(kw, arch)
-                    source_file = _resolve_file_from_copy_map(
-                        arch_path, copy_map, source_dir
-                    )
-                    if not source_file:
-                        continue
-                    logger.info(
-                        f"Extracting arch-specific packages from {source_file} for {arch}"
-                    )
-                    try:
-                        arch_packages.setdefault(arch, set()).update(
-                            _read_packages_from_file(source_file)
-                        )
-                    except OSError:
-                        continue
+                if not arch:
+                    continue
+                arch_path = resolved_path
+                for kw in ARCH_SUBSHELL_KEYWORDS:
+                    arch_path = arch_path.replace(kw, arch)
+                source_file = _resolve_file_from_copy_map(
+                    arch_path, copy_map, source_dir
+                )
+                if not source_file:
+                    continue
+                logger.info(
+                    f"Extracting packages from {source_file} for {arch}"
+                )
+                try:
+                    packages.update(_read_packages_from_file(source_file))
+                except OSError:
+                    continue
             else:
                 source_file = _resolve_file_from_copy_map(
                     resolved_path, copy_map, source_dir
@@ -334,8 +321,7 @@ def extract_packages_from_file_installs(
                 except OSError:
                     continue
 
-    arch_result = {arch: sorted(pkgs) for arch, pkgs in sorted(arch_packages.items())}
-    return sorted(packages), arch_result
+    return sorted(packages)
 
 
 def extract_packages_from_scripts(
@@ -343,7 +329,7 @@ def extract_packages_from_scripts(
     source_dir: Path | None = None,
     copy_map: dict[str, str] | None = None,
     env_vars: dict[str, str] | None = None,
-    arches: list[str] | None = None,
+    arch: str | None = None,
 ) -> StagePackages:
     """
     Find shell scripts invoked in RUN commands and extract yum/dnf
@@ -365,11 +351,11 @@ def extract_packages_from_scripts(
         copy_map (dict[str, str] | None): Container path to source path
             mapping from COPY/ADD instructions.
         env_vars (dict[str, str] | None): Variables for path resolution.
-        arches (list[str] | None): Architectures being resolved, passed
-            through for arch-conditional subshell detection.
+        arch (str | None): Architecture being resolved, used for
+            evaluating arch-conditional blocks.
     Return Value(s):
-        StagePackages: Extracted packages, update targets, arch-specific
-            packages, and update flag from scripts.
+        StagePackages: Extracted packages, update targets, and update
+            flag from scripts.
     """
     if not source_dir:
         return StagePackages()
@@ -383,7 +369,6 @@ def extract_packages_from_scripts(
     all_packages: set[str] = set()
     all_updates: set[str] = set()
     all_reinstalls: set[str] = set()
-    all_arch_packages: dict[str, set[str]] = {}
     all_builddep: set[str] = set()
     all_modules: set[str] = set()
     scripts_have_bare_update: bool = False
@@ -453,10 +438,8 @@ def extract_packages_from_scripts(
                     joined_lines.append(stripped)
             script_body = "\n".join(line for line in joined_lines if line.strip())
 
-            result = analyze_run_commands([script_body], arches=arches)
+            result = analyze_run_commands([script_body], arch=arch)
             all_packages.update(result.packages)
-            for arch, arch_pkgs in result.arch_packages.items():
-                all_arch_packages.setdefault(arch, set()).update(arch_pkgs)
             all_updates.update(result.update_targets)
             all_reinstalls.update(result.reinstall_targets)
             all_builddep.update(result.builddep_packages)
@@ -464,23 +447,18 @@ def extract_packages_from_scripts(
             if result.has_update:
                 scripts_have_bare_update = True
 
-            file_pkgs, file_arch_pkgs = extract_packages_from_file_installs(
+            file_pkgs = extract_packages_from_file_installs(
                 [script_body],
                 copy_map,
                 source_dir,
                 env_vars=env_vars,
-                arches=arches,
+                arch=arch,
             )
             all_packages.update(file_pkgs)
-            for arch, arch_pkgs in file_arch_pkgs.items():
-                all_arch_packages.setdefault(arch, set()).update(arch_pkgs)
 
     return StagePackages(
         packages=sorted(all_packages),
         has_update=scripts_have_bare_update,
-        arch_packages={
-            arch: sorted(pkgs) for arch, pkgs in sorted(all_arch_packages.items())
-        },
         update_targets=sorted(all_updates),
         reinstall_targets=sorted(all_reinstalls),
         builddep_packages=sorted(all_builddep),
@@ -491,7 +469,7 @@ def extract_packages_from_scripts(
 def analyze_containerfile_stages(
     containerfile_path: Path,
     source_dir: Path | None = None,
-    arches: list[str] | None = None,
+    arch: str | None = None,
 ) -> list[StagePackages]:
     """
     Parse a Containerfile and return per-stage package analysis.
@@ -504,16 +482,16 @@ def analyze_containerfile_stages(
     Also detects shell scripts invoked in RUN commands and extracts
     packages from them if the script file exists in source_dir.
 
-    Packages inside arch-conditional blocks (if [ $(arch) = X ]) are
-    returned separately so they can be resolved only for the matching
-    architecture.
+    Architecture-conditional blocks are evaluated against the given
+    arch parameter; matching packages are included, non-matching ones
+    are skipped.
 
     Arg(s):
         containerfile_path (Path): Path to the Containerfile/Dockerfile.
         source_dir (Path | None): Source tree root to locate script files
             referenced in RUN commands.
-        arches (list[str] | None): Architectures being resolved, passed
-            through for arch-conditional subshell detection.
+        arch (str | None): Architecture being resolved, used for
+            evaluating arch-conditional blocks.
     Return Value(s):
         list[StagePackages]: Per-stage package analysis.
     """
@@ -559,7 +537,9 @@ def analyze_containerfile_stages(
                 base_image = resolve_bash_expansion(m.group("img"), stage_vars)
                 stage_name = m.group("name") or ""
 
-        result = analyze_run_commands(run_values, env_vars=stage_vars, arches=arches)
+        result = analyze_run_commands(
+            run_values, env_vars=stage_vars, arch=arch
+        )
         stage = StagePackages(
             base_image=base_image,
             stage_name=stage_name,
@@ -573,20 +553,20 @@ def analyze_containerfile_stages(
                 source_dir=source_dir,
                 copy_map=copy_map,
                 env_vars=stage_vars,
-                arches=arches,
+                arch=arch,
             )
         )
 
         if source_dir:
-            file_pkgs, file_arch_pkgs = extract_packages_from_file_installs(
+            file_pkgs = extract_packages_from_file_installs(
                 run_values,
                 copy_map,
                 source_dir,
                 env_vars=stage_vars,
-                arches=arches,
+                arch=arch,
             )
             stage = stage.merge(
-                StagePackages(packages=file_pkgs, arch_packages=file_arch_pkgs)
+                StagePackages(packages=file_pkgs)
             )
 
         stages.append(stage)

--- a/rpm_lockfile/shell_commands.py
+++ b/rpm_lockfile/shell_commands.py
@@ -4,8 +4,9 @@ Shell command parsing for RPM package extraction.
 Provides bashlex-based AST walking to extract package names from
 yum/dnf install, update, and reinstall commands in RUN bodies and
 shell scripts.
-Handles variable assignments, arch-conditional blocks, subshell
-expansions, and bash-to-POSIX preprocessing.
+Handles variable assignments, subshell expansions, and bash-to-POSIX
+preprocessing. Architecture-conditional blocks are evaluated against
+a single target architecture passed as a parameter.
 """
 
 from __future__ import annotations
@@ -13,6 +14,7 @@ from __future__ import annotations
 import logging
 import re
 from dataclasses import dataclass, field
+from typing import NamedTuple
 
 from rpm_lockfile.vendor import bashlex
 
@@ -61,7 +63,6 @@ class RunCommandResult:
     """
 
     packages: list[str] = field(default_factory=list)
-    arch_packages: dict[str, list[str]] = field(default_factory=dict)
     update_targets: list[str] = field(default_factory=list)
     has_update: bool = False
     reinstall_targets: list[str] = field(default_factory=list)
@@ -76,11 +77,9 @@ class _WalkContext:
     """
 
     variables: dict[str, str] = field(default_factory=dict)
-    known_arches: frozenset[str] = field(default_factory=frozenset)
+    arch: str | None = None
     shell_vars: dict[str, str] = field(default_factory=dict)
-    arch_shell_vars: dict[str, dict[str, str]] = field(default_factory=dict)
     packages: set[str] = field(default_factory=set)
-    arch_packages: dict[str, set[str]] = field(default_factory=dict)
     update_targets: set[str] = field(default_factory=set)
     has_update: bool = False
     reinstall_targets: set[str] = field(default_factory=set)
@@ -124,12 +123,6 @@ def _has_arch_test(text: str) -> bool:
     return any(kw in text for kw in ARCH_KEYWORDS)
 
 
-def _extract_arch_values(text: str) -> list[str]:
-    """
-    Extract architecture names from conditional expressions.
-    """
-    return ARCH_VALUE_RE.findall(text)
-
 
 def _preprocess_for_bashlex(text: str) -> str:
     """
@@ -163,35 +156,55 @@ def _normalize_arch_names(arches: list[str]) -> list[str]:
     return [_GO_TO_RPM_ARCH.get(a, a) for a in arches]
 
 
-def _extract_condition_arch(node) -> list[str]:
+class _ConditionArches(NamedTuple):
+    """Arches extracted from an if/elif condition.
+
+    ``eq`` lists arches matched with ``=`` / ``==`` (the body runs on
+    these arches).  ``neq`` lists arches matched with ``!=`` (the body
+    runs on every arch *except* these).
+    """
+
+    eq: list[str]
+    neq: list[str]
+
+
+def _extract_condition_arch(node) -> _ConditionArches:
     """
     Extract architecture names from an if/elif condition node.
 
     Looks for patterns like ``[ $(arch) = x86_64 ]`` or
     ``[ $ARCH = aarch64 ]`` in the condition's command parts.
     Handles ``||`` conditions by collecting arches from all branches.
+
+    Also detects ``!=`` (not-equal) patterns and returns them separately
+    so the caller can compute the complement against the known arch set.
     """
     if not hasattr(node, "parts"):
-        return []
-    arches: list[str] = []
+        return _ConditionArches([], [])
+    eq_arches: list[str] = []
+    neq_arches: list[str] = []
     for part in node.parts:
         if hasattr(part, "parts"):
             words = [p.word for p in part.parts if hasattr(p, "word")]
             text = " ".join(words)
             if _has_arch_test(text):
-                arches.extend(_normalize_arch_names(_extract_arch_values(text)))
-    return arches
+                eq_arches.extend(
+                    _normalize_arch_names(ARCH_VALUE_RE.findall(text))
+                )
+                neq_arches.extend(
+                    _normalize_arch_names(ARCH_NEQ_VALUE_RE.findall(text))
+                )
+    return _ConditionArches(eq_arches, neq_arches)
 
 
-def _extract_list_arch_context(test_node, operator: str) -> list[str] | None:
+def _eval_list_arch_test(test_node, operator: str, current_arch: str | None) -> bool | None:
     """
-    Compute effective arch context from a ``[ test ] || cmd`` or
-    ``[ test ] && cmd`` pattern.
+    Evaluate whether a ``[ test ] || cmd`` or ``[ test ] && cmd``
+    pattern means the command should run on the current architecture.
 
-    Handles:
-        ``[ $(arch) != X ] || cmd`` -> [X] (double negation = only on X)
-        ``[ $(arch) = X ] && cmd``  -> [X] (direct match = only on X)
-        Other combos need full arch set -> returns None (unconditional).
+    Return Value(s):
+        True if the command should run, False if it should be skipped,
+        None if the test is not an architecture test (treat as unconditional).
     """
     if not hasattr(test_node, "parts"):
         return None
@@ -202,25 +215,35 @@ def _extract_list_arch_context(test_node, operator: str) -> list[str] | None:
     if not _has_arch_test(text):
         return None
 
-    neq_arches = ARCH_NEQ_VALUE_RE.findall(text)
-    eq_arches = ARCH_VALUE_RE.findall(text)
+    if current_arch is None:
+        return None
 
-    if neq_arches and operator == "||":
-        return _normalize_arch_names(neq_arches)
-    if eq_arches and operator == "&&":
-        return _normalize_arch_names(eq_arches)
+    neq_arches = _normalize_arch_names(ARCH_NEQ_VALUE_RE.findall(text))
+    eq_arches = _normalize_arch_names(ARCH_VALUE_RE.findall(text))
 
-    logger = logging.getLogger(__name__)
-    logger.debug(
-        f"Unsupported arch-conditional pattern (needs full arch set): {text} {operator} cmd"
-    )
+    if operator == "||":
+        # [ test ] || cmd  — cmd runs when test fails
+        # [ $(arch) != X ] || cmd  — test fails when arch IS X → run on X
+        # [ $(arch) = X ] || cmd   — test fails when arch is NOT X → run on all except X
+        if neq_arches:
+            return current_arch in neq_arches
+        if eq_arches:
+            return current_arch not in eq_arches
+    elif operator == "&&":
+        # [ test ] && cmd  — cmd runs when test succeeds
+        # [ $(arch) = X ] && cmd   — test succeeds when arch IS X → run on X
+        # [ $(arch) != X ] && cmd  — test succeeds when arch is NOT X → run on all except X
+        if eq_arches:
+            return current_arch in eq_arches
+        if neq_arches:
+            return current_arch not in neq_arches
+
     return None
 
 
 def _walk_list_node(
     node,
     ctx: _WalkContext,
-    arch_context: list[str] | None = None,
     in_conditional: bool = False,
 ):
     """
@@ -241,34 +264,34 @@ def _walk_list_node(
         op_node = parts[i + 1]
         if not hasattr(op_node, "op") or op_node.op not in ("||", "&&"):
             continue
-        arch_ctx = _extract_list_arch_context(part, op_node.op)
-        if arch_ctx is None:
+        should_run = _eval_list_arch_test(part, op_node.op, ctx.arch)
+        if should_run is None:
             continue
         consumed.add(i)
         consumed.add(i + 1)
         consumed.add(i + 2)
-        _walk_nodes([parts[i + 2]], ctx, arch_ctx, in_conditional=False)
+        if should_run:
+            _walk_nodes([parts[i + 2]], ctx, in_conditional=False)
 
     remaining = [p for idx, p in enumerate(parts) if idx not in consumed]
     if remaining:
-        _walk_nodes(remaining, ctx, arch_context, in_conditional)
+        _walk_nodes(remaining, ctx, in_conditional)
 
 
 def _walk_nodes(
     nodes: list,
     ctx: _WalkContext,
-    arch_context: list[str] | None = None,
     in_conditional: bool = False,
 ):
     """
-    Recursively walk bashlex AST nodes, extracting package names,
-    variable assignments, and arch-conditional context.
+    Recursively walk bashlex AST nodes, extracting package names
+    and variable assignments.
     """
     for node in nodes:
         kind = node.kind
 
         if kind == "list":
-            _walk_list_node(node, ctx, arch_context, in_conditional)
+            _walk_list_node(node, ctx, in_conditional)
 
         elif kind == "compound":
             for child in node.list:
@@ -280,7 +303,7 @@ def _walk_nodes(
                         for p in child.parts
                         if hasattr(p, "kind") and p.kind in ("list", "command")
                     ]
-                    _walk_nodes(body_nodes, ctx, arch_context, in_conditional)
+                    _walk_nodes(body_nodes, ctx, in_conditional)
                 elif child.kind == "function":
                     body_nodes = [
                         p
@@ -288,19 +311,19 @@ def _walk_nodes(
                         if hasattr(p, "kind") and p.kind == "compound"
                     ]
                     for body in body_nodes:
-                        _walk_nodes([body], ctx, arch_context, in_conditional)
+                        _walk_nodes([body], ctx, in_conditional)
                 else:
-                    _walk_nodes([child], ctx, arch_context, in_conditional)
+                    _walk_nodes([child], ctx, in_conditional)
 
         elif kind == "command":
-            _process_command_node(node, ctx, arch_context, in_conditional)
+            _process_command_node(node, ctx, in_conditional)
 
         elif kind == "pipeline":
             cmd_nodes = [
                 p for p in node.parts if hasattr(p, "kind") and p.kind == "command"
             ]
             for cmd_node in cmd_nodes:
-                _process_command_node(cmd_node, ctx, arch_context, in_conditional)
+                _process_command_node(cmd_node, ctx, in_conditional)
 
         elif kind == "if":
             _walk_if_node(node, ctx)
@@ -310,16 +333,22 @@ def _walk_nodes(
                 p for p in node.parts if hasattr(p, "kind") and p.kind == "compound"
             ]
             for body in body_nodes:
-                _walk_nodes([body], ctx, arch_context, in_conditional)
+                _walk_nodes([body], ctx, in_conditional)
 
 
 def _walk_if_node(node, ctx: _WalkContext):
     """
-    Walk an IfNode, detecting arch conditionals in if/elif branches.
+    Walk an IfNode, evaluating arch conditionals against the current
+    architecture. Non-arch conditionals are walked unconditionally
+    (both branches) since we can't evaluate them statically.
     Also walks condition nodes for commands (e.g. ``if ! yum install``).
     """
     parts = list(node.parts)
     i = 0
+    # Track whether any if/elif branch matched the current arch.
+    # If so, the else branch should be skipped. None means no arch
+    # condition was seen (non-arch if).
+    arch_branch_matched: bool | None = None
     while i < len(parts):
         part = parts[i]
         if not hasattr(part, "word"):
@@ -336,19 +365,43 @@ def _walk_if_node(node, ctx: _WalkContext):
                         body = parts[j + 1]
                     break
 
-            arch_ctx = None
-            if condition:
-                arch_ctx = _extract_condition_arch(condition) or None
-                _walk_nodes(
-                    [condition], ctx, arch_ctx, in_conditional=not bool(arch_ctx)
-                )
-
-            if body:
-                _walk_nodes([body], ctx, arch_ctx, in_conditional=not bool(arch_ctx))
+            cond = _extract_condition_arch(condition) if condition else _ConditionArches([], [])
+            if cond.eq or cond.neq:
+                # This is an arch-conditional branch.
+                if cond.eq:
+                    matches = ctx.arch in _normalize_arch_names(cond.eq) if ctx.arch else False
+                else:
+                    # != condition: matches everything except the listed arches
+                    matches = ctx.arch not in _normalize_arch_names(cond.neq) if ctx.arch else False
+                if arch_branch_matched is None:
+                    arch_branch_matched = False
+                if matches:
+                    arch_branch_matched = True
+                    if condition:
+                        _walk_nodes([condition], ctx, in_conditional=False)
+                    if body:
+                        _walk_nodes([body], ctx, in_conditional=False)
+                # else: skip this branch entirely
+            else:
+                # Not an arch condition — walk both condition and body
+                # as we can't evaluate statically.
+                if condition:
+                    _walk_nodes([condition], ctx, in_conditional=True)
+                if body:
+                    _walk_nodes([body], ctx, in_conditional=True)
 
         elif word == "else":
             if i + 1 < len(parts) and hasattr(parts[i + 1], "kind"):
-                _walk_nodes([parts[i + 1]], ctx, None, in_conditional=True)
+                if arch_branch_matched is True:
+                    # An arch branch matched; skip the else.
+                    pass
+                elif arch_branch_matched is False:
+                    # Arch conditions were present but none matched;
+                    # the else branch applies to this arch.
+                    _walk_nodes([parts[i + 1]], ctx, in_conditional=False)
+                else:
+                    # No arch conditions at all — walk else as conditional.
+                    _walk_nodes([parts[i + 1]], ctx, in_conditional=True)
 
         i += 1
 
@@ -356,7 +409,6 @@ def _walk_if_node(node, ctx: _WalkContext):
 def _process_assignments(
     assignments: list,
     ctx: _WalkContext,
-    arch_context: list[str] | None,
     in_conditional: bool,
 ):
     """
@@ -374,27 +426,11 @@ def _process_assignments(
         )
 
         if has_cmdsub:
-            extracted = _extract_subshell_packages(var_value)
+            extracted = _extract_subshell_packages(var_value, ctx.arch)
             if extracted:
-                target_arches = _extract_subshell_arch_condition(
-                    var_value, ctx.known_arches
-                )
-                if target_arches:
-                    per_arch = ctx.arch_shell_vars.setdefault(var_name, {})
-                    for arch in target_arches:
-                        if arch in per_arch:
-                            per_arch[arch] = f"{per_arch[arch]} {extracted}"
-                        else:
-                            per_arch[arch] = extracted
-                else:
-                    ctx.shell_vars[var_name] = extracted
-        elif arch_context:
-            per_arch = ctx.arch_shell_vars.setdefault(var_name, {})
-            for arch in arch_context:
-                if arch in per_arch:
-                    per_arch[arch] = f"{per_arch[arch]} {var_value}"
-                else:
-                    per_arch[arch] = var_value
+                ctx.shell_vars[var_name] = extracted
+            else:
+                ctx.shell_vars[var_name] = ""
         else:
             all_vars = {**ctx.variables, **ctx.shell_vars}
             resolved = resolve_bash_expansion(var_value, all_vars)
@@ -440,65 +476,14 @@ def _detect_pkg_action(
     return None, -1
 
 
-def _resolve_arch_specific_tokens(
-    pkg_words: list[str],
-    raw_args: str,
-    all_vars: dict[str, str],
-    ctx: _WalkContext,
-) -> set[str]:
-    """
-    Resolve arch-specific variable expansions and add per-arch packages.
-
-    Return Value(s):
-        set[str]: Tokens already classified as arch-specific (to exclude
-            from the common package list).
-    """
-    arch_resolved: set[str] = set()
-    if not ctx.arch_shell_vars:
-        return arch_resolved
-
-    used_arch_vars: dict[str, dict[str, str]] = {}
-    for var_name, per_arch in ctx.arch_shell_vars.items():
-        if f"${var_name}" in raw_args or f"${{{var_name}}}" in raw_args:
-            used_arch_vars[var_name] = per_arch
-
-    if not used_arch_vars:
-        return arch_resolved
-
-    no_arch_vars = dict.fromkeys(used_arch_vars, "")
-    common_resolved_tokens = set()
-    for pw in pkg_words:
-        r = resolve_bash_expansion(pw, {**all_vars, **no_arch_vars})
-        common_resolved_tokens.update(r.split())
-
-    all_arches: set[str] = set()
-    for per_arch in used_arch_vars.values():
-        all_arches.update(per_arch.keys())
-    for arch in all_arches:
-        arch_var_vals = {vn: pa.get(arch, "") for vn, pa in used_arch_vars.items()}
-        for pw in pkg_words:
-            r = resolve_bash_expansion(pw, {**all_vars, **arch_var_vals})
-            for token in r.split():
-                if (
-                    _is_valid_package_token(token)
-                    and token not in common_resolved_tokens
-                ):
-                    ctx.arch_packages.setdefault(arch, set()).add(token)
-                    arch_resolved.add(token)
-
-    return arch_resolved
-
-
 def _classify_package_tokens(
     resolved_tokens: list[str],
-    arch_resolved_tokens: set[str],
     action: str,
     ctx: _WalkContext,
-    arch_context: list[str] | None,
 ):
     """
-    Classify resolved tokens into packages, update targets, or
-    arch-specific packages.
+    Classify resolved tokens into packages, update targets, reinstall
+    targets, builddep packages, or module specs.
     """
     skip_next = False
     for token in resolved_tokens:
@@ -522,16 +507,11 @@ def _classify_package_tokens(
 
         if not _is_valid_package_token(token):
             continue
-        if token in arch_resolved_tokens:
-            continue
 
         if action == "update":
             ctx.update_targets.add(token)
         elif action == "reinstall":
             ctx.reinstall_targets.add(token)
-        elif arch_context:
-            for arch in arch_context:
-                ctx.arch_packages.setdefault(arch, set()).add(token)
         else:
             ctx.packages.add(token)
 
@@ -539,7 +519,6 @@ def _classify_package_tokens(
 def _process_command_node(
     node,
     ctx: _WalkContext,
-    arch_context: list[str] | None = None,
     in_conditional: bool = False,
 ):
     """
@@ -554,7 +533,7 @@ def _process_command_node(
         elif part.kind == "word":
             words.append(part)
 
-    _process_assignments(assignments, ctx, arch_context, in_conditional)
+    _process_assignments(assignments, ctx, in_conditional)
 
     if not words:
         return
@@ -572,82 +551,61 @@ def _process_command_node(
         return
 
     pkg_words = word_values[action_idx + 1 :]
-    combined_arch_vals = {
-        k: " ".join(per_arch.values()) for k, per_arch in ctx.arch_shell_vars.items()
-    }
-    all_vars_with_arch = {
-        **all_vars,
-        **{
-            k: resolve_bash_expansion(v, all_vars)
-            for k, v in combined_arch_vals.items()
-        },
-    }
 
     resolved_tokens: list[str] = []
-    raw_args = " ".join(pkg_words)
     for pw in pkg_words:
-        resolved = resolve_bash_expansion(pw, all_vars_with_arch)
+        resolved = resolve_bash_expansion(pw, all_vars)
         resolved_tokens.extend(resolved.split())
 
-    arch_resolved_tokens: set[str] = set()
-    if not arch_context:
-        arch_resolved_tokens = _resolve_arch_specific_tokens(
-            pkg_words, raw_args, all_vars, ctx
-        )
-
-    _classify_package_tokens(
-        resolved_tokens, arch_resolved_tokens, action, ctx, arch_context
-    )
+    _classify_package_tokens(resolved_tokens, action, ctx)
 
 
-def _extract_subshell_arch_condition(
-    subshell_body: str, known_arches: frozenset[str]
-) -> list[str] | None:
+def _eval_subshell_arch_condition(
+    subshell_body: str, current_arch: str | None
+) -> bool:
     """
-    Detect architecture conditions inside a subshell body and return
-    the list of arches where the subshell produces output.
+    Evaluate whether a subshell with an architecture condition produces
+    output for the current architecture.
 
     Arg(s):
         subshell_body (str): Text inside a $(...) subshell, e.g.
             'if [ "$(uname -m)" != "s390x" ]; then echo -n mstflint; fi'
-        known_arches (frozenset[str]): Full set of architectures being
-            resolved, used for complement computation on != patterns.
+        current_arch (str | None): Architecture being resolved.
     Return Value(s):
-        list[str] | None: Target arches (RPM names), or None if no
-            arch condition detected or pattern is ambiguous.
+        bool: True if the subshell produces output for this arch.
     """
     if not _has_arch_test(subshell_body):
-        return None
+        return True
 
-    if not known_arches:
-        return None
+    if not current_arch:
+        return True
 
-    neq_arches = ARCH_NEQ_VALUE_RE.findall(subshell_body)
-    eq_arches = ARCH_VALUE_RE.findall(subshell_body)
+    neq_arches = _normalize_arch_names(ARCH_NEQ_VALUE_RE.findall(subshell_body))
+    eq_arches = _normalize_arch_names(ARCH_VALUE_RE.findall(subshell_body))
 
     if neq_arches and eq_arches:
-        return None
+        return True
 
     if neq_arches:
-        excluded = set(_normalize_arch_names(neq_arches))
-        target = sorted(known_arches - excluded)
-        return target if target else None
+        return current_arch not in neq_arches
 
     if eq_arches:
-        if len(eq_arches) > 1:
-            return None
-        return _normalize_arch_names(eq_arches)
+        return current_arch in eq_arches
 
-    return None
+    return True
 
 
-def _extract_subshell_packages(subshell_body: str) -> str:
+def _extract_subshell_packages(subshell_body: str, current_arch: str | None = None) -> str:
     """
-    Extract package names from echo commands inside a $(...) subshell.
+    Extract package names from echo commands inside a $(...) subshell,
+    evaluating any architecture condition against the current arch.
 
     Handles patterns like:
         $(if [ "$(uname -m)" != "s390x" ]; then echo -n mstflint; fi)
     """
+    if not _eval_subshell_arch_condition(subshell_body, current_arch):
+        return ""
+
     packages: list[str] = []
     for match in re.finditer(r"\becho\s+(?:-\w+\s+)*([\w\s-]+)", subshell_body):
         tokens = match.group(1).strip().split()
@@ -664,7 +622,7 @@ def _extract_subshell_packages(subshell_body: str) -> str:
 def _parse_and_walk(
     run_values: list[str],
     env_vars: dict[str, str] | None = None,
-    arches: list[str] | None = None,
+    arch: str | None = None,
 ) -> _WalkContext:
     """
     Single pass: preprocess, parse with bashlex, and walk all RUN bodies.
@@ -672,15 +630,15 @@ def _parse_and_walk(
     Arg(s):
         run_values (list[str]): RUN command bodies.
         env_vars (dict[str, str] | None): Variables from ARG/ENV directives.
-        arches (list[str] | None): Architectures being resolved, used for
-            complement computation in subshell arch conditions.
+        arch (str | None): Architecture being resolved, used for
+            evaluating arch-conditional blocks.
     Return Value(s):
         _WalkContext: Walk context with accumulated packages and state.
     """
     logger = logging.getLogger(__name__)
     ctx = _WalkContext(
         variables=dict(env_vars or {}),
-        known_arches=frozenset(arches) if arches else frozenset(),
+        arch=arch,
     )
 
     for run_body in run_values:
@@ -692,7 +650,6 @@ def _parse_and_walk(
             continue
 
         ctx.shell_vars = {}
-        ctx.arch_shell_vars = {}
         _walk_nodes(ast_nodes, ctx)
 
     return ctx
@@ -701,7 +658,7 @@ def _parse_and_walk(
 def analyze_run_commands(
     run_values: list[str],
     env_vars: dict[str, str] | None = None,
-    arches: list[str] | None = None,
+    arch: str | None = None,
 ) -> RunCommandResult:
     """
     Single-pass analysis of RUN command bodies.
@@ -709,18 +666,15 @@ def analyze_run_commands(
     Arg(s):
         run_values (list[str]): RUN command bodies.
         env_vars (dict[str, str] | None): Variables from ARG/ENV directives.
-        arches (list[str] | None): Architectures being resolved, used for
-            complement computation in subshell arch conditions.
+        arch (str | None): Architecture being resolved, used for
+            evaluating arch-conditional blocks.
     Return Value(s):
-        RunCommandResult: Sorted packages, arch-specific packages,
-            update targets, builddep patterns, and module specs.
+        RunCommandResult: Sorted packages, update targets, builddep
+            patterns, and module specs.
     """
-    ctx = _parse_and_walk(run_values, env_vars, arches)
+    ctx = _parse_and_walk(run_values, env_vars, arch)
     return RunCommandResult(
         packages=sorted(ctx.packages),
-        arch_packages={
-            arch: sorted(pkgs) for arch, pkgs in sorted(ctx.arch_packages.items())
-        },
         update_targets=sorted(ctx.update_targets),
         has_update=ctx.has_update,
         reinstall_targets=sorted(ctx.reinstall_targets),

--- a/tests/integration/data/success/pfc-if-arch-neq-install/Dockerfile
+++ b/tests/integration/data/success/pfc-if-arch-neq-install/Dockerfile
@@ -1,0 +1,5 @@
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+RUN microdnf install -y test-common && \
+    if [ $(arch) != s390x ]; then \
+        microdnf install -y test-not-s390x; \
+    fi

--- a/tests/integration/data/success/pfc-if-arch-neq-install/expected.lock.yaml
+++ b/tests/integration/data/success/pfc-if-arch-neq-install/expected.lock.yaml
@@ -1,0 +1,51 @@
+---
+lockfileVersion: 1
+lockfileVendor: redhat
+arches:
+- arch: s390x
+  packages:
+  - url: http://localhost:PORT/test-repo/test-common-1.0-1.noarch.rpm
+    repoid: test-repo
+    size: 33488
+    checksum: sha256:f744da761b44ab0c00f94f391f3386dee075a81c12c9db4bc1ed6f6e4bf23ed8
+    name: test-common
+    evr: 1.0-1
+    sourcerpm: test-common-1.0-1.src.rpm
+  source:
+  - url: http://localhost:PORT/test-repo/test-common-1.0-1.src.rpm
+    repoid: test-repo
+    size: 17508
+    checksum: sha256:f2dff9061e5b23158b3cd4e2aae77f235abd6f127e6227935d3be9f0d9e0b5c4
+    name: test-common
+    evr: 1.0-1
+  module_metadata: []
+- arch: x86_64
+  packages:
+  - url: http://localhost:PORT/test-repo/test-common-1.0-1.noarch.rpm
+    repoid: test-repo
+    size: 33488
+    checksum: sha256:f744da761b44ab0c00f94f391f3386dee075a81c12c9db4bc1ed6f6e4bf23ed8
+    name: test-common
+    evr: 1.0-1
+    sourcerpm: test-common-1.0-1.src.rpm
+  - url: http://localhost:PORT/test-repo/test-not-s390x-1.0-1.noarch.rpm
+    repoid: test-repo
+    size: 85870
+    checksum: sha256:bdcdad0a8579275d98115a92fb2185bf416eb1dafae2197f8cc605cacac50ade
+    name: test-not-s390x
+    evr: 1.0-1
+    sourcerpm: test-not-s390x-1.0-1.src.rpm
+  source:
+  - url: http://localhost:PORT/test-repo/test-common-1.0-1.src.rpm
+    repoid: test-repo
+    size: 17508
+    checksum: sha256:f2dff9061e5b23158b3cd4e2aae77f235abd6f127e6227935d3be9f0d9e0b5c4
+    name: test-common
+    evr: 1.0-1
+  - url: http://localhost:PORT/test-repo/test-not-s390x-1.0-1.src.rpm
+    repoid: test-repo
+    size: 70600
+    checksum: sha256:31a792dec263ebdf34b79d323880d0631abcbe6f9c556bf0352eee68c4b459d0
+    name: test-not-s390x
+    evr: 1.0-1
+  module_metadata: []

--- a/tests/integration/data/success/pfc-if-arch-neq-install/repos/test-repo.yaml
+++ b/tests/integration/data/success/pfc-if-arch-neq-install/repos/test-repo.yaml
@@ -1,0 +1,4 @@
+packages:
+  - nvr: test-common-1.0-1
+
+  - nvr: test-not-s390x-1.0-1

--- a/tests/integration/data/success/pfc-if-arch-neq-install/rpms.in.yaml
+++ b/tests/integration/data/success/pfc-if-arch-neq-install/rpms.in.yaml
@@ -1,0 +1,10 @@
+contentOrigin:
+  repos:
+    - repoid: test-repo
+      baseurl: http://localhost:PORT/test-repo
+packagesFromContainerfile: Dockerfile
+arches:
+  - x86_64
+  - s390x
+context:
+  bare: true

--- a/tests/integration/data/success/pfc-if-else-install/expected.lock.yaml
+++ b/tests/integration/data/success/pfc-if-else-install/expected.lock.yaml
@@ -21,13 +21,6 @@ arches:
   module_metadata: []
 - arch: x86_64
   packages:
-  - url: http://localhost:PORT/test-repo/test-else-branch-1.0-1.noarch.rpm
-    repoid: test-repo
-    size: 97013
-    checksum: sha256:abf4a1cedd438c64304defef0ac383a1c43e8c8e3dbac9d92377ae81caf884bd
-    name: test-else-branch
-    evr: 1.0-1
-    sourcerpm: test-else-branch-1.0-1.src.rpm
   - url: http://localhost:PORT/test-repo/test-x86-branch-1.0-1.noarch.rpm
     repoid: test-repo
     size: 3481
@@ -36,12 +29,6 @@ arches:
     evr: 1.0-1
     sourcerpm: test-x86-branch-1.0-1.src.rpm
   source:
-  - url: http://localhost:PORT/test-repo/test-else-branch-1.0-1.src.rpm
-    repoid: test-repo
-    size: 4642
-    checksum: sha256:7d513a86ec9ebfb3677017dd1a78a5a12bae38ed3b7a68aa83458ebda3d9c65a
-    name: test-else-branch
-    evr: 1.0-1
   - url: http://localhost:PORT/test-repo/test-x86-branch-1.0-1.src.rpm
     repoid: test-repo
     size: 65378

--- a/tests/test_containerfile_packages.py
+++ b/tests/test_containerfile_packages.py
@@ -109,11 +109,10 @@ class TestExtractPackagesFromFileInstalls(unittest.TestCase):
             run_values = [
                 "xargs -rtd'\\n' dnf install -y < /tmp/main-packages-list.txt"
             ]
-            result, arch_result = extract_packages_from_file_installs(
+            result = extract_packages_from_file_installs(
                 run_values, copy_map, source_dir
             )
             self.assertEqual(result, ["httpd", "python3-pip", "qemu-img"])
-            self.assertEqual(arch_result, {})
 
     def test_pipe_to_xargs_install(self):
         with TemporaryDirectory() as tmpdir:
@@ -125,11 +124,10 @@ class TestExtractPackagesFromFileInstalls(unittest.TestCase):
             run_values = [
                 "grep -vE '^(#|$)' /tmp/main-packages-list.ocp | xargs -rtd'\\n' dnf install -y"
             ]
-            result, arch_result = extract_packages_from_file_installs(
+            result = extract_packages_from_file_installs(
                 run_values, copy_map, source_dir
             )
             self.assertEqual(result, ["httpd", "qemu-img", "sqlite"])
-            self.assertEqual(arch_result, {})
 
     def test_pipe_with_quoted_env_var_in_path(self):
         with TemporaryDirectory() as tmpdir:
@@ -141,7 +139,7 @@ class TestExtractPackagesFromFileInstalls(unittest.TestCase):
             run_values = [
                 "grep -v '^#' \"/tmp/${PKGS_LIST}\" | xargs -rtd'\\n' dnf install -y"
             ]
-            result, _ = extract_packages_from_file_installs(
+            result = extract_packages_from_file_installs(
                 run_values,
                 copy_map,
                 source_dir,
@@ -159,15 +157,23 @@ class TestExtractPackagesFromFileInstalls(unittest.TestCase):
             run_values = [
                 "grep -vE '^(#|$)' /tmp/${PKGS_LIST}-$(arch) | xargs -rtd'\\n' dnf install -y"
             ]
-            result, arch_result = extract_packages_from_file_installs(
+            result = extract_packages_from_file_installs(
                 run_values,
                 copy_map,
                 source_dir,
                 env_vars={"PKGS_LIST": "packages-list.ocp"},
-                arches=["x86_64", "s390x", "ppc64le", "aarch64"],
+                arch="x86_64",
+            )
+            self.assertEqual(result, ["biosdevname"])
+
+            result = extract_packages_from_file_installs(
+                run_values,
+                copy_map,
+                source_dir,
+                env_vars={"PKGS_LIST": "packages-list.ocp"},
+                arch="s390x",
             )
             self.assertEqual(result, [])
-            self.assertEqual(arch_result.get("x86_64"), ["biosdevname"])
 
 
 class TestExtractPackagesFromScripts(unittest.TestCase):
@@ -230,17 +236,25 @@ class TestExtractPackagesFromScripts(unittest.TestCase):
 
             copy_map = {"/bin/prepare-efi.sh": "prepare-efi.sh"}
             run_values = ["prepare-efi.sh redhat"]
+
             result = extract_packages_from_scripts(
-                run_values, source_dir=source_dir, copy_map=copy_map
+                run_values, source_dir=source_dir, copy_map=copy_map,
+                arch="x86_64",
             )
             self.assertIn("grub2", result.packages)
             self.assertIn("dosfstools", result.packages)
-            self.assertEqual(
-                result.arch_packages.get("x86_64"), ["grub2-efi-x64", "shim-x64"]
+            self.assertIn("grub2-efi-x64", result.packages)
+            self.assertIn("shim-x64", result.packages)
+            self.assertNotIn("grub2-efi-aa64", result.packages)
+
+            result = extract_packages_from_scripts(
+                run_values, source_dir=source_dir, copy_map=copy_map,
+                arch="aarch64",
             )
-            self.assertEqual(
-                result.arch_packages.get("aarch64"), ["grub2-efi-aa64", "shim-aa64"]
-            )
+            self.assertIn("grub2", result.packages)
+            self.assertIn("grub2-efi-aa64", result.packages)
+            self.assertIn("shim-aa64", result.packages)
+            self.assertNotIn("grub2-efi-x64", result.packages)
 
     def test_bare_update_in_script_sets_has_update(self):
         with TemporaryDirectory() as tmpdir:
@@ -326,12 +340,11 @@ class TestAnalyzeContainerfileStages(unittest.TestCase):
                 "    fi\n"
             )
             path = self._write_containerfile(tmpdir, content)
-            stages = analyze_containerfile_stages(path)
-            self.assertEqual(stages[0].packages, ["make"])
-            self.assertEqual(
-                stages[0].arch_packages,
-                {"aarch64": ["kernel-64k-devel"], "x86_64": ["kernel-rt-devel"]},
-            )
+            stages = analyze_containerfile_stages(path, arch="x86_64")
+            self.assertEqual(stages[0].packages, ["kernel-rt-devel", "make"])
+
+            stages = analyze_containerfile_stages(path, arch="aarch64")
+            self.assertEqual(stages[0].packages, ["kernel-64k-devel", "make"])
 
     def test_copy_then_bash_script(self):
         with TemporaryDirectory() as tmpdir:
@@ -371,16 +384,23 @@ class TestAnalyzeContainerfileStages(unittest.TestCase):
                 "RUN dnf install -y httpd\n"
             )
             path = self._write_containerfile(tmpdir, content)
-            stages = analyze_containerfile_stages(path, source_dir=source_dir)
+
+            stages = analyze_containerfile_stages(
+                path, source_dir=source_dir, arch="x86_64"
+            )
             self.assertIn("grub2", stages[0].packages)
             self.assertIn("dosfstools", stages[0].packages)
-            self.assertEqual(
-                stages[0].arch_packages.get("x86_64"), ["grub2-efi-x64", "shim-x64"]
-            )
-            self.assertEqual(
-                stages[0].arch_packages.get("aarch64"), ["grub2-efi-aa64", "shim-aa64"]
-            )
+            self.assertIn("grub2-efi-x64", stages[0].packages)
+            self.assertIn("shim-x64", stages[0].packages)
+            self.assertNotIn("grub2-efi-aa64", stages[0].packages)
             self.assertEqual(stages[1].packages, ["httpd"])
+
+            stages = analyze_containerfile_stages(
+                path, source_dir=source_dir, arch="aarch64"
+            )
+            self.assertIn("grub2-efi-aa64", stages[0].packages)
+            self.assertIn("shim-aa64", stages[0].packages)
+            self.assertNotIn("grub2-efi-x64", stages[0].packages)
 
     def test_detect_update(self):
         with TemporaryDirectory() as tmpdir:

--- a/tests/test_shell_commands.py
+++ b/tests/test_shell_commands.py
@@ -74,7 +74,6 @@ class TestAnalyzeRunCommands(unittest.TestCase):
         run_values = ["dnf install -y gcc-${GCC_VERSION} gcc-c++-${GCC_VERSION}"]
         result = analyze_run_commands(run_values, env_vars={"GCC_VERSION": "12"})
         self.assertEqual(result.packages, ["gcc-12", "gcc-c++-12"])
-        self.assertEqual(result.arch_packages, {})
 
     def test_kernel_devel_conditional_with_version(self):
         run_values = [
@@ -87,7 +86,6 @@ class TestAnalyzeRunCommands(unittest.TestCase):
         self.assertEqual(
             result.packages, ["kernel-devel-5.14.0", "kernel-headers-5.14.0"]
         )
-        self.assertEqual(result.arch_packages, {})
 
     def test_kernel_devel_conditional_without_version(self):
         run_values = [
@@ -98,29 +96,27 @@ class TestAnalyzeRunCommands(unittest.TestCase):
         ]
         result = analyze_run_commands(run_values, env_vars={})
         self.assertEqual(result.packages, ["kernel-devel", "kernel-headers"])
-        self.assertEqual(result.arch_packages, {})
 
     def test_unresolved_var_skipped(self):
         run_values = ["dnf install -y gcc-${UNKNOWN} make"]
         result = analyze_run_commands(run_values, env_vars={})
         self.assertEqual(result.packages, ["make"])
-        self.assertEqual(result.arch_packages, {})
 
     def test_no_env_vars_backward_compatible(self):
         run_values = ['INSTALL_PKGS="wget tar" && dnf install -y ${INSTALL_PKGS} git']
         result = analyze_run_commands(run_values)
         self.assertEqual(result.packages, ["git", "tar", "wget"])
-        self.assertEqual(result.arch_packages, {})
 
     def test_arch_conditional_x86_64(self):
         run_values = [
             "dnf install -y make && if [ $(arch) = x86_64 ]; then dnf -y install kernel-rt-devel kernel-rt-modules; fi"
         ]
-        result = analyze_run_commands(run_values)
-        self.assertEqual(result.packages, ["make"])
+        result = analyze_run_commands(run_values, arch="x86_64")
         self.assertEqual(
-            result.arch_packages, {"x86_64": ["kernel-rt-devel", "kernel-rt-modules"]}
+            result.packages, ["kernel-rt-devel", "kernel-rt-modules", "make"]
         )
+        result = analyze_run_commands(run_values, arch="aarch64")
+        self.assertEqual(result.packages, ["make"])
 
     def test_reinstall_packages_parsed(self):
         run_values = ["dnf -y reinstall tzdata && dnf clean all"]
@@ -149,7 +145,6 @@ class TestAnalyzeRunCommands(unittest.TestCase):
         ]
         result = analyze_run_commands(run_values)
         self.assertEqual(result.packages, ["gcc", "gcc-c++"])
-        self.assertEqual(result.arch_packages, {})
 
     def test_if_not_yum_install(self):
         run_values = [
@@ -157,7 +152,6 @@ class TestAnalyzeRunCommands(unittest.TestCase):
         ]
         result = analyze_run_commands(run_values)
         self.assertEqual(result.packages, ["prometheus-promu"])
-        self.assertEqual(result.arch_packages, {})
 
     def test_subshell_arch_conditional_var(self):
         run_values = [
@@ -166,16 +160,15 @@ class TestAnalyzeRunCommands(unittest.TestCase):
                 "yum -y install pciutils hwdata kmod $ARCH_DEP_PKGS"
             )
         ]
-        result = analyze_run_commands(
-            run_values, arches=["x86_64", "s390x", "ppc64le", "aarch64"]
-        )
-        self.assertNotIn("mstflint", result.packages)
+        result = analyze_run_commands(run_values, arch="x86_64")
+        self.assertIn("mstflint", result.packages)
         self.assertIn("pciutils", result.packages)
         self.assertIn("hwdata", result.packages)
         self.assertIn("kmod", result.packages)
-        for a in ("x86_64", "aarch64", "ppc64le"):
-            self.assertIn("mstflint", result.arch_packages.get(a, []))
-        self.assertNotIn("s390x", result.arch_packages)
+
+        result = analyze_run_commands(run_values, arch="s390x")
+        self.assertNotIn("mstflint", result.packages)
+        self.assertIn("pciutils", result.packages)
 
     def test_subshell_arch_conditional_var_eq(self):
         run_values = [
@@ -184,19 +177,19 @@ class TestAnalyzeRunCommands(unittest.TestCase):
                 "yum -y install base-pkg $SPECIAL"
             )
         ]
-        result = analyze_run_commands(
-            run_values, arches=["x86_64", "s390x", "ppc64le", "aarch64"]
-        )
+        result = analyze_run_commands(run_values, arch="x86_64")
+        self.assertIn("intel-pkg", result.packages)
+        self.assertIn("base-pkg", result.packages)
+
+        result = analyze_run_commands(run_values, arch="s390x")
         self.assertNotIn("intel-pkg", result.packages)
         self.assertIn("base-pkg", result.packages)
-        self.assertEqual(result.arch_packages, {"x86_64": ["intel-pkg"]})
 
     def test_subshell_no_arch_condition(self):
         run_values = ["EXTRA=$(echo extra-pkg) && yum -y install base-pkg $EXTRA"]
         result = analyze_run_commands(run_values)
         self.assertIn("extra-pkg", result.packages)
         self.assertIn("base-pkg", result.packages)
-        self.assertEqual(result.arch_packages, {})
 
     def test_subshell_arch_conditional_var_go_arch(self):
         run_values = [
@@ -205,12 +198,13 @@ class TestAnalyzeRunCommands(unittest.TestCase):
                 "yum -y install common-pkg $SPECIAL"
             )
         ]
-        result = analyze_run_commands(
-            run_values, arches=["x86_64", "s390x", "ppc64le", "aarch64"]
-        )
+        result = analyze_run_commands(run_values, arch="x86_64")
+        self.assertIn("x86-only", result.packages)
+        self.assertIn("common-pkg", result.packages)
+
+        result = analyze_run_commands(run_values, arch="s390x")
         self.assertNotIn("x86-only", result.packages)
         self.assertIn("common-pkg", result.packages)
-        self.assertEqual(result.arch_packages, {"x86_64": ["x86-only"]})
 
     def test_arch_conditional_multiple_arches(self):
         run_values = [
@@ -219,12 +213,11 @@ class TestAnalyzeRunCommands(unittest.TestCase):
                 "if [ $(arch) = aarch64 ]; then dnf -y install kernel-64k-devel; fi"
             )
         ]
-        result = analyze_run_commands(run_values)
-        self.assertEqual(result.packages, [])
-        self.assertEqual(
-            result.arch_packages,
-            {"aarch64": ["kernel-64k-devel"], "x86_64": ["kernel-rt-devel"]},
-        )
+        result = analyze_run_commands(run_values, arch="x86_64")
+        self.assertEqual(result.packages, ["kernel-rt-devel"])
+
+        result = analyze_run_commands(run_values, arch="aarch64")
+        self.assertEqual(result.packages, ["kernel-64k-devel"])
 
     def test_hosttype_arch_conditional(self):
         run_values = [
@@ -234,11 +227,13 @@ class TestAnalyzeRunCommands(unittest.TestCase):
                 "yum install -y $PACKAGES"
             )
         ]
-        result = analyze_run_commands(run_values)
+        result = analyze_run_commands(run_values, arch="x86_64")
         self.assertIn("git", result.packages)
         self.assertIn("gzip", result.packages)
+        self.assertIn("realtime-tests", result.packages)
+
+        result = analyze_run_commands(run_values, arch="aarch64")
         self.assertNotIn("realtime-tests", result.packages)
-        self.assertEqual(result.arch_packages.get("x86_64"), ["realtime-tests"])
 
     def test_glob_package_pattern_with_resolved_var(self):
         """
@@ -248,7 +243,6 @@ class TestAnalyzeRunCommands(unittest.TestCase):
         run_values = ['dnf install -y "golang-*$VERSION*"']
         result = analyze_run_commands(run_values, env_vars={"VERSION": "1.26"})
         self.assertIn("golang-*1.26*", result.packages)
-        self.assertEqual(result.arch_packages, {})
 
     def test_glob_package_pattern_without_var(self):
         """
@@ -257,7 +251,6 @@ class TestAnalyzeRunCommands(unittest.TestCase):
         run_values = ["dnf install -y python3*"]
         result = analyze_run_commands(run_values)
         self.assertIn("python3*", result.packages)
-        self.assertEqual(result.arch_packages, {})
 
     def test_double_bracket_conditional_with_quoted_var_install(self):
         run_values = [
@@ -270,13 +263,13 @@ class TestAnalyzeRunCommands(unittest.TestCase):
                 'dnf install -y "$GRUB_PKG" "$SHIM_PKG"'
             )
         ]
-        result = analyze_run_commands(run_values)
-        self.assertEqual(result.packages, [])
+        result = analyze_run_commands(run_values, arch="x86_64")
         self.assertEqual(
-            result.arch_packages.get("x86_64"), ["grub2-efi-x64", "shim-x64"]
+            result.packages, ["grub2-efi-x64", "shim-x64"]
         )
+        result = analyze_run_commands(run_values, arch="aarch64")
         self.assertEqual(
-            result.arch_packages.get("aarch64"), ["grub2-efi-aa64", "shim-aa64"]
+            result.packages, ["grub2-efi-aa64", "shim-aa64"]
         )
 
     def test_version_constraints_stripped(self):
@@ -353,65 +346,97 @@ class TestListArchConditional(unittest.TestCase):
     patterns in list nodes.
     """
 
-    def test_neq_or_extracts_arch_packages(self):
+    def test_neq_or_installs_on_matching_arch(self):
         """
         ``[ $(arch) != x86_64 ] || dnf install -y pkg`` installs only on x86_64.
         """
         result = analyze_run_commands(
-            ["[ $(arch) != x86_64 ] || dnf install -y special-pkg"]
+            ["[ $(arch) != x86_64 ] || dnf install -y special-pkg"],
+            arch="x86_64",
+        )
+        self.assertIn("special-pkg", result.packages)
+
+        result = analyze_run_commands(
+            ["[ $(arch) != x86_64 ] || dnf install -y special-pkg"],
+            arch="aarch64",
         )
         self.assertEqual(result.packages, [])
-        self.assertEqual(result.arch_packages, {"x86_64": ["special-pkg"]})
 
-    def test_eq_and_extracts_arch_packages(self):
+    def test_eq_and_installs_on_matching_arch(self):
         """
         ``[ $(arch) = x86_64 ] && dnf install -y pkg`` installs only on x86_64.
         """
         result = analyze_run_commands(
-            ["[ $(arch) = x86_64 ] && dnf install -y special-pkg"]
+            ["[ $(arch) = x86_64 ] && dnf install -y special-pkg"],
+            arch="x86_64",
+        )
+        self.assertIn("special-pkg", result.packages)
+
+        result = analyze_run_commands(
+            ["[ $(arch) = x86_64 ] && dnf install -y special-pkg"],
+            arch="aarch64",
         )
         self.assertEqual(result.packages, [])
-        self.assertEqual(result.arch_packages, {"x86_64": ["special-pkg"]})
 
     def test_double_bracket_neq_or(self):
         """
         ``[[ $(arch) != aarch64 ]] || yum install -y arm-pkg`` with [[ ]] preprocessing.
         """
         result = analyze_run_commands(
-            ["[[ $(arch) != aarch64 ]] || yum install -y arm-pkg"]
+            ["[[ $(arch) != aarch64 ]] || yum install -y arm-pkg"],
+            arch="aarch64",
+        )
+        self.assertIn("arm-pkg", result.packages)
+
+    def test_eq_or_installs_on_non_matching_arch(self):
+        """
+        ``[ $(arch) = x86_64 ] || dnf install -y pkg`` means "all except x86_64".
+        """
+        result = analyze_run_commands(
+            ["[ $(arch) = x86_64 ] || dnf install -y pkg"],
+            arch="aarch64",
+        )
+        self.assertIn("pkg", result.packages)
+
+        result = analyze_run_commands(
+            ["[ $(arch) = x86_64 ] || dnf install -y pkg"],
+            arch="x86_64",
         )
         self.assertEqual(result.packages, [])
-        self.assertEqual(result.arch_packages, {"aarch64": ["arm-pkg"]})
 
-    def test_eq_or_treated_as_unconditional(self):
+    def test_neq_and_installs_on_non_matching_arch(self):
         """
-        ``[ $(arch) = x86_64 ] || dnf install -y pkg`` means "all except x86_64"
-        which needs the full arch set — treated as unconditional.
+        ``[ $(arch) != x86_64 ] && dnf install -y pkg`` means "all except x86_64".
         """
-        result = analyze_run_commands(["[ $(arch) = x86_64 ] || dnf install -y pkg"])
+        result = analyze_run_commands(
+            ["[ $(arch) != x86_64 ] && dnf install -y pkg"],
+            arch="aarch64",
+        )
         self.assertIn("pkg", result.packages)
-        self.assertEqual(result.arch_packages, {})
 
-    def test_neq_and_treated_as_unconditional(self):
-        """
-        ``[ $(arch) != x86_64 ] && dnf install -y pkg`` means "all except x86_64"
-        — treated as unconditional.
-        """
-        result = analyze_run_commands(["[ $(arch) != x86_64 ] && dnf install -y pkg"])
-        self.assertIn("pkg", result.packages)
-        self.assertEqual(result.arch_packages, {})
+        result = analyze_run_commands(
+            ["[ $(arch) != x86_64 ] && dnf install -y pkg"],
+            arch="x86_64",
+        )
+        self.assertEqual(result.packages, [])
 
     def test_arch_context_only_applies_to_next_command(self):
         """
         In ``[ test ] || cmd1 && cmd2``, only cmd1 gets the arch context.
         """
         result = analyze_run_commands(
-            [
-                "[ $(arch) != x86_64 ] || dnf install -y special-pkg && dnf install -y common-pkg"
-            ]
+            ["[ $(arch) != x86_64 ] || dnf install -y special-pkg && dnf install -y common-pkg"],
+            arch="x86_64",
         )
         self.assertIn("common-pkg", result.packages)
-        self.assertEqual(result.arch_packages, {"x86_64": ["special-pkg"]})
+        self.assertIn("special-pkg", result.packages)
+
+        result = analyze_run_commands(
+            ["[ $(arch) != x86_64 ] || dnf install -y special-pkg && dnf install -y common-pkg"],
+            arch="aarch64",
+        )
+        self.assertIn("common-pkg", result.packages)
+        self.assertNotIn("special-pkg", result.packages)
 
     def test_regular_or_fallback_unchanged(self):
         """
@@ -422,17 +447,16 @@ class TestListArchConditional(unittest.TestCase):
         )
         self.assertIn("preferred-pkg", result.packages)
         self.assertIn("fallback-pkg", result.packages)
-        self.assertEqual(result.arch_packages, {})
 
     def test_uname_m_neq_or(self):
         """
         ``[ $(uname -m) != s390x ] || dnf install -y s390x-pkg``
         """
         result = analyze_run_commands(
-            ["[ $(uname -m) != s390x ] || dnf install -y s390x-pkg"]
+            ["[ $(uname -m) != s390x ] || dnf install -y s390x-pkg"],
+            arch="s390x",
         )
-        self.assertEqual(result.packages, [])
-        self.assertEqual(result.arch_packages, {"s390x": ["s390x-pkg"]})
+        self.assertIn("s390x-pkg", result.packages)
 
     def test_go_env_goarch_neq_or(self):
         """
@@ -440,26 +464,21 @@ class TestListArchConditional(unittest.TestCase):
         Go arch name ``amd64`` is normalized to RPM name ``x86_64``.
         """
         result = analyze_run_commands(
-            ['[ $(go env GOARCH) != "amd64" ] || yum install -y special-pkg']
+            ['[ $(go env GOARCH) != "amd64" ] || yum install -y special-pkg'],
+            arch="x86_64",
         )
-        self.assertEqual(result.packages, [])
-        self.assertEqual(result.arch_packages, {"x86_64": ["special-pkg"]})
+        self.assertIn("special-pkg", result.packages)
 
     def test_go_env_goarch_neq_or_subshell(self):
         """
         ``[ $(go env GOARCH) != "amd64" ] || (yum install -y pkg1 pkg2 && other)``
-        — subshell grouping after ``||`` should still extract arch packages.
         Go arch name ``amd64`` is normalized to RPM name ``x86_64``.
         """
         result = analyze_run_commands(
-            [
-                '[ $(go env GOARCH) != "amd64" ] || (yum install -y llvm-toolset cmake3 gcc-c++ && tar zfx cross.tar.gz)'
-            ]
+            ['[ $(go env GOARCH) != "amd64" ] || (yum install -y llvm-toolset cmake3 gcc-c++ && tar zfx cross.tar.gz)'],
+            arch="x86_64",
         )
-        self.assertEqual(result.packages, [])
-        self.assertEqual(
-            result.arch_packages, {"x86_64": ["cmake3", "gcc-c++", "llvm-toolset"]}
-        )
+        self.assertEqual(result.packages, ["cmake3", "gcc-c++", "llvm-toolset"])
 
     def test_goarch_var_neq_or(self):
         """
@@ -467,10 +486,10 @@ class TestListArchConditional(unittest.TestCase):
         Go arch name ``arm64`` is normalized to RPM name ``aarch64``.
         """
         result = analyze_run_commands(
-            ['[ $GOARCH != "arm64" ] || dnf install -y arm-only-pkg']
+            ['[ $GOARCH != "arm64" ] || dnf install -y arm-only-pkg'],
+            arch="aarch64",
         )
-        self.assertEqual(result.packages, [])
-        self.assertEqual(result.arch_packages, {"aarch64": ["arm-only-pkg"]})
+        self.assertIn("arm-only-pkg", result.packages)
 
 
 class TestBuilddepParsing(unittest.TestCase):
@@ -488,7 +507,6 @@ class TestBuilddepParsing(unittest.TestCase):
         run_values = ["dnf install -y gcc make && dnf builddep -y pkcs11-helper*"]
         result = analyze_run_commands(run_values)
         self.assertEqual(result.packages, ["gcc", "make"])
-        self.assertEqual(result.arch_packages, {})
         self.assertEqual(result.builddep_packages, ["pkcs11-helper*"])
 
     def test_build_dep_hyphenated(self):


### PR DESCRIPTION
Instead of parsing the Containerfile once and producing common packages    plus a dict of arch-specific packages, the parser now takes a single    arch parameter and produces a flat set of packages for that    architecture. This is conceptually simpler and eliminates the parallel    tracking infrastructure.

One integration test doesn't work anymore with the change. It tested the scenario of `if [ $arch = x86_64 ]; then ... ; else ... ; fi`, where the `else` branch was added to the common packages. That was incorrect behaviour in the first place.

One new test with `if [ $arch != s390 ]; then dnf install foo; fi` is added. This did not work on main, but it is working with the refactored branch.