### PR TITLE
Sort arches in generate-expected to match tool output

### DIFF
--- a/tests/integration/generate-expected
+++ b/tests/integration/generate-expected
@@ -39,7 +39,7 @@ def main():
 
     with open(rpms_in) as f:
         config = yaml.safe_load(f)
-    arches = config.get("arches", ["x86_64"])
+    arches = sorted(config.get("arches", ["x86_64"]))
 
     # Collect all packages from all repos, tracking each package's origin path.
     # The relative path of the YAML file (minus extension) determines the URL


### PR DESCRIPTION
The tool outputs arches in sorted order, but generate-expected used the order from rpms.in.yaml. This caused the generated expected file to have arches in a different order than the actual output, requiring manual reordering.