### PR TITLE
feat: support exclude-packages in rpm-ostree treefile processing

### DIFF
--- a/rpm_lockfile/__init__.py
+++ b/rpm_lockfile/__init__.py
@@ -383,7 +383,25 @@ def collect_content_origins(config_dir, origins, variables=None):
 def read_packages_from_treefile(arch, treefile):
     # Reference: https://coreos.github.io/rpm-ostree/treefile/
     # TODO this should move to a separate module
+    packages, arch_packages, excludes = _read_packages_from_treefile(arch, treefile)
+    # exclude-packages removes from generic packages only; arch-specific
+    # packages (packages-$basearch) are explicit per-arch overrides and
+    # are not subject to exclusion.
+    return (packages - excludes) | arch_packages
+
+
+def _read_packages_from_treefile(arch, treefile):
+    """Recursively collect packages and exclude-packages from a treefile.
+
+    Returns a tuple of (packages, arch_packages, exclude_packages) so that
+    exclude-packages entries from all levels of the include chain are
+    accumulated and applied against the generic package set only.
+    Arch-specific packages (packages-$basearch) are kept separate so they
+    are not affected by exclude-packages.
+    """
     packages = set()
+    arch_packages = set()
+    excludes = set()
     with open(treefile) as f:
         data = yaml.safe_load(f)
 
@@ -395,22 +413,31 @@ def read_packages_from_treefile(arch, treefile):
         )
 
         for path in treefiles_to_include:
-            packages.update(
-                read_packages_from_treefile(
+            child_pkgs, child_arch_pkgs, child_excludes = (
+                _read_packages_from_treefile(
                     arch, os.path.join(os.path.dirname(treefile), path)
                 )
             )
+            packages.update(child_pkgs)
+            arch_packages.update(child_arch_pkgs)
+            excludes.update(child_excludes)
 
         if arch_include := data.get("arch-include", {}).get(arch):
-            packages.update(
-                read_packages_from_treefile(
+            child_pkgs, child_arch_pkgs, child_excludes = (
+                _read_packages_from_treefile(
                     arch, os.path.join(os.path.dirname(treefile), arch_include)
                 )
             )
+            packages.update(child_pkgs)
+            arch_packages.update(child_arch_pkgs)
+            excludes.update(child_excludes)
 
-        for key in ("packages", f"packages-{arch}"):
-            for entry in data.get(key, []):
-                packages.update(entry.split())
+        for entry in data.get("packages", []):
+            packages.update(entry.split())
+
+        arch_key = f"packages-{arch}"
+        for entry in data.get(arch_key, []):
+            arch_packages.update(entry.split())
 
         for entry in data.get("repo-packages", []):
             # The repo should not be needed, as the packages should be present
@@ -418,9 +445,11 @@ def read_packages_from_treefile(arch, treefile):
             for e in entry.get("packages", []):
                 packages.update(e.split())
 
+        for entry in data.get("exclude-packages", []):
+            excludes.update(entry.split())
+
         # TODO conditional-include
-        # TODO exclude-packages might be needed here
-    return packages
+    return packages, arch_packages, excludes
 
 
 def _arch_matches(spec, arch):

--- a/tests/integration/data/success/treefile-exclude-packages/base-treefile.yaml
+++ b/tests/integration/data/success/treefile-exclude-packages/base-treefile.yaml
@@ -1,0 +1,2 @@
+packages:
+  - test-base

--- a/tests/integration/data/success/treefile-exclude-packages/expected.lock.yaml
+++ b/tests/integration/data/success/treefile-exclude-packages/expected.lock.yaml
@@ -1,0 +1,34 @@
+---
+lockfileVersion: 1
+lockfileVendor: redhat
+arches:
+- arch: x86_64
+  packages:
+  - url: http://localhost:PORT/test-repo/test-app-1.0-1.noarch.rpm
+    repoid: test-repo
+    size: 32658
+    checksum: sha256:6d69d191e63688e2ca93f8c0d6114cf73affc3a7b864291f93cb4f4d03476a72
+    name: test-app
+    evr: 1.0-1
+    sourcerpm: test-app-1.0-1.src.rpm
+  - url: http://localhost:PORT/test-repo/test-arch-specific-1.0-1.noarch.rpm
+    repoid: test-repo
+    size: 82372
+    checksum: sha256:e44f049f63f1a1fdfe696d499ca52b239b6c157119c26344a49b64ca188bf4fc
+    name: test-arch-specific
+    evr: 1.0-1
+    sourcerpm: test-arch-specific-1.0-1.src.rpm
+  source:
+  - url: http://localhost:PORT/test-repo/test-app-1.0-1.src.rpm
+    repoid: test-repo
+    size: 6803
+    checksum: sha256:ee8a029197f249dd51b673fb93d8d7ac5ed496ee11d5b31d0ab3d452ef4208fb
+    name: test-app
+    evr: 1.0-1
+  - url: http://localhost:PORT/test-repo/test-arch-specific-1.0-1.src.rpm
+    repoid: test-repo
+    size: 74729
+    checksum: sha256:d93fafc97e52fec7d7e328a477a69dcb99e7649f52b358460635189dcc1a4d89
+    name: test-arch-specific
+    evr: 1.0-1
+  module_metadata: []

--- a/tests/integration/data/success/treefile-exclude-packages/repos/test-repo.yaml
+++ b/tests/integration/data/success/treefile-exclude-packages/repos/test-repo.yaml
@@ -1,0 +1,10 @@
+packages:
+  - nvr: test-base-1.0-1
+
+  - nvr: test-app-1.0-1
+
+  - nvr: test-arch-specific-1.0-1
+
+  - nvr: test-from-repo-packages-1.0-1
+
+  - nvr: test-not-in-treefile-1.0-1

--- a/tests/integration/data/success/treefile-exclude-packages/rpms.in.yaml
+++ b/tests/integration/data/success/treefile-exclude-packages/rpms.in.yaml
@@ -1,0 +1,9 @@
+contentOrigin:
+  repos:
+    - repoid: test-repo
+      baseurl: http://localhost:PORT/test-repo
+packages: []
+arches:
+  - x86_64
+context:
+  rpmOstreeTreefile: treefile.yaml

--- a/tests/integration/data/success/treefile-exclude-packages/treefile.yaml
+++ b/tests/integration/data/success/treefile-exclude-packages/treefile.yaml
@@ -1,0 +1,13 @@
+include:
+  - base-treefile.yaml
+packages:
+  - test-app
+packages-x86_64:
+  - test-arch-specific
+repo-packages:
+  - repo: test-repo
+    packages:
+      - test-from-repo-packages
+exclude-packages:
+  - test-from-repo-packages
+  - test-base

--- a/tests/integration/data/success/treefile-exclude-with-arch-override/base-treefile.yaml
+++ b/tests/integration/data/success/treefile-exclude-with-arch-override/base-treefile.yaml
@@ -1,0 +1,2 @@
+packages:
+  - test-base

--- a/tests/integration/data/success/treefile-exclude-with-arch-override/expected.lock.yaml
+++ b/tests/integration/data/success/treefile-exclude-with-arch-override/expected.lock.yaml
@@ -1,0 +1,51 @@
+---
+lockfileVersion: 1
+lockfileVendor: redhat
+arches:
+- arch: aarch64
+  packages:
+  - url: http://localhost:PORT/test-repo/test-app-1.0-1.noarch.rpm
+    repoid: test-repo
+    size: 32658
+    checksum: sha256:6d69d191e63688e2ca93f8c0d6114cf73affc3a7b864291f93cb4f4d03476a72
+    name: test-app
+    evr: 1.0-1
+    sourcerpm: test-app-1.0-1.src.rpm
+  source:
+  - url: http://localhost:PORT/test-repo/test-app-1.0-1.src.rpm
+    repoid: test-repo
+    size: 6803
+    checksum: sha256:ee8a029197f249dd51b673fb93d8d7ac5ed496ee11d5b31d0ab3d452ef4208fb
+    name: test-app
+    evr: 1.0-1
+  module_metadata: []
+- arch: x86_64
+  packages:
+  - url: http://localhost:PORT/test-repo/test-app-1.0-1.noarch.rpm
+    repoid: test-repo
+    size: 32658
+    checksum: sha256:6d69d191e63688e2ca93f8c0d6114cf73affc3a7b864291f93cb4f4d03476a72
+    name: test-app
+    evr: 1.0-1
+    sourcerpm: test-app-1.0-1.src.rpm
+  - url: http://localhost:PORT/test-repo/test-base-1.0-1.noarch.rpm
+    repoid: test-repo
+    size: 17899
+    checksum: sha256:e3ca3c340759b02d09400e29a1c739e1f2c2bf8c793b2baf7bcebc3f44da5c53
+    name: test-base
+    evr: 1.0-1
+    sourcerpm: test-base-1.0-1.src.rpm
+  source:
+  - url: http://localhost:PORT/test-repo/test-app-1.0-1.src.rpm
+    repoid: test-repo
+    size: 6803
+    checksum: sha256:ee8a029197f249dd51b673fb93d8d7ac5ed496ee11d5b31d0ab3d452ef4208fb
+    name: test-app
+    evr: 1.0-1
+  - url: http://localhost:PORT/test-repo/test-base-1.0-1.src.rpm
+    repoid: test-repo
+    size: 2327
+    checksum: sha256:6a3850963dc1c535e77b51fcbad730f392c4dad235c1c690a77044e418243fbf
+    name: test-base
+    evr: 1.0-1
+  module_metadata: []

--- a/tests/integration/data/success/treefile-exclude-with-arch-override/repos/test-repo.yaml
+++ b/tests/integration/data/success/treefile-exclude-with-arch-override/repos/test-repo.yaml
@@ -1,0 +1,10 @@
+packages:
+  - nvr: test-base-1.0-1
+
+  - nvr: test-app-1.0-1
+
+  - nvr: test-arch-specific-1.0-1
+
+  - nvr: test-from-repo-packages-1.0-1
+
+  - nvr: test-not-in-treefile-1.0-1

--- a/tests/integration/data/success/treefile-exclude-with-arch-override/rpms.in.yaml
+++ b/tests/integration/data/success/treefile-exclude-with-arch-override/rpms.in.yaml
@@ -1,0 +1,10 @@
+contentOrigin:
+  repos:
+    - repoid: test-repo
+      baseurl: http://localhost:PORT/test-repo
+packages: []
+arches:
+  - x86_64
+  - aarch64
+context:
+  rpmOstreeTreefile: treefile.yaml

--- a/tests/integration/data/success/treefile-exclude-with-arch-override/treefile.yaml
+++ b/tests/integration/data/success/treefile-exclude-with-arch-override/treefile.yaml
@@ -1,0 +1,9 @@
+include:
+  - base-treefile.yaml
+packages:
+  - test-app
+packages-x86_64:
+  # Re-add test-base only for x86_64 despite the global exclusion
+  - test-base
+exclude-packages:
+  - test-base


### PR DESCRIPTION
Implement the exclude-packages directive from the rpm-ostree treefile specification. Previously this was marked as a TODO and ignored, causing lockfile generation to fail when a treefile used exclude-packages to remove packages that are unavailable on certain architectures.

The implementation collects exclude-packages entries from all levels of the treefile include chain and subtracts them from the final merged package set, matching rpm-ostree's semantics.

This fixes lockfile generation for CentOS Stream 9 bootc images where clevis-pin-tpm2 is excluded on ppc64le/s390x (not available in c9s repos for those architectures).

Done with AI, but tested with: https://gitlab.com/redhat/centos-stream/containers/bootc/-/merge_requests/1094