### PR TITLE
Support argFile for resolving ARG-based base images in Containerfiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,11 @@ containerfile:
   stageName: builder
   # Get base image that contains a match for the given regular expression.
   imagePattern: example.com
+  # Path to a KEY=VALUE file (relative to the config file) whose values
+  # override ARG defaults when resolving the base image. Same format as
+  # podman/docker --build-arg-file. Useful when the Containerfile uses
+  # ARGs with no default or with a placeholder value.
+  argFile: build-args.env
 ```
 
 If multiple filters for selecting stage are set, the first one to match is

--- a/rpm_lockfile/__init__.py
+++ b/rpm_lockfile/__init__.py
@@ -469,6 +469,14 @@ def _get_containerfile_filters(context):
     return {}
 
 
+def _get_containerfile_extra_args(config_dir, context):
+    """Load extra build args from argFile if specified in the containerfile config."""
+    cf = context.get("containerfile")
+    if isinstance(cf, dict) and cf.get("argFile"):
+        return utils.load_variables_file(cf["argFile"], config_dir)
+    return None
+
+
 def logging_setup(debug=False):
 
     class ExcludeErrorsFilter(logging.Filter):
@@ -651,7 +659,11 @@ def main():
             )
         rpmdb = image_rpmdb(
             image
-            or utils.extract_image(containerfile, **_get_containerfile_filters(context))
+            or utils.extract_image(
+                containerfile,
+                **_get_containerfile_filters(context),
+                extra_args=_get_containerfile_extra_args(config_dir, context),
+            )
         )
 
     # Determine package extraction source — independent of rpmdb mode.

--- a/rpm_lockfile/utils.py
+++ b/rpm_lockfile/utils.py
@@ -48,9 +48,19 @@ def logged_run(cmd, *args, **kwargs):
     return subprocess.run(cmd, *args, **kwargs)  # noqa: PLW1510 - check passed via kwargs
 
 
-def extract_image(containerfile, stage_num=None, stage_name=None, image_pattern=None):
+def extract_image(
+    containerfile,
+    stage_num=None,
+    stage_name=None,
+    image_pattern=None,
+    extra_args=None,
+):
     """Find matching image mentioned in the containerfile.
     If no filters are specified, then the last image is returned.
+
+    extra_args is an optional dict of build-arg values that override any
+    defaults declared in the Containerfile's ARG instructions, equivalent
+    to passing --build-arg or --build-arg-file to podman/docker build.
     """
     logger.debug("Looking for base image in %s", containerfile)
     baseimg = ""
@@ -140,9 +150,10 @@ def extract_image(containerfile, stage_num=None, stage_name=None, image_pattern=
                 in_stage = True
                 raw_img = from_match.group("img")
 
-                # Expand variables using both global and stage args
-                # Stage args override global args
-                all_args = {**global_args, **stage_args}
+                # Expand variables: global args < stage args < extra_args
+                # extra_args (from an argfile) take highest precedence,
+                # matching podman/docker --build-arg-file behaviour.
+                all_args = {**global_args, **stage_args, **(extra_args or {})}
                 expanded_img = expand_vars(raw_img, all_args)
 
                 # Resolve to external base image
@@ -299,11 +310,16 @@ def _get_containerfile_labels(containerfile, config_dir):
             "stage_name": containerfile.get("stageName"),
             "image_pattern": containerfile.get("imagePattern"),
         }
+        arg_file = containerfile.get("argFile")
+        extra_args = load_variables_file(arg_file, config_dir) if arg_file else None
     else:
         fp = containerfile
         filters = {}
+        extra_args = None
 
-    return _get_image_labels(extract_image(os.path.join(config_dir, fp), **filters))
+    return _get_image_labels(
+        extract_image(os.path.join(config_dir, fp), **filters, extra_args=extra_args)
+    )
 
 
 def split_image(image_spec):
@@ -442,6 +458,7 @@ CONTAINERFILE_SCHEMA = {
                 "stageNum": {"type": "number"},
                 "stageName": {"type": "string"},
                 "imagePattern": {"type": "string"},
+                "argFile": {"type": "string"},
             },
             "additionalProperties": False,
             "required": ["file"],

--- a/tests/integration/data/success/containerfile-argfile-labels/Containerfile
+++ b/tests/integration/data/success/containerfile-argfile-labels/Containerfile
@@ -1,0 +1,3 @@
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE}
+RUN echo "hello"

--- a/tests/integration/data/success/containerfile-argfile-labels/build-args.env
+++ b/tests/integration/data/success/containerfile-argfile-labels/build-args.env
@@ -1,0 +1,1 @@
+BASE_IMAGE=registry.access.redhat.com/ubi9/ubi-minimal@sha256:062c52ff973065752b0965787649db2bcf551a6c727a00e95a3eb42cebadbdab

--- a/tests/integration/data/success/containerfile-argfile-labels/expected.lock.yaml
+++ b/tests/integration/data/success/containerfile-argfile-labels/expected.lock.yaml
@@ -1,0 +1,21 @@
+---
+lockfileVersion: 1
+lockfileVendor: redhat
+arches:
+- arch: x86_64
+  packages:
+  - url: http://localhost:PORT/test-repo/9.8/test-base-1.0-1.noarch.rpm
+    repoid: test-repo
+    size: 17899
+    checksum: sha256:e3ca3c340759b02d09400e29a1c739e1f2c2bf8c793b2baf7bcebc3f44da5c53
+    name: test-base
+    evr: 1.0-1
+    sourcerpm: test-base-1.0-1.src.rpm
+  source:
+  - url: http://localhost:PORT/test-repo/9.8/test-base-1.0-1.src.rpm
+    repoid: test-repo
+    size: 2327
+    checksum: sha256:6a3850963dc1c535e77b51fcbad730f392c4dad235c1c690a77044e418243fbf
+    name: test-base
+    evr: 1.0-1
+  module_metadata: []

--- a/tests/integration/data/success/containerfile-argfile-labels/repos/test-repo/9.8.yaml
+++ b/tests/integration/data/success/containerfile-argfile-labels/repos/test-repo/9.8.yaml
@@ -1,0 +1,2 @@
+packages:
+  - nvr: test-base-1.0-1

--- a/tests/integration/data/success/containerfile-argfile-labels/rpms.in.yaml
+++ b/tests/integration/data/success/containerfile-argfile-labels/rpms.in.yaml
@@ -1,0 +1,13 @@
+contentOrigin:
+  repos:
+    - repoid: test-repo
+      baseurl: http://localhost:PORT/test-repo/{version}
+      varsFromContainerfile:
+        file: Containerfile
+        argFile: build-args.env
+packages:
+  - test-base
+arches:
+  - x86_64
+context:
+  bare: true

--- a/tests/integration/data/success/containerfile-argfile/Containerfile
+++ b/tests/integration/data/success/containerfile-argfile/Containerfile
@@ -1,0 +1,3 @@
+ARG BASE_IMAGE=overridden
+FROM ${BASE_IMAGE}
+RUN echo "hello"

--- a/tests/integration/data/success/containerfile-argfile/build-args.env
+++ b/tests/integration/data/success/containerfile-argfile/build-args.env
@@ -1,0 +1,1 @@
+BASE_IMAGE=registry.access.redhat.com/ubi9/ubi-minimal:latest

--- a/tests/integration/data/success/containerfile-argfile/expected.lock.yaml
+++ b/tests/integration/data/success/containerfile-argfile/expected.lock.yaml
@@ -1,0 +1,21 @@
+---
+lockfileVersion: 1
+lockfileVendor: redhat
+arches:
+- arch: x86_64
+  packages:
+  - url: http://localhost:PORT/test-repo/test-base-1.0-1.noarch.rpm
+    repoid: test-repo
+    size: 17899
+    checksum: sha256:e3ca3c340759b02d09400e29a1c739e1f2c2bf8c793b2baf7bcebc3f44da5c53
+    name: test-base
+    evr: 1.0-1
+    sourcerpm: test-base-1.0-1.src.rpm
+  source:
+  - url: http://localhost:PORT/test-repo/test-base-1.0-1.src.rpm
+    repoid: test-repo
+    size: 2327
+    checksum: sha256:6a3850963dc1c535e77b51fcbad730f392c4dad235c1c690a77044e418243fbf
+    name: test-base
+    evr: 1.0-1
+  module_metadata: []

--- a/tests/integration/data/success/containerfile-argfile/repos/test-repo.yaml
+++ b/tests/integration/data/success/containerfile-argfile/repos/test-repo.yaml
@@ -1,0 +1,4 @@
+packages:
+  - nvr: test-base-1.0-1
+    requires:
+      - bash

--- a/tests/integration/data/success/containerfile-argfile/rpms.in.yaml
+++ b/tests/integration/data/success/containerfile-argfile/rpms.in.yaml
@@ -1,0 +1,12 @@
+contentOrigin:
+  repos:
+    - repoid: test-repo
+      baseurl: http://localhost:PORT/test-repo
+packages:
+  - test-base
+arches:
+  - x86_64
+context:
+  containerfile:
+    file: Containerfile
+    argFile: build-args.env

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -6,7 +6,7 @@ from xml.etree import ElementTree
 import pytest
 
 import rpm_lockfile
-from rpm_lockfile import assumed_provides, schema
+from rpm_lockfile import _get_containerfile_extra_args, assumed_provides, schema
 
 
 @pytest.mark.parametrize(
@@ -125,3 +125,65 @@ class TestPackagesFromContainerfileSchema:
             "packagesFromContainerfile": "Containerfile",
         }
         schema.validate(config)
+
+
+class TestContainerfileArgFileSchema:
+    def test_accepts_argfile_in_context_containerfile(self):
+        config = {
+            "contentOrigin": {"repos": []},
+            "context": {
+                "containerfile": {
+                    "file": "Containerfile",
+                    "argFile": "build-args.env",
+                }
+            },
+        }
+        schema.validate(config)
+
+    def test_accepts_argfile_in_packages_from_containerfile(self):
+        config = {
+            "contentOrigin": {"repos": []},
+            "packagesFromContainerfile": {
+                "file": "Containerfile",
+                "argFile": "build-args.env",
+            },
+        }
+        schema.validate(config)
+
+    def test_rejects_unknown_property(self):
+        config = {
+            "contentOrigin": {"repos": []},
+            "context": {
+                "containerfile": {
+                    "file": "Containerfile",
+                    "unknownKey": "value",
+                }
+            },
+        }
+        with pytest.raises(SystemExit):
+            schema.validate(config)
+
+
+class TestGetContainerfileExtraArgs:
+    def test_returns_none_when_no_containerfile(self, tmp_path):
+        assert _get_containerfile_extra_args(str(tmp_path), {}) is None
+
+    def test_returns_none_when_containerfile_is_string(self, tmp_path):
+        context = {"containerfile": "Containerfile"}
+        assert _get_containerfile_extra_args(str(tmp_path), context) is None
+
+    def test_returns_none_when_no_argfile_key(self, tmp_path):
+        context = {"containerfile": {"file": "Containerfile", "stageNum": 1}}
+        assert _get_containerfile_extra_args(str(tmp_path), context) is None
+
+    def test_loads_argfile_when_specified(self, tmp_path):
+        argfile = tmp_path / "build-args.env"
+        argfile.write_text("BASE_IMAGE=registry.example.com/image:latest\n")
+        context = {"containerfile": {"file": "Containerfile", "argFile": "build-args.env"}}
+        result = _get_containerfile_extra_args(str(tmp_path), context)
+        assert result == {"BASE_IMAGE": "registry.example.com/image:latest"}
+
+    def test_raises_if_argfile_missing(self, tmp_path):
+        context = {"containerfile": {"file": "Containerfile", "argFile": "nonexistent.env"}}
+        with pytest.raises(FileNotFoundError):
+            _get_containerfile_extra_args(str(tmp_path), context)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -318,6 +318,72 @@ FROM ${BASE_IMAGE}
         assert result == "registry.io/base:latest"
 
 
+def test_extract_image_extra_args_override_default():
+    """extra_args override ARG defaults declared in the Containerfile."""
+    file = """ARG BASE_IMAGE=registry.io/default:latest
+FROM ${BASE_IMAGE}
+"""
+    with patch("builtins.open", mock_open(read_data=file)):
+        result = utils.extract_image(
+            file, extra_args={"BASE_IMAGE": "registry.io/override:latest"}
+        )
+        assert result == "registry.io/override:latest"
+
+
+def test_extract_image_extra_args_supply_missing_default():
+    """extra_args can provide a value for an ARG with no default."""
+    file = """ARG BASE_IMAGE
+FROM ${BASE_IMAGE}
+"""
+    with patch("builtins.open", mock_open(read_data=file)):
+        result = utils.extract_image(
+            file,
+            extra_args={
+                "BASE_IMAGE": "registry.redhat.io/rhel9/rhel-bootc:latest@sha256:4140526fa1f9bec23eb35065dbb33ef8ed4d48039c024d3f04dc5a54b86f3e58"
+            },
+        )
+        assert result == "registry.redhat.io/rhel9/rhel-bootc:latest@sha256:4140526fa1f9bec23eb35065dbb33ef8ed4d48039c024d3f04dc5a54b86f3e58"
+
+
+def test_extract_image_extra_args_partial_override():
+    """extra_args can override some ARGs while others use their Containerfile defaults."""
+    file = """ARG REGISTRY=registry.io
+ARG NAMESPACE=default
+FROM ${REGISTRY}/${NAMESPACE}/base:latest
+"""
+    with patch("builtins.open", mock_open(read_data=file)):
+        result = utils.extract_image(
+            file, extra_args={"NAMESPACE": "custom"}
+        )
+        assert result == "registry.io/custom/base:latest"
+
+
+def test_extract_image_extra_args_unused_key_ignored():
+    """extra_args keys not referenced in the Containerfile are silently ignored."""
+    file = """ARG BASE_IMAGE=registry.io/base:latest
+FROM ${BASE_IMAGE}
+"""
+    with patch("builtins.open", mock_open(read_data=file)):
+        result = utils.extract_image(
+            file, extra_args={"UNRELATED": "something", "BASE_IMAGE": "registry.io/override:latest"}
+        )
+        assert result == "registry.io/override:latest"
+
+
+def test_extract_image_extra_args_missing_arg_still_raises():
+    """If an ARG is referenced but supplied neither in Containerfile nor extra_args, raise."""
+    file = """ARG BASE_IMAGE
+FROM ${BASE_IMAGE}
+"""
+    with (
+        patch("builtins.open", mock_open(read_data=file)),
+        pytest.raises(
+            RuntimeError, match="ARG 'BASE_IMAGE' is used but has no default value"
+        ),
+    ):
+        utils.extract_image(file, extra_args={"OTHER": "value"})
+
+
 @pytest.mark.parametrize(
     "file,stage_num,stage_name,image_pattern,expected",
     [
@@ -518,6 +584,56 @@ def test_get_labels_from_containerfile_stage(tmpdir, filter):
     assert labels == INSPECT_OUTPUT["Labels"]
     mock_run.assert_called_once_with(
         ["skopeo", "inspect", "--no-tags", f"docker://{image}"],
+        check=True,
+        stdout=subprocess.PIPE,
+    )
+
+
+def test_get_labels_from_containerfile_with_argfile(tmpdir):
+    """argFile values are passed as extra_args to resolve ARGs with no default."""
+    image = "registry.example.com/image:latest"
+    containerfile = tmpdir / "Containerfile"
+    containerfile.write_text("ARG BASE_IMAGE\nFROM ${BASE_IMAGE}\nRUN date\n", encoding="utf-8")
+    argfile = tmpdir / "build-args.env"
+    argfile.write_text(f"BASE_IMAGE={image}\n", encoding="utf-8")
+
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = Mock(stdout=json.dumps(INSPECT_OUTPUT))
+        labels = utils.get_labels(
+            {"varsFromContainerfile": {"file": "Containerfile", "argFile": "build-args.env"}},
+            tmpdir,
+        )
+
+    assert labels == INSPECT_OUTPUT["Labels"]
+    mock_run.assert_called_once_with(
+        ["skopeo", "inspect", "--no-tags", f"docker://{image}"],
+        check=True,
+        stdout=subprocess.PIPE,
+    )
+
+
+def test_get_labels_from_containerfile_argfile_overrides_default(tmpdir):
+    """argFile values take precedence over ARG defaults in the Containerfile."""
+    default_image = "registry.example.com/default:latest"
+    override_image = "registry.example.com/override:latest"
+    containerfile = tmpdir / "Containerfile"
+    containerfile.write_text(
+        f"ARG BASE_IMAGE={default_image}\nFROM ${{BASE_IMAGE}}\nRUN date\n",
+        encoding="utf-8",
+    )
+    argfile = tmpdir / "build-args.env"
+    argfile.write_text(f"BASE_IMAGE={override_image}\n", encoding="utf-8")
+
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = Mock(stdout=json.dumps(INSPECT_OUTPUT))
+        labels = utils.get_labels(
+            {"varsFromContainerfile": {"file": "Containerfile", "argFile": "build-args.env"}},
+            tmpdir,
+        )
+
+    assert labels == INSPECT_OUTPUT["Labels"]
+    mock_run.assert_called_once_with(
+        ["skopeo", "inspect", "--no-tags", f"docker://{override_image}"],
         check=True,
         stdout=subprocess.PIPE,
     )


### PR DESCRIPTION
Some Containerfiles declare the base image via an ARG with no default or a placeholder value, relying on --build-arg-file at build time to supply the real image reference. This change adds equivalent support to rpm-lockfile-prototype.