### PR TITLE
Restrict config file paths to the git repository

### DIFF
--- a/rpm_lockfile/utils.py
+++ b/rpm_lockfile/utils.py
@@ -25,10 +25,42 @@ CACHE_PATH = (
 )
 
 
+def find_git_root(path):
+    """Return the git repository root containing path, or None if not in a repo."""
+    resolved = Path(path).resolve()
+    for candidate in [resolved, *resolved.parents]:
+        if (candidate / ".git").exists():
+            return str(candidate)
+    return None
+
+
+def check_in_git_repo(resolved_path, config_dir):
+    """Raise if config_dir is inside a git repo and resolved_path escapes it.
+
+    When the config file lives inside a git repository, all file references
+    must stay within that repository. This prevents a malicious config from
+    reading host files (e.g. secrets mounted into CI) by using absolute paths
+    or ../ traversal.
+
+    Does nothing if config_dir is not inside a git repository.
+    """
+    git_root = find_git_root(config_dir)
+    if git_root is None:
+        return
+    git_root = Path(git_root).resolve()
+    resolved = Path(resolved_path).resolve()
+    if not resolved.is_relative_to(git_root):
+        raise ValueError(
+            f"{resolved_path!r} is outside the git repository at {git_root}"
+        )
+
+
 def relative_to(directory, path):
     """os.path.join() that gracefully handles None"""
     if path:
-        return os.path.join(directory, path)
+        resolved = os.path.join(directory, path)
+        check_in_git_repo(resolved, directory)
+        return resolved
     return None
 
 
@@ -216,7 +248,7 @@ def load_variables_file(filepath, config_dir):
     blank lines and lines starting with # are skipped, optional quotes on
     values are stripped.
     """
-    resolved = os.path.join(config_dir, filepath)
+    resolved = relative_to(config_dir, filepath)
     variables = {}
     with open(resolved) as f:
         for line in f:
@@ -318,7 +350,7 @@ def _get_containerfile_labels(containerfile, config_dir):
         extra_args = None
 
     return _get_image_labels(
-        extract_image(os.path.join(config_dir, fp), **filters, extra_args=extra_args)
+        extract_image(relative_to(config_dir, fp), **filters, extra_args=extra_args)
     )
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -537,7 +537,10 @@ def test_get_labels_from_containerfile(tmpdir):
     containerfile = tmpdir / "Containerfile"
     containerfile.write_text(f"FROM {image}\nRUN date\n", encoding="utf-8")
 
-    with patch("subprocess.run") as mock_run:
+    with (
+        patch("subprocess.run") as mock_run,
+        patch("rpm_lockfile.utils.find_git_root", return_value=None),
+    ):
         mock_run.return_value = Mock(stdout=json.dumps(INSPECT_OUTPUT))
         labels = utils.get_labels({"varsFromContainerfile": "Containerfile"}, tmpdir)
 
@@ -574,7 +577,10 @@ def test_get_labels_from_containerfile_stage(tmpdir, filter):
         encoding="utf-8",
     )
 
-    with patch("subprocess.run") as mock_run:
+    with (
+        patch("subprocess.run") as mock_run,
+        patch("rpm_lockfile.utils.find_git_root", return_value=None),
+    ):
         mock_run.return_value = Mock(stdout=json.dumps(INSPECT_OUTPUT))
         labels = utils.get_labels(
             {"varsFromContainerfile": {"file": "Containerfile"} | filter},
@@ -597,7 +603,10 @@ def test_get_labels_from_containerfile_with_argfile(tmpdir):
     argfile = tmpdir / "build-args.env"
     argfile.write_text(f"BASE_IMAGE={image}\n", encoding="utf-8")
 
-    with patch("subprocess.run") as mock_run:
+    with (
+        patch("subprocess.run") as mock_run,
+        patch("rpm_lockfile.utils.find_git_root", return_value=None),
+    ):
         mock_run.return_value = Mock(stdout=json.dumps(INSPECT_OUTPUT))
         labels = utils.get_labels(
             {"varsFromContainerfile": {"file": "Containerfile", "argFile": "build-args.env"}},
@@ -624,7 +633,10 @@ def test_get_labels_from_containerfile_argfile_overrides_default(tmpdir):
     argfile = tmpdir / "build-args.env"
     argfile.write_text(f"BASE_IMAGE={override_image}\n", encoding="utf-8")
 
-    with patch("subprocess.run") as mock_run:
+    with (
+        patch("subprocess.run") as mock_run,
+        patch("rpm_lockfile.utils.find_git_root", return_value=None),
+    ):
         mock_run.return_value = Mock(stdout=json.dumps(INSPECT_OUTPUT))
         labels = utils.get_labels(
             {"varsFromContainerfile": {"file": "Containerfile", "argFile": "build-args.env"}},
@@ -673,6 +685,70 @@ def test_load_variables_file(content, expected, tmp_path):
 def test_load_variables_file_missing(tmp_path):
     with pytest.raises(FileNotFoundError):
         utils.load_variables_file("nonexistent.conf", str(tmp_path))
+
+
+class TestFindGitRoot:
+    def test_finds_root_from_subdirectory(self, tmp_path):
+        (tmp_path / ".git").mkdir()
+        subdir = tmp_path / "sub"
+        subdir.mkdir()
+        assert utils.find_git_root(str(subdir)) == str(tmp_path)
+
+    def test_finds_root_when_config_dir_is_git_root(self, tmp_path):
+        (tmp_path / ".git").mkdir()
+        assert utils.find_git_root(str(tmp_path)) == str(tmp_path)
+
+    def test_returns_none_when_not_in_git_repo(self, tmp_path):
+        assert utils.find_git_root(str(tmp_path)) is None
+
+
+class TestCheckInGitRepo:
+    def test_allows_path_inside_repo(self, tmp_path):
+        git_root = str(tmp_path)
+        target = str(tmp_path / "subdir" / "file.txt")
+        with patch("rpm_lockfile.utils.find_git_root", return_value=git_root):
+            # Should not raise
+            utils.check_in_git_repo(target, git_root)
+
+    def test_allows_path_when_not_in_git_repo(self, tmp_path):
+        target = "/etc/passwd"
+        with patch("rpm_lockfile.utils.find_git_root", return_value=None):
+            # No git repo — no restriction
+            utils.check_in_git_repo(target, str(tmp_path))
+
+    def test_blocks_absolute_path_outside_repo(self, tmp_path):
+        git_root = str(tmp_path)
+        with (
+            patch("rpm_lockfile.utils.find_git_root", return_value=git_root),
+            pytest.raises(ValueError, match="outside the git repository"),
+        ):
+            utils.check_in_git_repo("/etc/passwd", git_root)
+
+    def test_blocks_traversal_outside_repo(self, tmp_path):
+        git_root = str(tmp_path)
+        config_dir = str(tmp_path / "config")
+        target = str(tmp_path / "config" / ".." / ".." / "etc" / "passwd")
+        with (
+            patch("rpm_lockfile.utils.find_git_root", return_value=git_root),
+            pytest.raises(ValueError, match="outside the git repository"),
+        ):
+            utils.check_in_git_repo(target, config_dir)
+
+    def test_relative_to_enforces_git_boundary(self, tmp_path):
+        git_root = str(tmp_path)
+        with (
+            patch("rpm_lockfile.utils.find_git_root", return_value=git_root),
+            pytest.raises(ValueError, match="outside the git repository"),
+        ):
+            utils.relative_to(git_root, "/etc/passwd")
+
+    def test_load_variables_file_enforces_git_boundary(self, tmp_path):
+        git_root = str(tmp_path)
+        with (
+            patch("rpm_lockfile.utils.find_git_root", return_value=git_root),
+            pytest.raises(ValueError, match="outside the git repository"),
+        ):
+            utils.load_variables_file("/etc/passwd", git_root)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
When the config file lives inside a git repository, any file path referenced from the config (containerfile paths, variables files, argfiles) must resolve to a path inside that same repository. This prevents a malicious config from reading host files outside the repo (e.g. secrets mounted into CI) via absolute paths or ../ traversal.

The restriction is enforced in relative_to(), which is the single primitive used to resolve all config-sourced file paths. It does not apply to repofiles, which intentionally support absolute paths to system .repo files.

When the config is not inside a git repository the check is a no-op, preserving existing behaviour for non-git use cases.